### PR TITLE
[FEAT] global exception / cunstom exception / ErrorCode 정의 및 구현

### DIFF
--- a/src/main/java/app/dearobjet/backend/global/exception/BusinessException.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/BusinessException.java
@@ -1,0 +1,28 @@
+package app.dearobjet.backend.global.exception;
+
+import lombok.Getter;
+
+/**
+ * 비즈니스 로직 예외의 기본 클래스
+ * 모든 커스텀 비즈니스 예외는 이 클래스를 상속받습니다.
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/exception/DuplicateEntityException.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/DuplicateEntityException.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.global.exception;
+
+/**
+ * 중복된 엔티티가 존재할 때 발생하는 예외
+ */
+public class DuplicateEntityException extends BusinessException {
+
+    public DuplicateEntityException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DuplicateEntityException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/exception/EntityNotFoundException.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/EntityNotFoundException.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.global.exception;
+
+/**
+ * 엔티티를 찾을 수 없을 때 발생하는 예외
+ */
+public class EntityNotFoundException extends BusinessException {
+
+    public EntityNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public EntityNotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
@@ -1,0 +1,45 @@
+package app.dearobjet.backend.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 애플리케이션 전역 에러 코드 정의
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common (C0XX)
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력입니다"),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C002", "데이터를 찾을 수 없습니다"),
+    DUPLICATE_ENTITY(HttpStatus.CONFLICT, "C003", "이미 존재하는 데이터입니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 내부 오류가 발생했습니다"),
+
+    // User (U0XX)
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다"),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "U002", "이미 사용 중인 이메일입니다"),
+    PHONE_ALREADY_EXISTS(HttpStatus.CONFLICT, "U003", "이미 사용 중인 전화번호입니다"),
+    USER_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "U004", "이미 가입 완료된 사용자입니다"),
+
+    // Chat (CH0XX)
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CH001", "채팅방을 찾을 수 없습니다"),
+    NOT_CHAT_PARTICIPANT(HttpStatus.FORBIDDEN, "CH002", "채팅방에 참여하지 않았습니다"),
+    CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CH003", "자기 자신과는 채팅할 수 없습니다"),
+    INVALID_CHAT_PARTICIPANTS(HttpStatus.BAD_REQUEST, "CH004", "유효하지 않은 참여자입니다"),
+    GROUP_CHAT_MIN_PARTICIPANTS(HttpStatus.BAD_REQUEST, "CH005", "그룹 채팅은 최소 3명 이상이어야 합니다"),
+
+    // Auth (A0XX)
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다"),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A003", "리프레시 토큰을 찾을 수 없습니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A004", "인증이 필요합니다"),
+
+    // Notice (N0XX)
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "공지사항을 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/app/dearobjet/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,96 @@
+package app.dearobjet.backend.global.exception;
+
+import app.dearobjet.backend.global.api.ApiResponse;
+import app.dearobjet.backend.global.api.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+/**
+ * 전역 예외 처리기
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * BusinessException 처리 (커스텀 비즈니스 예외)
+     */
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleBusinessException(BusinessException e) {
+        log.warn("BusinessException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.of(errorCode, e.getMessage());
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * @Valid 검증 실패 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        log.warn("Validation failed: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getBindingResult());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * IllegalArgumentException 처리 (하위 호환성)
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleIllegalArgumentException(
+            IllegalArgumentException e) {
+        log.warn("IllegalArgumentException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * IllegalStateException 처리 (하위 호환성)
+     */
+    @ExceptionHandler(IllegalStateException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleIllegalStateException(
+            IllegalStateException e) {
+        log.warn("IllegalStateException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * 존재하지 않는 리소스 요청 처리 (404)
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleNoResourceFoundException(
+            NoResourceFoundException e) {
+        log.warn("Resource not found: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.ENTITY_NOT_FOUND, e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * 그 외 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleException(Exception e) {
+        log.error("Unexpected exception: ", e);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.of(response));
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/exception/InvalidInputException.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/InvalidInputException.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.global.exception;
+
+/**
+ * 잘못된 입력값 예외
+ */
+public class InvalidInputException extends BusinessException {
+
+    public InvalidInputException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidInputException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/exception/UnauthorizedException.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.global.exception;
+
+/**
+ * 인증/인가 관련 예외
+ */
+public class UnauthorizedException extends BusinessException {
+
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UnauthorizedException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}


### PR DESCRIPTION
### 예외 클래스 계층 구조
  RuntimeException
   └── BusinessException (기본 클래스 - ErrorCode 보유)
        ├── EntityNotFoundException    (데이터 미존재: 404)
        ├── DuplicateEntityException   (데이터 중복: 409)
        ├── InvalidInputException      (잘못된 입력/권한: 400/403)
        └── UnauthorizedException      (인증/인가 실패: 401)

### ErrorCode Enum
도메인별 prefix로 분류
- C0XX: 공통 (잘못된 입력, 엔티티 미존재, 중복, 서버 오류)
- U0XX: 사용자 (사용자 미존재, 이메일/전화번호 중복, 이미 가입됨)
- CH0XX: 채팅 (채팅방 미존재, 비참여자, 자기 자신 채팅, 잘못된 참여자, 그룹 최소 인원)
- A0XX: 인증 (유효하지 않은 토큰, 만료된 토큰, 리프레시 토큰 없음, 미인증)
- N0XX: 공지사항 (공지 미존재)

### ErrorResponse 구조

#### 일반 에러
```
{
    "data": {
      "code": "CH001",
      "message": "채팅방을 찾을 수 없습니다",
      "errors": null
    }
  }
```

#### `@Valid` 에러
```
{
    "data": {
      "code": "C001",
      "message": "잘못된 입력입니다",
      "errors": [
        { "field": "email", "value": "", "reason": "이메일은 필수입니다" },
        { "field": "name", "value": "", "reason": "이름은 필수입니다" }
      ]
    }
  }
```