### PR TITLE
[FEAT] 채팅방 목록 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/app/dearobjet/backend/domain/chat/controller/ChatController.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/controller/ChatController.java
@@ -1,0 +1,29 @@
+package app.dearobjet.backend.domain.chat.controller;
+
+import app.dearobjet.backend.domain.chat.dto.ChatRoomListResponse;
+import app.dearobjet.backend.domain.chat.service.ChatService;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chats")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @GetMapping
+    public ApiResponse<List<ChatRoomListResponse>> getMyChatRooms(
+            @AuthenticationPrincipal User user // 현재 로그인한 유저 주입
+    ) {
+        List<ChatRoomListResponse> response = chatService.getMyChatRooms(user);
+        return ApiResponse.of(response);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/dto/ChatRoomListResponse.java
@@ -1,0 +1,30 @@
+package app.dearobjet.backend.domain.chat.dto;
+
+import app.dearobjet.backend.domain.chat.entity.ChatRoom;
+import app.dearobjet.backend.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomListResponse(
+        Long chatRoomId,
+        String lastMessage,
+        LocalDateTime lastModifiedAt,
+        Integer unreadCount,
+
+        // 상대방 정보
+        Long partnerId,
+        String partnerNickname,
+        String partnerProfileImage
+) {
+    public static ChatRoomListResponse of(ChatRoom chatRoom, User partner, Integer unreadCount) {
+        return new ChatRoomListResponse(
+                chatRoom.getId(),
+                chatRoom.getLastMessage(),
+                chatRoom.getLastModifiedAt(),
+                unreadCount,
+                partner.getUserId(),
+                partner.getName(),
+                partner.getProfileImage()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/dto/CreateChatRoomResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/dto/CreateChatRoomResponse.java
@@ -1,0 +1,11 @@
+package app.dearobjet.backend.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateChatRoomResponse {
+    private Long chatRoomId;
+    private boolean isNew; // true: 새로 생성됨, false: 이미 존재하던 방
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatMessage.java
@@ -4,6 +4,8 @@ import app.dearobjet.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "chat_messages")
 @Getter
@@ -15,7 +17,7 @@ public class ChatMessage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "chat_messages_id")
-    private Long chatMessagesId;
+    private Long id;
 
     @Column(name = "message_type")
     private String messageType;  // TEXT, IMAGE, FILE
@@ -24,7 +26,7 @@ public class ChatMessage {
     private String content;
 
     @Column(name = "created_at")
-    private java.time.LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "is_read")
     private Boolean isRead;

--- a/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatParticipant.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.domain.chat.entity;
 
 import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ChatParticipant {
+public class ChatParticipant extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,4 +30,7 @@ public class ChatParticipant {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id", nullable = false)
     private ChatRoom chatRoom;
+
+    @Column(name = "unread_count")
+    private Integer unreadCount;
 }

--- a/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatRoom.java
@@ -4,6 +4,8 @@ import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "chat_room")
 @Getter
@@ -15,14 +17,17 @@ public class ChatRoom extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "chat_room_id")
-    private Long chatRoomId;
+    private Long id;
 
     @Column(name = "last_modified_at")
-    private java.time.LocalDateTime lastModifiedAt;
-
-    @Column(name = "unread_count")
-    private Integer unreadCount;
+    private LocalDateTime lastModifiedAt;
 
     @Column(name = "last_message")
     private String lastMessage;
+
+    // 방의 상태를 갱신하는 비즈니스 메서드
+    public void updateLastMessage(String message, LocalDateTime now) {
+        this.lastMessage = message;
+        this.lastModifiedAt = now; // 방의 정렬 순서를 위해 시간 갱신
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/repository/ChatParticipantRepository.java
@@ -1,0 +1,45 @@
+package app.dearobjet.backend.domain.chat.repository;
+
+import app.dearobjet.backend.domain.chat.entity.ChatParticipant;
+import app.dearobjet.backend.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+
+    /**
+     * 내 참여 정보 조회 (채팅방 정보 Fetch Join)
+     */
+    @Query("SELECT cp FROM ChatParticipant cp " +
+            "JOIN FETCH cp.chatRoom cr " +
+            "WHERE cp.user.userId = :userId " +
+            "ORDER BY cr.lastModifiedAt DESC")
+    List<ChatParticipant> findAllMyself(@Param("userId") Long userId);
+
+    /**
+     * 파트너 정보 조회 (유저 정보 Fetch Join)
+     * 주어진 채팅방 ID 목록(roomIds)에 포함되면서, 내가 아닌(userId != myId) 참여자 조회
+     */
+    @Query("SELECT cp FROM ChatParticipant cp " +
+            "JOIN FETCH cp.user u " +
+            "WHERE cp.chatRoom.id IN :roomIds " +
+            "AND cp.user.userId <> :myUserId")
+    List<ChatParticipant> findAllPartners(@Param("roomIds") List<Long> roomIds,
+                                          @Param("myUserId") Long myUserId);
+
+    /**
+     * 두 유저(user1, user2)가 공통으로 참여하고 있는 채팅방이 있는지 조회
+     * Self Join을 사용하여 하나의 방 ID에 두 유저가 모두 속해있는지 확인
+     */
+    @Query("SELECT p1.chatRoom " +
+            "FROM ChatParticipant p1 " +
+            "JOIN ChatParticipant p2 ON p1.chatRoom.id = p2.chatRoom.id " +
+            "WHERE p1.user.userId = :firstUserId " +
+            "AND p2.user.userId = :secondUserId")
+    Optional<ChatRoom> findExistingChatRoom(@Param("firstUserId") Long firstUserId,
+                                            @Param("secondUserId") Long secondUserId);
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package app.dearobjet.backend.domain.chat.repository;
+
+import app.dearobjet.backend.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/service/ChatService.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/service/ChatService.java
@@ -1,0 +1,99 @@
+package app.dearobjet.backend.domain.chat.service;
+
+import app.dearobjet.backend.domain.chat.dto.ChatRoomListResponse;
+import app.dearobjet.backend.domain.chat.dto.CreateChatRoomResponse;
+import app.dearobjet.backend.domain.chat.entity.ChatMessage;
+import app.dearobjet.backend.domain.chat.entity.ChatParticipant;
+import app.dearobjet.backend.domain.chat.entity.ChatRoom;
+import app.dearobjet.backend.domain.chat.repository.ChatParticipantRepository;
+import app.dearobjet.backend.domain.chat.repository.ChatRoomRepository;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+
+    public List<ChatRoomListResponse> getMyChatRooms(User user) {
+        // 내 참여 정보 리스트 조회
+        List<ChatParticipant> myParticipations = chatParticipantRepository.findAllMyself(user.getUserId());
+
+        if (myParticipations.isEmpty()) {
+            return List.of();
+        }
+
+        // 채팅방 ID 목록 추출
+        List<Long> chatRoomIds = myParticipations.stream()
+                .map(cp -> cp.getChatRoom().getId())
+                .toList();
+
+        // 해당 채팅방들의 상대방 정보 조회
+        List<ChatParticipant> partnerParticipations = chatParticipantRepository.findAllPartners(chatRoomIds, user.getUserId());
+
+        // 상대방 정보를 Map으로 변환 (Key: ChatRoomId, Value: Partner User)
+        Map<Long, User> partnerMap = partnerParticipations.stream()
+                .collect(Collectors.toMap(
+                        cp -> cp.getChatRoom().getId(),
+                        ChatParticipant::getUser
+                ));
+
+        // 내 참여 정보와 상대방 정보를 조합하여 응답 생성
+        return myParticipations.stream()
+                .map(myCp -> {
+                    Long roomId = myCp.getChatRoom().getId();
+                    User partner = partnerMap.get(roomId);
+
+                    return ChatRoomListResponse.of(
+                            myCp.getChatRoom(),
+                            partner,
+                            myCp.getUnreadCount() // 내 안 읽은 메시지 수 사용
+                    );
+                })
+                .toList();
+    }
+
+    @Transactional
+    public CreateChatRoomResponse createChatRoom(User me, Long partnerId) {
+        // 이미 둘 사이에 방이 있는지 확인
+        Optional<ChatRoom> existingRoom = chatParticipantRepository.findExistingChatRoom(me.getUserId(), partnerId);
+
+        // 있다면 그 방의 ID를 바로 반환
+        if (existingRoom.isPresent()) {
+            return new CreateChatRoomResponse(existingRoom.get().getId(), false);
+        }
+
+        // 없다면 새로 생성
+        User partner = userRepository.findById(partnerId)
+                .orElseThrow(() -> new EntityNotFoundException("상대방을 찾을 수 없습니다."));
+
+        // 방 생성
+        ChatRoom newRoom = chatRoomRepository.save(ChatRoom.builder()
+                .lastModifiedAt(LocalDateTime.now())
+                .lastMessage("")
+                .build());
+
+        // 참여자 연결 (나, 상대방)
+        chatParticipantRepository.save(ChatParticipant.builder()
+                .chatRoom(newRoom).user(me).unreadCount(0).build());
+        chatParticipantRepository.save(ChatParticipant.builder()
+                .chatRoom(newRoom).user(partner).unreadCount(0).build());
+
+        return new CreateChatRoomResponse(newRoom.getId(), true);
+    }
+
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.domain.user.entity;
 
+import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/app/dearobjet/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package app.dearobjet.backend.domain.user.repository;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/app/dearobjet/backend/global/common/config/JpaConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package app.dearobjet.backend.global.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/test/java/app/dearobjet/backend/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/chat/controller/ChatControllerTest.java
@@ -1,0 +1,53 @@
+package app.dearobjet.backend.domain.chat.controller;
+
+import app.dearobjet.backend.domain.chat.dto.ChatRoomListResponse;
+import app.dearobjet.backend.domain.chat.service.ChatService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatController.class)
+class ChatControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean ChatService chatService;
+
+    @Test
+    @DisplayName("채팅방 목록 조회 API는 ApiResponse 포맷인 data 필드로 감싸져서 반환된다.")
+    @WithMockUser // Spring Security 통과용 가짜 유저
+    void getMyChatRoomsApiTest() throws Exception {
+        // given
+        ChatRoomListResponse responseDto = new ChatRoomListResponse(
+                1L, "마지막 메시지", LocalDateTime.now(), 5,
+                2L, "상대방닉네임", "img.jpg"
+        );
+
+        // 서비스는 단순히 위 객체를 리스트로 반환한다고 가정 (Mocking)
+        given(chatService.getMyChatRooms(any())).willReturn(List.of(responseDto));
+
+        // when & then
+        mockMvc.perform(get("/api/chats")
+                        .with(csrf())) // CSRF 보호가 켜져있다면 필요
+                .andDo(print())
+                .andExpect(status().isOk())
+                // ★ ApiResponse 검증: 최상위에 'data' 필드가 있어야 함
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].unreadCount").value(5))
+                .andExpect(jsonPath("$.data[0].partnerNickname").value("상대방닉네임"));
+    }
+}

