### PR TITLE
[FEAT] 공지 조회 API 구현 및 공통 응답 포맷(ApiResponse) 적용

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
@@ -3,24 +3,30 @@ package app.dearobjet.backend.domain.notification;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.OffsetDateTime;
+
 @Entity
 @Table(name = "notification")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Notification {
+public class Notice {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id")
     private Long notificationId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NoticeCategory category;   // NOTICE | NEWS | EVENT | FESTIVAL
+
     private String title;
 
     @Column(columnDefinition = "TEXT")
     private String body;
 
-    @Column(name = "field3")
-    private String field3;
+    @Column(nullable = false)
+    private OffsetDateTime publishedAt;
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeCategory.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeCategory.java
@@ -1,0 +1,5 @@
+package app.dearobjet.backend.domain.notification;
+
+public enum NoticeCategory {
+    NOTICE, NEWS, EVENT, FESTIVAL
+}

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeController.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeController.java
@@ -1,0 +1,27 @@
+package app.dearobjet.backend.domain.notification;
+
+import app.dearobjet.backend.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class NoticeController {
+
+    private final NoticeService noticeQueryService;
+
+    @GetMapping("/notices")
+    public ApiResponse<NoticeListResponse> getNotices(
+            @RequestParam(required = false) NoticeCategory category, // null이면 공지 전체 목록 조회
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.of(noticeQueryService.getNotices(category, page, size));
+    }
+
+    @GetMapping("/notices/{noticeId}")
+    public ApiResponse<NoticeResponse> getNotice(@PathVariable Long noticeId) {
+        return ApiResponse.of(noticeQueryService.getNotice(noticeId));
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeListResponse.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.domain.notification;
+
+import app.dearobjet.backend.domain.notification.NoticeResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NoticeListResponse {
+    private final List<NoticeResponse> items;
+    private final int page;
+    private final int totalPages;
+}

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeNotFoundException.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeNotFoundException.java
@@ -1,0 +1,7 @@
+package app.dearobjet.backend.domain.notification;
+
+public class NoticeNotFoundException extends RuntimeException {
+    public NoticeNotFoundException(Long noticeId) {
+        super("해당 공지사항을 찾을 수 없습니다. noticeId=" + noticeId);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
@@ -1,0 +1,10 @@
+package app.dearobjet.backend.domain.notification;
+
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice,Long> {
+    Page<Notice> findByCategory(NoticeCategory noticeCategory, Pageable pageable);
+}

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
@@ -1,0 +1,16 @@
+package app.dearobjet.backend.domain.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@AllArgsConstructor
+public class NoticeResponse {
+    private final Long noticeId;
+    private final NoticeCategory category;
+    private final String title;
+    private final String body;
+    private final OffsetDateTime publishedAt;
+}

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
@@ -1,0 +1,51 @@
+package app.dearobjet.backend.domain.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    public NoticeListResponse getNotices(NoticeCategory category, int page, int size) {
+        Pageable pageable = PageRequest.of(
+                Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "publishedAt")
+        );
+
+        Page<Notice> noticePage = (category == null)
+                ? noticeRepository.findAll(pageable)
+                : noticeRepository.findByCategory(category, pageable);
+
+        List<NoticeResponse> noticeResponses = new ArrayList<>();
+        for (Notice notice : noticePage.getContent()) {
+            noticeResponses.add(toResponse(notice));
+        }
+
+        return new NoticeListResponse(noticeResponses, page, noticePage.getTotalPages());
+    }
+
+    public NoticeResponse getNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+
+        return toResponse(notice);
+    }
+
+    private NoticeResponse toResponse(Notice notice) {
+        return new NoticeResponse(
+                notice.getNotificationId(),
+                notice.getCategory(),
+                notice.getTitle(),
+                notice.getBody(),
+                notice.getPublishedAt()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/api/ApiResponse.java
+++ b/src/main/java/app/dearobjet/backend/global/api/ApiResponse.java
@@ -1,0 +1,10 @@
+package app.dearobjet.backend.global.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class ApiResponse<T> {
+    private final T data;
+}


### PR DESCRIPTION
공지 목록/상세 조회 API(/api/v1/notices, /api/v1/notices/{noticeId}) 구현했습니다.
성공 응답을 명세 { data: ... }로 통일하기 위해 ApiResponse<T>를 적용했습니다.