### PR TITLE
feat: 공지사항 카테고리 확장 및 배지/New 응답 필드 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
@@ -20,7 +20,10 @@ public class Notice {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private NoticeCategory category;   // NOTICE | NEWS | EVENT | FESTIVAL
+    private NoticeCategory category;   // NOTICE | NEWS | EVENT | FESTIVAL | GENERAL | GUIDE
+
+    @Column(length = 30)
+    private String badge;
 
     private String title;
 

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeCategory.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeCategory.java
@@ -1,5 +1,7 @@
 package app.dearobjet.backend.domain.notification;
 
 public enum NoticeCategory {
-    NOTICE, NEWS, EVENT, FESTIVAL
+    NOTICE, NEWS, EVENT, FESTIVAL,
+    GENERAL,   // 일반
+    GUIDE      // 이용안내
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
@@ -10,7 +10,9 @@ import java.time.OffsetDateTime;
 public class NoticeResponse {
     private final Long noticeId;
     private final NoticeCategory category;
+    private final String badge;
     private final String title;
     private final String body;
     private final OffsetDateTime publishedAt;
+    private final boolean isNew;
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,6 +15,8 @@ import java.util.List;
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
+
+    private static final int NEW_DAYS = 7;
 
     public NoticeListResponse getNotices(NoticeCategory category, int page, int size) {
         Pageable pageable = PageRequest.of(
@@ -40,12 +43,16 @@ public class NoticeService {
     }
 
     private NoticeResponse toResponse(Notice notice) {
+        boolean isNew = notice.getPublishedAt() != null
+                && notice.getPublishedAt().isAfter(OffsetDateTime.now().minusDays(NEW_DAYS));
         return new NoticeResponse(
                 notice.getNotificationId(),
                 notice.getCategory(),
+                notice.getBadge(),
                 notice.getTitle(),
                 notice.getBody(),
-                notice.getPublishedAt()
+                notice.getPublishedAt(),
+                isNew
         );
     }
 }


### PR DESCRIPTION
공지사항 조회 API(/api/v1/notices, /api/v1/notices/{noticeId})에서 기획서 요구사항을 반영했습니다.

- NoticeCategory에 GENERAL(일반), GUIDE(이용안내)를 추가하고, Notice 엔티티에 badge 필드를 확장했습니다.
- NoticeResponse에 badge 및 isNew 값을 포함하도록 했으며, NoticeService에서 publishedAt 기준으로 신규 공지 여부를 계산해 응답 DTO에 매핑합니다.