### PR TITLE
[FEAT] 결제 내역 조회 기능 구현

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentController.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -40,5 +42,18 @@ public class PaymentController {
     ) {
         paymentService.cancelPayment(userDetails.getUserId(), paymentId, req);
         return ApiResponse.of(null);
+    }
+
+    @GetMapping("/payments")
+    public ApiResponse<PaymentListResponse> getPayments(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam LocalDate from,
+            @RequestParam LocalDate to,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponse.of(
+                paymentService.getPayments(userDetails.getUserId(), from, to, page, size)
+        );
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentRepository.java
@@ -1,10 +1,20 @@
 package app.dearobjet.backend.domain.payment;
 
 import app.dearobjet.backend.domain.payment.entity.Payment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByPaymentKey(String paymentKey);
+
+    Page<Payment> findByOrder_User_IdAndCreatedAtBetween(
+            Long userId,
+            LocalDateTime from,
+            LocalDateTime to,
+            Pageable pageable
+    );
 }

--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentService.java
@@ -10,8 +10,18 @@ import app.dearobjet.backend.domain.payment.entity.*;
 import app.dearobjet.backend.domain.payment.toss.TossPaymentsClient;
 import app.dearobjet.backend.domain.payment.toss.TossPaymentsProperties;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -131,5 +141,45 @@ public class PaymentService {
             payment.markDone(paymentKey);
             payment.getOrder().updateStatus(OrderStatus.PAID);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentListResponse getPayments(Long userId, LocalDate from, LocalDate to, int page, int size) {
+        LocalDateTime fromDt = from.atStartOfDay();
+        LocalDateTime toDt = LocalDateTime.of(to, LocalTime.of(23, 59, 59));
+
+        Pageable pageable = PageRequest.of(
+                Math.max(page - 1, 0),
+                size,
+                Sort.by(Sort.Direction.DESC, "paymentId")
+        );
+
+        Page<Payment> paymentPage = paymentRepository.findByOrder_User_IdAndCreatedAtBetween(
+                userId, fromDt, toDt, pageable
+        );
+
+        List<PaymentResponse> items = new ArrayList<>();
+        for (Payment payment : paymentPage.getContent()) {
+            items.add(toResponse(payment));
+        }
+
+        return new PaymentListResponse(items, page, paymentPage.getTotalPages());
+    }
+
+    private PaymentResponse toResponse(Payment payment) {
+        Order order = payment.getOrder();
+
+        return new PaymentResponse(
+                payment.getPaymentId(),
+                order.getOrdersId(),
+                order.getOrderNumber(),
+                payment.getProvider(),
+                payment.getStatus(),
+                payment.getAmount(),
+                payment.getPaymentKey(),
+                payment.getApprovedAt(),
+                payment.getCanceledAt(),
+                payment.getFailReason()
+        );
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/payment/dto/PaymentListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/dto/PaymentListResponse.java
@@ -1,0 +1,14 @@
+package app.dearobjet.backend.domain.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PaymentListResponse {
+    private final List<PaymentResponse> items;
+    private final int page;
+    private final int totalPages;
+}

--- a/src/main/java/app/dearobjet/backend/domain/payment/dto/PaymentResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/dto/PaymentResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.payment.dto;
+
+import app.dearobjet.backend.domain.payment.entity.PaymentProvider;
+import app.dearobjet.backend.domain.payment.entity.PaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PaymentResponse {
+    private final Long paymentId;
+    private final Long orderId;
+    private final String orderNo;
+    private final PaymentProvider provider;
+    private final PaymentStatus status;
+    private final Long amount;
+    private final String paymentKey;
+    private final OffsetDateTime approvedAt;
+    private final OffsetDateTime canceledAt;
+    private final String failReason;
+}


### PR DESCRIPTION
결제 내역 조회 /api/v1/payments 엔드포인트를 추가했습니다.
PaymentResponse, PaymentListResponse DTO를 추가하고, PaymentRepository에 사용자별 기간 조회 메서드를 구현했습니다. PaymentService에서 조회 결과를 페이지 형태로 매핑하도록 구성했습니다.