### PR TITLE
[FEAT] Oauth, JWT 기반 인증 인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,15 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7-alpine
+    container_name: dearobjet-redis
+    ports:
+      - "6379:6379"
+    command: [ "redis-server", "--appendonly", "yes" ]
+    volumes:
+      - redisdata:/data
+
 volumes:
   pgdata:
+  redisdata:

--- a/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
@@ -1,0 +1,58 @@
+package app.dearobjet.backend.domain.user.controller;
+
+import app.dearobjet.backend.domain.user.dto.CompleteSignupRequest;
+import app.dearobjet.backend.domain.user.service.UserService;
+import app.dearobjet.backend.global.auth.jwt.JwtProvider;
+import app.dearobjet.backend.global.auth.security.CustomUserDetails;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+
+    /**
+     * 추가 회원가입 (TEMP → CUSTOMER / ARTIST / SHOP)
+     */
+    @PostMapping("/complete")
+    public ResponseEntity<Void> completeSignup(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CompleteSignupRequest request,
+            HttpServletResponse response
+    ) {
+        Long userId = userDetails.getUserId();
+
+        // 추가 회원가입
+        userService.completeSignup(
+                userId,
+                request.getName(),
+                request.getEmail(),
+                request.getPhoneNumber(),
+                request.getSmsAgreement(),
+                request.getMarketingAgreement(),
+                request.getRole()
+        );
+
+        // role 변경되었으므로 JWT 재발급
+        String newAccessToken =
+                jwtProvider.createAccessToken(userId, request.getRole());
+
+        Cookie cookie = new Cookie("ACCESS_TOKEN", newAccessToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // dev 환경
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60);
+
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
@@ -2,10 +2,8 @@ package app.dearobjet.backend.domain.user.controller;
 
 import app.dearobjet.backend.domain.user.dto.CompleteSignupRequest;
 import app.dearobjet.backend.domain.user.service.UserService;
-import app.dearobjet.backend.global.auth.jwt.JwtProvider;
+import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.security.CustomUserDetails;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,22 +13,18 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
-
     private final UserService userService;
-    private final JwtProvider jwtProvider;
 
     /**
      * 추가 회원가입 (TEMP → CUSTOMER / ARTIST / SHOP)
      */
     @PostMapping("/complete")
-    public ResponseEntity<Void> completeSignup(
+    public ResponseEntity<ApiResponse<Void>> completeSignup(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody CompleteSignupRequest request,
-            HttpServletResponse response
+            @RequestBody CompleteSignupRequest request
     ) {
         Long userId = userDetails.getUserId();
 
-        // 추가 회원가입
         userService.completeSignup(
                 userId,
                 request.getName(),
@@ -41,18 +35,6 @@ public class UserController {
                 request.getRole()
         );
 
-        // role 변경되었으므로 JWT 재발급
-        String newAccessToken =
-                jwtProvider.createAccessToken(userId, request.getRole());
-
-        Cookie cookie = new Cookie("ACCESS_TOKEN", newAccessToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false); // dev 환경
-        cookie.setPath("/");
-        cookie.setMaxAge(60 * 60);
-
-        response.addCookie(cookie);
-
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.of(null));
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/user/dto/CompleteSignupRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/dto/CompleteSignupRequest.java
@@ -1,0 +1,17 @@
+package app.dearobjet.backend.domain.user.dto;
+
+import app.dearobjet.backend.domain.user.enums.Role;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CompleteSignupRequest {
+
+    private String name;
+    private String email;
+    private String phoneNumber;
+    private Boolean smsAgreement;
+    private Boolean marketingAgreement;
+    private Role role; // CUSTOMER / ARTIST / SHOP
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
@@ -1,5 +1,7 @@
 package app.dearobjet.backend.domain.user.entity;
 
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -35,18 +37,20 @@ public class User {
     @Column(name = "marketing_agreement")
     private Boolean marketingAgreement;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String role;  // CUSTOMER, ARTIST, SHOP
+    private Role role;
 
     @Column(name = "profile_url")
     private String profileUrl;
 
-    @Column(name = "user_status")
-    private String userStatus;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_status", nullable = false)
+    private UserStatus userStatus;
 
-
-    @Column(name = "login_type")
-    private String loginType;  // EMAIL, KAKAO, NAVER, GOOGLE
+    // 카카오 단일
+//    @Column(name = "login_type")
+//    private String loginType;  // EMAIL, KAKAO, NAVER, GOOGLE
 
     @Column(name = "social_id")
     private String socialId;
@@ -58,7 +62,6 @@ public class User {
     }
 
     public void deactivate() {
-        this.userStatus = "INACTIVE";
+        this.userStatus = UserStatus.INACTIVE;
     }
-
 }

--- a/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
@@ -64,4 +64,25 @@ public class User {
     public void deactivate() {
         this.userStatus = UserStatus.INACTIVE;
     }
+
+    public void completeRegistration(
+            String name,
+            String email,
+            String phoneNumber,
+            Boolean smsAgreement,
+            Boolean marketingAgreement,
+            Role role
+    ) {
+        if (this.userStatus != UserStatus.PENDING) {
+            throw new IllegalStateException("User already registered");
+        }
+
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.smsAgreement = smsAgreement;
+        this.marketingAgreement = marketingAgreement;
+        this.role = role;
+        this.userStatus = UserStatus.ACTIVE;
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
@@ -72,7 +72,7 @@ public class User {
             Boolean marketingAgreement,
             Role role
     ) {
-        if (this.userStatus != UserStatus.PENDING) {
+        if (this.role != Role.TEMP) {
             throw new IllegalStateException("User already registered");
         }
 
@@ -82,6 +82,5 @@ public class User {
         this.smsAgreement = smsAgreement;
         this.marketingAgreement = marketingAgreement;
         this.role = role;
-        this.userStatus = UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
@@ -19,13 +19,12 @@ public class User {
     @Column(name = "user_id")
     private Long userId;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
 
-    @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String phoneNumber;
 
     @Column(name = "profile_image")

--- a/src/main/java/app/dearobjet/backend/domain/user/enums/Role.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/enums/Role.java
@@ -1,0 +1,7 @@
+package app.dearobjet.backend.domain.user.enums;
+
+public enum Role {
+    CUSTOMER,
+    ARTIST,
+    SHOP
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/enums/Role.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/enums/Role.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.domain.user.enums;
 
 public enum Role {
+    TEMP, // OAuth만 완료 (추가회원가입 전)
     CUSTOMER,
     ARTIST,
     SHOP

--- a/src/main/java/app/dearobjet/backend/domain/user/enums/UserStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/enums/UserStatus.java
@@ -1,7 +1,6 @@
 package app.dearobjet.backend.domain.user.enums;
 
 public enum UserStatus {
-    PENDING,   // OAuth만 된 상태
     ACTIVE,
     INACTIVE
 }

--- a/src/main/java/app/dearobjet/backend/domain/user/enums/UserStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/enums/UserStatus.java
@@ -1,0 +1,8 @@
+package app.dearobjet.backend.domain.user.enums;
+
+public enum UserStatus {
+    PENDING,   // OAuth만 된 상태
+    ACTIVE,
+    INACTIVE
+}
+

--- a/src/main/java/app/dearobjet/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package app.dearobjet.backend.domain.user.repository;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findBySocialId(String socialId);
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/service/UserService.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/service/UserService.java
@@ -1,0 +1,25 @@
+package app.dearobjet.backend.domain.user.service;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
+
+public interface UserService {
+
+    // 카카오 OAuth 사용자 조회 또는 신규 생성
+    User getOrCreateKakaoUser(String socialId);
+
+    // 추가 회원가입
+    void completeSignup(
+            Long userId,
+            String name,
+            String email,
+            String phoneNumber,
+            Boolean smsAgreement,
+            Boolean marketingAgreement,
+            Role role
+    );
+
+    // 회원 비활성화
+    void deactivateUser(Long userId);
+}
+

--- a/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,78 @@
+package app.dearobjet.backend.domain.user.service;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 카카오 OAuth 로그인 사용자 조회 or 생성
+     */
+    @Override
+    public User getOrCreateKakaoUser(String socialId) {
+        return userRepository.findBySocialId(socialId)
+                .orElseGet(() -> createPendingUser(socialId));
+    }
+
+    private User createPendingUser(String socialId) {
+        User user = User.builder()
+                .socialId(socialId)
+                .role(Role.CUSTOMER)
+                .userStatus(UserStatus.PENDING)
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    /**
+     * 추가 회원가입 완료
+     */
+    @Override
+    public void completeSignup(
+            Long userId,
+            String name,
+            String email,
+            String phoneNumber,
+            Boolean smsAgreement,
+            Boolean marketingAgreement,
+            Role role
+    ) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // 이메일 중복 체크
+        if (userRepository.existsByEmail(email)) {
+            throw new IllegalStateException("Email already exists");
+        }
+
+        user.completeRegistration(
+                name,
+                email,
+                phoneNumber,
+                smsAgreement,
+                marketingAgreement,
+                role
+        );
+    }
+
+    /**
+     * 회원 비활성화
+     */
+    @Override
+    public void deactivateUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        user.deactivate();
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
@@ -21,14 +21,14 @@ public class UserServiceImpl implements UserService {
     @Override
     public User getOrCreateKakaoUser(String socialId) {
         return userRepository.findBySocialId(socialId)
-                .orElseGet(() -> createPendingUser(socialId));
+                .orElseGet(() -> createTempUser(socialId));
     }
 
-    private User createPendingUser(String socialId) {
+    private User createTempUser(String socialId) {
         User user = User.builder()
                 .socialId(socialId)
-                .role(Role.CUSTOMER)
-                .userStatus(UserStatus.PENDING)
+                .role(Role.TEMP)
+                .userStatus(UserStatus.ACTIVE)
                 .build();
 
         return userRepository.save(user);

--- a/src/main/java/app/dearobjet/backend/global/api/ErrorResponse.java
+++ b/src/main/java/app/dearobjet/backend/global/api/ErrorResponse.java
@@ -1,0 +1,10 @@
+package app.dearobjet.backend.global.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private String message;
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/controller/AuthController.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/controller/AuthController.java
@@ -1,0 +1,19 @@
+package app.dearobjet.backend.global.auth.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @PostMapping("/auth/logout")
+    public void logout(HttpServletResponse response) {
+        Cookie cookie = new Cookie("ACCESS_TOKEN", null);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0); // 즉시 삭제
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/controller/AuthController.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package app.dearobjet.backend.global.auth.controller;
 
-import app.dearobjet.backend.global.auth.refresh.RefreshTokenRedisService;
+import app.dearobjet.backend.global.auth.service.RefreshTokenRedisService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/app/dearobjet/backend/global/auth/controller/AuthController.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/controller/AuthController.java
@@ -1,19 +1,49 @@
 package app.dearobjet.backend.global.auth.controller;
 
+import app.dearobjet.backend.global.auth.refresh.RefreshTokenRedisService;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class AuthController {
 
+    private final RefreshTokenRedisService refreshTokenRedisService;
+
     @PostMapping("/auth/logout")
-    public void logout(HttpServletResponse response) {
-        Cookie cookie = new Cookie("ACCESS_TOKEN", null);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(0); // 즉시 삭제
-        response.addCookie(cookie);
+    public ResponseEntity<Void> logout(HttpServletRequest request,
+                                       HttpServletResponse response) {
+
+        // 1. refresh 쿠키에서 값 추출
+        String refreshToken = null;
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    refreshToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        // 2. Redis에서 refresh 삭제
+        if (refreshToken != null) {
+            refreshTokenRedisService.delete(refreshToken);
+        }
+
+        // 3. refresh 쿠키 삭제
+        Cookie deleteCookie = new Cookie("refreshToken", null);
+        deleteCookie.setHttpOnly(true);
+        deleteCookie.setSecure(true); // https 환경
+        deleteCookie.setPath("/");
+        deleteCookie.setMaxAge(0);
+
+        response.addCookie(deleteCookie);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/app/dearobjet/backend/global/auth/controller/TokenController.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/controller/TokenController.java
@@ -8,6 +8,7 @@ import app.dearobjet.backend.global.auth.jwt.JwtProvider;
 import app.dearobjet.backend.global.auth.refresh.RefreshTokenRedisService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,19 +26,22 @@ public class TokenController {
     private final UserRepository userRepository;
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<AccessTokenResponse>> refresh(HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> refresh(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
 
         String refreshToken = extractRefreshToken(request);
         if (refreshToken == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        // 1. refresh JWT 자체 검증
+        // 1. refresh JWT 검증
         if (!jwtProvider.validateToken(refreshToken)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        // 2. Redis에 존재하는지 확인 + userId 조회
+        // 2. Redis 조회 + userId 확보
         Long userId;
         try {
             userId = refreshTokenRedisService.getUserId(refreshToken);
@@ -45,13 +49,35 @@ public class TokenController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        // 3. 사용자 조회
+        // 3. 기존 refresh 즉시 폐기 (RTR 핵심)
+        refreshTokenRedisService.delete(refreshToken);
+
+        // 4. 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow();
 
-        // 4. 새 access token 발급
+        // 5. 새 토큰 발급
         String newAccessToken =
                 jwtProvider.createAccessToken(user.getUserId(), user.getRole());
+
+        String newRefreshToken =
+                jwtProvider.createRefreshToken(user.getUserId());
+
+        // 6. 새 refresh Redis 저장
+        long refreshTtlMillis = jwtProvider.getRefreshTokenExpiration();
+        refreshTokenRedisService.save(
+                newRefreshToken,
+                user.getUserId(),
+                refreshTtlMillis
+        );
+
+        // 7. refresh 쿠키 교체
+        Cookie refreshCookie = new Cookie("refreshToken", newRefreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge((int) (refreshTtlMillis / 1000));
+        response.addCookie(refreshCookie);
 
         return ResponseEntity.ok(
                 ApiResponse.of(new AccessTokenResponse(newAccessToken))

--- a/src/main/java/app/dearobjet/backend/global/auth/controller/TokenController.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/controller/TokenController.java
@@ -1,11 +1,9 @@
 package app.dearobjet.backend.global.auth.controller;
 
-import app.dearobjet.backend.domain.user.entity.User;
-import app.dearobjet.backend.domain.user.repository.UserRepository;
 import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.dto.AccessTokenResponse;
-import app.dearobjet.backend.global.auth.jwt.JwtProvider;
-import app.dearobjet.backend.global.auth.refresh.RefreshTokenRedisService;
+import app.dearobjet.backend.global.auth.dto.RefreshResult;
+import app.dearobjet.backend.global.auth.service.TokenService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,9 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TokenController {
 
-    private final JwtProvider jwtProvider;
-    private final RefreshTokenRedisService refreshTokenRedisService;
-    private final UserRepository userRepository;
+    private final TokenService tokenService;
 
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<AccessTokenResponse>> refresh(
@@ -36,51 +32,24 @@ public class TokenController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        // 1. refresh JWT 검증
-        if (!jwtProvider.validateToken(refreshToken)) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-
-        // 2. Redis 조회 + userId 확보
-        Long userId;
+        RefreshResult result;
         try {
-            userId = refreshTokenRedisService.getUserId(refreshToken);
-        } catch (RuntimeException e) {
+            result = tokenService.refresh(refreshToken);
+        } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        // 3. 기존 refresh 즉시 폐기 (RTR 핵심)
-        refreshTokenRedisService.delete(refreshToken);
-
-        // 4. 사용자 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow();
-
-        // 5. 새 토큰 발급
-        String newAccessToken =
-                jwtProvider.createAccessToken(user.getUserId(), user.getRole());
-
-        String newRefreshToken =
-                jwtProvider.createRefreshToken(user.getUserId());
-
-        // 6. 새 refresh Redis 저장
-        long refreshTtlMillis = jwtProvider.getRefreshTokenExpiration();
-        refreshTokenRedisService.save(
-                newRefreshToken,
-                user.getUserId(),
-                refreshTtlMillis
-        );
-
-        // 7. refresh 쿠키 교체
-        Cookie refreshCookie = new Cookie("refreshToken", newRefreshToken);
+        // refresh 쿠키 설정
+        Cookie refreshCookie = new Cookie("refreshToken", result.getRefreshToken());
         refreshCookie.setHttpOnly(true);
         refreshCookie.setSecure(true);
         refreshCookie.setPath("/");
-        refreshCookie.setMaxAge((int) (refreshTtlMillis / 1000));
         response.addCookie(refreshCookie);
 
         return ResponseEntity.ok(
-                ApiResponse.of(new AccessTokenResponse(newAccessToken))
+                ApiResponse.of(
+                        new AccessTokenResponse(result.getAccessToken())
+                )
         );
     }
 

--- a/src/main/java/app/dearobjet/backend/global/auth/controller/TokenController.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/controller/TokenController.java
@@ -1,0 +1,72 @@
+package app.dearobjet.backend.global.auth.controller;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import app.dearobjet.backend.global.api.ApiResponse;
+import app.dearobjet.backend.global.auth.dto.AccessTokenResponse;
+import app.dearobjet.backend.global.auth.jwt.JwtProvider;
+import app.dearobjet.backend.global.auth.refresh.RefreshTokenRedisService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/token")
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> refresh(HttpServletRequest request) {
+
+        String refreshToken = extractRefreshToken(request);
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // 1. refresh JWT 자체 검증
+        if (!jwtProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // 2. Redis에 존재하는지 확인 + userId 조회
+        Long userId;
+        try {
+            userId = refreshTokenRedisService.getUserId(refreshToken);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // 3. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow();
+
+        // 4. 새 access token 발급
+        String newAccessToken =
+                jwtProvider.createAccessToken(user.getUserId(), user.getRole());
+
+        return ResponseEntity.ok(
+                ApiResponse.of(new AccessTokenResponse(newAccessToken))
+        );
+    }
+
+    private String extractRefreshToken(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("refreshToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/dto/AccessTokenResponse.java
@@ -1,0 +1,10 @@
+package app.dearobjet.backend.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AccessTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/dto/RefreshResult.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/dto/RefreshResult.java
@@ -1,0 +1,12 @@
+package app.dearobjet.backend.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshResult {
+    private String accessToken;
+    private String refreshToken;
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/entrypoint/RestAuthenticationEntryPoint.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/entrypoint/RestAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package app.dearobjet.backend.global.auth.entrypoint;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                "{\"message\": \"로그인이 필요합니다\"}"
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/entrypoint/RestAuthenticationEntryPoint.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/entrypoint/RestAuthenticationEntryPoint.java
@@ -1,5 +1,8 @@
 package app.dearobjet.backend.global.auth.entrypoint;
 
+import app.dearobjet.backend.global.api.ApiResponse;
+import app.dearobjet.backend.global.api.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -10,6 +13,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public void commence(
             HttpServletRequest request,
@@ -19,8 +24,12 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<ErrorResponse> body =
+                ApiResponse.of(new ErrorResponse("로그인이 필요합니다"));
+
         response.getWriter().write(
-                "{\"message\": \"로그인이 필요합니다\"}"
+                objectMapper.writeValueAsString(body)
         );
     }
 }

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package app.dearobjet.backend.global.auth.jwt;
+
+import app.dearobjet.backend.global.auth.security.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+
+            if (jwtProvider.validateToken(token)) {
+                Long userId = jwtProvider.getUserId(token);
+
+                UserDetails userDetails =
+                        userDetailsService.loadUserByUsername(String.valueOf(userId));
+
+                Authentication authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+
+                SecurityContextHolder.getContext()
+                        .setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtAuthenticationFilter.java
@@ -27,7 +27,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return uri.startsWith("/oauth2")
                 || uri.startsWith("/login")
-                || uri.startsWith("/error");
+                || uri.startsWith("/error")
+                || uri.startsWith("/auth/token/refresh");
     }
 
     @Override
@@ -37,36 +38,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        String token = null;
+        String authHeader = request.getHeader("Authorization");
 
-        // 쿠키에서 JWT 추출
-        if (token == null && request.getCookies() != null) {
-            for (var cookie : request.getCookies()) {
-                if ("ACCESS_TOKEN".equals(cookie.getName())) {
-                    token = cookie.getValue();
-                    break;
-                }
-            }
+        // access token 자체가 없는 경우 → 인증 시도 안 함
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
         }
 
-        // 토큰이 있을 때만 인증 처리
-        if (token != null && jwtProvider.validateToken(token)) {
-            Long userId = jwtProvider.getUserId(token);
+        String token = authHeader.substring(7);
 
-            UserDetails userDetails =
-                    userDetailsService.loadUserByUsername(String.valueOf(userId));
-
-            Authentication authentication =
-                    new UsernamePasswordAuthenticationToken(
-                            userDetails,
-                            null,
-                            userDetails.getAuthorities()
-                    );
-
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        // access token이 있는데 유효하지 않으면 → 바로 401
+        if (!jwtProvider.validateToken(token)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
         }
+
+        Long userId = jwtProvider.getUserId(token);
+
+        UserDetails userDetails =
+                userDetailsService.loadUserByUsername(String.valueOf(userId));
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }
 }
-

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProperties.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProperties.java
@@ -1,0 +1,17 @@
+package app.dearobjet.backend.global.auth.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class JwtProperties {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProperties.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProperties.java
@@ -13,5 +13,8 @@ public class JwtProperties {
 
     @Value("${jwt.access-token-expiration}")
     private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
 }
 

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProvider.java
@@ -1,0 +1,62 @@
+package app.dearobjet.backend.global.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(
+                jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    /** Access Token 생성 */
+    public String createAccessToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /** 토큰에서 userId 추출 */
+    public Long getUserId(String token) {
+        return Long.valueOf(
+                Jwts.parserBuilder()
+                        .setSigningKey(getSigningKey())
+                        .build()
+                        .parseClaimsJws(token)
+                        .getBody()
+                        .getSubject()
+        );
+    }
+
+    /** 토큰 유효성 검증 */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.global.auth.jwt;
 
+import app.dearobjet.backend.domain.user.enums.Role;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -23,12 +24,13 @@ public class JwtProvider {
     }
 
     /** Access Token 생성 */
-    public String createAccessToken(Long userId) {
+    public String createAccessToken(Long userId, Role role) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
+                .claim("role", role.name())
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -58,5 +60,16 @@ public class JwtProvider {
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
+    }
+
+    public Role getRole(String token) {
+        String role = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+
+        return Role.valueOf(role);
     }
 }

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtProvider.java
@@ -37,6 +37,19 @@ public class JwtProvider {
                 .compact();
     }
 
+    /** Refresh Token 생성 */
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
     /** 토큰에서 userId 추출 */
     public Long getUserId(String token) {
         return Long.valueOf(
@@ -71,5 +84,13 @@ public class JwtProvider {
                 .get("role", String.class);
 
         return Role.valueOf(role);
+    }
+
+    public long getRefreshTokenExpiration() {
+        return jwtProperties.getRefreshTokenExpiration();
+    }
+
+    public long getAccessTokenExpiration() {
+        return jwtProperties.getAccessTokenExpiration();
     }
 }

--- a/src/main/java/app/dearobjet/backend/global/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,36 @@
+package app.dearobjet.backend.global.auth.oauth;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService
+        implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest)
+            throws OAuth2AuthenticationException {
+
+        DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 카카오 고유 ID
+        String id = attributes.get("id").toString();
+
+        return new DefaultOAuth2User(
+                oAuth2User.getAuthorities(),
+                attributes,
+                "id" // user-name-attribute
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.global.auth.oauth;
 
 import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.service.UserService;
 import app.dearobjet.backend.global.auth.jwt.JwtProvider;
 import jakarta.servlet.http.Cookie;
@@ -34,11 +35,11 @@ public class OAuthSuccessHandler
         // 카카오 고유 ID
         String socialId = oAuth2User.getAttribute("id").toString();
 
-        // 사용자 조회 or 생성 (PENDING)
+        // 사용자 조회 or 생성
         User user = userService.getOrCreateKakaoUser(socialId);
 
         // JWT 발급
-        String accessToken = jwtProvider.createAccessToken(user.getUserId());
+        String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getRole());
 
         Cookie cookie = new Cookie("ACCESS_TOKEN", accessToken);
         cookie.setHttpOnly(true);
@@ -49,9 +50,7 @@ public class OAuthSuccessHandler
         response.addCookie(cookie);
 
         // 프론트로 전달
-        response.sendRedirect(
-                "http://localhost:5173/oauth/callback?token=" + accessToken
-        );
+        response.sendRedirect("http://localhost:5173/oauth/callback");
     }
 }
 

--- a/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
@@ -1,0 +1,57 @@
+package app.dearobjet.backend.global.auth.oauth;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.service.UserService;
+import app.dearobjet.backend.global.auth.jwt.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthSuccessHandler
+        extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        // 카카오 고유 ID
+        String socialId = oAuth2User.getAttribute("id").toString();
+
+        // 사용자 조회 or 생성 (PENDING)
+        User user = userService.getOrCreateKakaoUser(socialId);
+
+        // JWT 발급
+        String accessToken = jwtProvider.createAccessToken(user.getUserId());
+
+        Cookie cookie = new Cookie("ACCESS_TOKEN", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true); // https면 true
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60); // 1시간
+
+        response.addCookie(cookie);
+
+        // 프론트로 전달
+        response.sendRedirect(
+                "http://localhost:5173/oauth/callback?token=" + accessToken
+        );
+    }
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
@@ -1,15 +1,14 @@
 package app.dearobjet.backend.global.auth.oauth;
 
 import app.dearobjet.backend.domain.user.entity.User;
-import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.service.UserService;
 import app.dearobjet.backend.global.auth.jwt.JwtProvider;
+import app.dearobjet.backend.global.auth.refresh.RefreshTokenRedisService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -17,11 +16,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class OAuthSuccessHandler
-        extends SimpleUrlAuthenticationSuccessHandler {
+public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final UserService userService;
     private final JwtProvider jwtProvider;
+    private final RefreshTokenRedisService refreshTokenRedisService;
 
     @Override
     public void onAuthenticationSuccess(
@@ -32,25 +31,31 @@ public class OAuthSuccessHandler
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        // 카카오 고유 ID
         String socialId = oAuth2User.getAttribute("id").toString();
 
-        // 사용자 조회 or 생성
         User user = userService.getOrCreateKakaoUser(socialId);
 
-        // JWT 발급
-        String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getRole());
+        // refresh token 발급
+        String refreshToken = jwtProvider.createRefreshToken(user.getUserId());
 
-        Cookie cookie = new Cookie("ACCESS_TOKEN", accessToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true); // https면 true
-        cookie.setPath("/");
-        cookie.setMaxAge(60 * 60); // 1시간
+        // Redis 저장
+        refreshTokenRedisService.save(
+                refreshToken,
+                user.getUserId(),
+                jwtProvider.getRefreshTokenExpiration()
+        );
 
-        response.addCookie(cookie);
+        // refresh token을 HttpOnly 쿠키로 저장
+        Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setSecure(true); // https 환경
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(14 * 24 * 60 * 60); // 14일
 
-        // 프론트로 전달
+        response.addCookie(refreshCookie);
+
+        // access는 여기서 주지 않는다
+        // 프론트에서 /auth/token/refresh 호출하게 함
         response.sendRedirect("http://localhost:5173/oauth/callback");
     }
 }
-

--- a/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/oauth/OAuthSuccessHandler.java
@@ -1,14 +1,16 @@
 package app.dearobjet.backend.global.auth.oauth;
 
 import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.service.UserService;
 import app.dearobjet.backend.global.auth.jwt.JwtProvider;
-import app.dearobjet.backend.global.auth.refresh.RefreshTokenRedisService;
+import app.dearobjet.backend.global.auth.service.RefreshTokenRedisService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -21,6 +23,8 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final UserService userService;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRedisService refreshTokenRedisService;
+    @Value("${app.frontend.base-url}")
+    private String frontendBaseUrl;
 
     @Override
     public void onAuthenticationSuccess(
@@ -54,8 +58,13 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         response.addCookie(refreshCookie);
 
-        // access는 여기서 주지 않는다
-        // 프론트에서 /auth/token/refresh 호출하게 함
-        response.sendRedirect("http://localhost:5173/oauth/callback");
+        // 추가 회원가입 필요 여부 판단
+        boolean signupRequired = user.getRole() == Role.TEMP;
+
+        String redirectUrl = frontendBaseUrl
+                + "/oauth/callback"
+                + (signupRequired ? "?signup=required" : "?signup=completed");
+
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/app/dearobjet/backend/global/auth/refresh/RefreshTokenRedisService.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/refresh/RefreshTokenRedisService.java
@@ -1,0 +1,36 @@
+package app.dearobjet.backend.global.auth.refresh;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PREFIX = "refresh:";
+
+    public void save(String refreshToken, Long userId, long ttlMillis) {
+        redisTemplate.opsForValue().set(
+                PREFIX + refreshToken,
+                String.valueOf(userId),
+                ttlMillis,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public Long getUserId(String refreshToken) {
+        String value = redisTemplate.opsForValue().get(PREFIX + refreshToken);
+        if (value == null) {
+            throw new RuntimeException("refresh token not found");
+        }
+        return Long.valueOf(value);
+    }
+
+    public void delete(String refreshToken) {
+        redisTemplate.delete(PREFIX + refreshToken);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/security/CustomUserDetails.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/CustomUserDetails.java
@@ -1,0 +1,67 @@
+package app.dearobjet.backend.global.auth.security;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public Long getUserId() {
+        return user.getUserId();
+    }
+
+    public Role getRole() {
+        return user.getRole();
+    }
+
+    public UserStatus getUserStatus() {
+        return user.getUserStatus();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name())
+        );
+    }
+
+    /**
+     * OAuth/JWT 구조라 비밀번호 사용 안 함
+     */
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    /**
+     * username = 식별자
+     * → JWT subject / OAuth 이후 인증 기준
+     */
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getUserId());
+    }
+
+    /**
+     * 상태 기반 계정 제어
+     */
+    @Override
+    public boolean isEnabled() {
+        return user.getUserStatus() == UserStatus.ACTIVE;
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/security/CustomUserDetails.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/CustomUserDetails.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-public class CustomUserDetails implements UserDetails {
+    public class CustomUserDetails implements UserDetails {
 
     private final User user;
 

--- a/src/main/java/app/dearobjet/backend/global/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package app.dearobjet.backend.global.auth.security;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService
+        implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("User not found")
+                );
+
+        return new CustomUserDetails(user);
+    }
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/security/DevSecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/DevSecurityConfig.java
@@ -1,0 +1,24 @@
+package app.dearobjet.backend.global.auth.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile({"dev"})
+public class DevSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain devFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.global.auth.security;
 
+import app.dearobjet.backend.global.auth.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,11 +8,14 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,15 +30,18 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/auth/**",
-                                "/oauth/**",
-                                "/health"
-                        ).permitAll()
+                        .requestMatchers("/auth/**", "/oauth/**").permitAll()
                         .anyRequest().authenticated()
+                );
+
+        http
+                .addFilterBefore(
+                        jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();
     }
 }
+
 

--- a/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.global.auth.security;
 
+import app.dearobjet.backend.global.auth.entrypoint.RestAuthenticationEntryPoint;
 import app.dearobjet.backend.global.auth.jwt.JwtAuthenticationFilter;
 import app.dearobjet.backend.global.auth.oauth.CustomOAuth2UserService;
 import app.dearobjet.backend.global.auth.oauth.OAuthSuccessHandler;
@@ -19,6 +20,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final OAuthSuccessHandler oAuthSuccessHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -27,7 +29,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
-
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(restAuthenticationEntryPoint)
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/oauth2/authorization/**",

--- a/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
@@ -1,0 +1,40 @@
+package app.dearobjet.backend.global.auth.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/**",
+                                "/oauth/**",
+                                "/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}
+

--- a/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
@@ -34,6 +34,9 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/auth/token/refresh",
+                                "/auth/login",
+                                "/oauth/**",
                                 "/oauth2/authorization/**",
                                 "/login/oauth2/**",
                                 "/error"

--- a/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import app.dearobjet.backend.global.auth.oauth.OAuthSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
+@Profile("prod")
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/app/dearobjet/backend/global/auth/service/RefreshTokenRedisService.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/service/RefreshTokenRedisService.java
@@ -1,4 +1,4 @@
-package app.dearobjet.backend.global.auth.refresh;
+package app.dearobjet.backend.global.auth.service;
 
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/app/dearobjet/backend/global/auth/service/TokenService.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/service/TokenService.java
@@ -1,0 +1,51 @@
+package app.dearobjet.backend.global.auth.service;
+
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import app.dearobjet.backend.global.auth.dto.RefreshResult;
+import app.dearobjet.backend.global.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final UserRepository userRepository;
+
+    public RefreshResult refresh(String refreshToken) {
+
+        // 1. refresh token 검증
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new IllegalStateException("INVALID_REFRESH_TOKEN");
+        }
+
+        // 2. Redis에서 userId 조회
+        Long userId = refreshTokenRedisService.getUserId(refreshToken);
+
+        // 3. RTR: 기존 refresh 폐기
+        refreshTokenRedisService.delete(refreshToken);
+
+        // 4. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow();
+
+        // 5. 새 토큰 발급
+        String newAccessToken =
+                jwtProvider.createAccessToken(user.getUserId(), user.getRole());
+
+        String newRefreshToken =
+                jwtProvider.createRefreshToken(user.getUserId());
+
+        // 6. 새 refresh Redis 저장
+        refreshTokenRedisService.save(
+                newRefreshToken,
+                user.getUserId(),
+                jwtProvider.getRefreshTokenExpiration()
+        );
+
+        return new RefreshResult(newAccessToken, newRefreshToken);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/config/RedisConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package app.dearobjet.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(
+            RedisConnectionFactory connectionFactory) {
+
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: backend
 
+  config:
+    import: optional:file:.env[.properties]
+
   datasource:
     url: jdbc:postgresql://localhost:5432/dearobjet
     username: dearobjet
@@ -9,12 +12,34 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create # update로 수정해야함
     properties:
       hibernate:
         format_sql: true
     open-in-view: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            client-authentication-method: client_secret_post
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 logging:
   level:
     org.hibernate.SQL: debug
+    org.springframework.security: DEBUG
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 3600000 # 1시간(ms)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,11 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 logging:
   level:
     org.hibernate.SQL: debug
@@ -43,3 +48,4 @@ logging:
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600000 # 1시간(ms)
+  refresh-token-expiration: 1209600000  # 14일 (ms)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: backend
 
   profiles:
-    active: local # 인증인가가 필요하다면 prod로 변경
+    active: prod # 인증인가가 필요하다면 prod로 변경
 
   config:
     import: optional:file:.env[.properties]
@@ -52,3 +52,7 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600000 # 1시간(ms)
   refresh-token-expiration: 1209600000  # 14일 (ms)
+
+app:
+  frontend:
+    base-url: ${FRONTEND_BASE_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   application:
     name: backend
 
+  profiles:
+    active: local # 인증인가가 필요하다면 prod로 변경
+
   config:
     import: optional:file:.env[.properties]
 


### PR DESCRIPTION
Oauth를 통해 로그인하면 
refresh 토큰을 쿠키로 발급 받고

프론트에서
/auth/token/refresh 로 액세스 토큰을 발급받을 수 있고

리프레쉬 토큰이 없거나 유효하지 않으면 401로 프론트에서 로그인 처리

그리고 로테이선 전략을 사용하여 리프레쉬 토큰이 탈취 되더라도 무제한으로 사용할 수 없도록
리프레쉬토큰을 이용해서 액세스토큰을 발급받으면 리프레쉬 토큰이 재발급 되도록 변경

리프레쉬 토큰은 redis에 저장하여 db까지 안가고 빠른 조회를 통해 부하 줄였음