--- a/src/test/java/app/dearobjet/backend/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/chat/service/ChatServiceTest.java
@@ -1,0 +1,167 @@
+package app.dearobjet.backend.domain.chat.service;
+
+import app.dearobjet.backend.domain.chat.dto.ChatRoomListResponse;
+import app.dearobjet.backend.domain.chat.dto.CreateChatRoomResponse;
+import app.dearobjet.backend.domain.chat.entity.ChatParticipant;
+import app.dearobjet.backend.domain.chat.entity.ChatRoom;
+import app.dearobjet.backend.domain.chat.repository.ChatParticipantRepository;
+import app.dearobjet.backend.domain.chat.repository.ChatRoomRepository;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class ChatServiceTest {
+
+    @Autowired ChatService chatService;
+    @Autowired UserRepository userRepository;
+    @Autowired ChatRoomRepository chatRoomRepository;
+    @Autowired ChatParticipantRepository chatParticipantRepository;
+
+    @Test
+    @DisplayName("채팅방 목록 조회 시, 내 unreadCount 와 상대방 정보가 올바르게 매핑되어야 한다.")
+    void getMyChatRoomsTest() {
+        // given
+
+        // 1. 유저 생성
+        User me = userRepository.save(User.builder()
+                .email("me@test.com")
+                .name("나")
+                .phoneNumber("010-1111-1111")
+                .role("CUSTOMER")
+                .profileImage("my.png")
+                .build());
+
+        User partner = userRepository.save(User.builder()
+                .email("partner@test.com")
+                .name("상대방")
+                .phoneNumber("010-2222-2222")
+                .role("ARTIST")
+                .profileImage("partner.png")
+                .build());
+
+        // 2. 채팅방 생성
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder()
+                .lastMessage("안녕")
+                .lastModifiedAt(LocalDateTime.now())
+                .build());
+
+        // 3. 참여자 정보 생성
+        // 나 (안 읽은 메시지 3개)
+        chatParticipantRepository.save(ChatParticipant.builder()
+                .chatRoom(chatRoom)
+                .user(me)
+                .unreadCount(3)
+                .build());
+
+        // 상대방 (안 읽은 메시지 0개)
+        chatParticipantRepository.save(ChatParticipant.builder()
+                .chatRoom(chatRoom)
+                .user(partner)
+                .unreadCount(0)
+                .build());
+
+        // when
+        List<ChatRoomListResponse> result = chatService.getMyChatRooms(me);
+
+        // then
+        assertThat(result).hasSize(1);
+
+        ChatRoomListResponse response = result.get(0);
+
+        // 상대방 정보 검증
+        assertThat(response.partnerId()).isEqualTo(partner.getUserId());
+        assertThat(response.partnerNickname()).isEqualTo("상대방");
+        assertThat(response.partnerProfileImage()).isEqualTo("partner.png");
+
+        // 내 unreadCount(3)가 나와야 함 (상대방의 0이 아님)
+        assertThat(response.unreadCount()).isEqualTo(3);
+
+        // 메시지 검증
+        assertThat(response.lastMessage()).isEqualTo("안녕");
+    }
+
+    @Test
+    @DisplayName("채팅방 목록은 마지막 수정 시간(lastModifiedAt) 기준 최신순으로 정렬되어야 한다.")
+    void getMyChatRoomsSortingTest() {
+        // given
+        User me = userRepository.save(User.builder().email("me@sort.com").name("나").phoneNumber("010-3333-3333").role("USER").build());
+        User partnerOld = userRepository.save(User.builder().email("old@sort.com").name("과거").phoneNumber("010-4444-4444").role("USER").build());
+        User partnerNew = userRepository.save(User.builder().email("new@sort.com").name("최신").phoneNumber("010-5555-5555").role("USER").build());
+
+        // 과거 방 생성
+        CreateChatRoomResponse oldResp = chatService.createChatRoom(me, partnerOld.getUserId());
+        Long oldRoomId = oldResp.getChatRoomId();
+
+        // 시간 강제 변경 (어제로)
+        ChatRoom oldRoom = chatRoomRepository.findById(oldRoomId).get();
+        ChatRoom updateOldRoom = ChatRoom.builder()
+                .id(oldRoom.getId())
+                .lastMessage("과거 메시지")
+                .lastModifiedAt(LocalDateTime.now().minusDays(1))
+                .build();
+        chatRoomRepository.save(updateOldRoom);
+
+        // 최신 방 생성
+        CreateChatRoomResponse newResp = chatService.createChatRoom(me, partnerNew.getUserId());
+        Long recentRoomId = newResp.getChatRoomId(); // DTO에서 ID 꺼내기
+
+        // 시간/메시지 설정
+        ChatRoom recentRoom = chatRoomRepository.findById(recentRoomId).get();
+        ChatRoom updateRecentRoom = ChatRoom.builder()
+                .id(recentRoom.getId())
+                .lastMessage("최신 메시지")
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
+        chatRoomRepository.save(updateRecentRoom);
+
+        // when
+        List<ChatRoomListResponse> result = chatService.getMyChatRooms(me);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        // 최신 방(recentRoomId)이 0번째
+        assertThat(result.get(0).chatRoomId()).isEqualTo(recentRoomId);
+        assertThat(result.get(0).lastMessage()).isEqualTo("최신 메시지");
+
+        // 과거 방(oldRoomId)이 1번째
+        assertThat(result.get(1).chatRoomId()).isEqualTo(oldRoomId);
+    }
+
+    @Test
+    @DisplayName("1:1 채팅방 생성 시, 없으면 새로 만들고 있으면 기존 방을 반환한다.")
+    void createOrGetChatRoomTest() {
+        // given
+        User me = userRepository.save(User.builder().email("a@test.com").name("a").phoneNumber("010-1111-1111").role("USER").build());
+        User partner = userRepository.save(User.builder().email("b@test.com").name("b").phoneNumber("010-2222-2222").role("USER").build());
+
+        // when
+        // 첫 번째 요청: 방이 없으므로 새로 생성되어야 함
+        CreateChatRoomResponse response1 = chatService.createChatRoom(me, partner.getUserId());
+
+        // 두 번째 요청: 이미 방이 있으므로 기존 방이 반환되어야 함
+        CreateChatRoomResponse response2 = chatService.createChatRoom(me, partner.getUserId());
+
+        // then
+        // ID가 동일해야 함 (같은 방)
+        assertThat(response1.getChatRoomId()).isEqualTo(response2.getChatRoomId());
+
+        assertThat(response1.isNew()).isTrue();  // 첫 요청은 "새 방입니다"
+        assertThat(response2.isNew()).isFalse(); // 두 번째는 "헌 방입니다"
+
+        // DB에 저장된 방의 개수는 1개여야 함
+        List<ChatRoom> allRooms = chatRoomRepository.findAll();
+        assertThat(allRooms).hasSize(1);
+    }
+}


### PR DESCRIPTION
### 기능 구현
- 채팅방 목록 조회
- 채팅방 최신순 정렬
- 1:1 방 생성 한 개 보장

### 설정
- `BaseTimeEntity.java` 적용을 위해 `JpaConfig.java` 추가
- `build.gradle` H2 데이터베이스 추가

### 테스트
  - ApiResponse data 필드로 감싸져서 응답 확인
  - 채팅 목록 Service 통합 테스트
    - 통합 테스트로 USER 도메인 수정 및 생성
    - 채팅방 목록 확인
    - 채팅방 최신순 정렬
    - unread_count 송수신자 개수 정합성 확인
    - 1:1 방 생성 한 개 보장