### PR TITLE
[FEAT] 공지사항 대상별 조회 및 카테고리 체계 개편

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
@@ -19,8 +19,12 @@ public class Notice {
     private Long notificationId;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NoticeTarget target;   // USER | ARTIST_SHOP
+
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private NoticeCategory category;   // NOTICE | NEWS | EVENT | FESTIVAL | GENERAL | GUIDE
+    private NoticeCategory category;   // IMPORTANT | GENERAL | FESTIVAL | CULTURE_PERFORMANCE | EVENT
 
     @Column(length = 30)
     private String badge;

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeCategory.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeCategory.java
@@ -1,7 +1,9 @@
 package app.dearobjet.backend.domain.notification;
 
 public enum NoticeCategory {
-    NOTICE, NEWS, EVENT, FESTIVAL,
-    GENERAL,   // 일반
-    GUIDE      // 이용안내
+    IMPORTANT,             // 주요공지
+    GENERAL,               // 일반
+    FESTIVAL,              // 축제
+    CULTURE_PERFORMANCE,   // 문화공연
+    EVENT                  // 이벤트
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeController.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeController.java
@@ -13,11 +13,12 @@ public class NoticeController {
 
     @GetMapping("/notices")
     public ApiResponse<NoticeListResponse> getNotices(
+            @RequestParam NoticeTarget target,
             @RequestParam(required = false) NoticeCategory category, // null이면 공지 전체 목록 조회
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ApiResponse.of(noticeQueryService.getNotices(category, page, size));
+        return ApiResponse.of(noticeQueryService.getNotices(target, category, page, size));
     }
 
     @GetMapping("/notices/{noticeId}")

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice,Long> {
-    Page<Notice> findByCategory(NoticeCategory noticeCategory, Pageable pageable);
+    Page<Notice> findByTarget(NoticeTarget target, Pageable pageable);
+
+    Page<Notice> findByTargetAndCategory(NoticeTarget target, NoticeCategory category, Pageable pageable);
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
@@ -9,10 +9,11 @@ import java.time.OffsetDateTime;
 @AllArgsConstructor
 public class NoticeResponse {
     private final Long noticeId;
+    private final NoticeTarget target;
     private final NoticeCategory category;
     private final String badge;
     private final String title;
     private final String body;
-    private final OffsetDateTime publishedAt;
+    private final OffsetDateTime createdAt;
     private final boolean isNew;
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
@@ -18,14 +18,14 @@ public class NoticeService {
 
     private static final int NEW_DAYS = 7;
 
-    public NoticeListResponse getNotices(NoticeCategory category, int page, int size) {
+    public NoticeListResponse getNotices(NoticeTarget target, NoticeCategory category, int page, int size) {
         Pageable pageable = PageRequest.of(
                 Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "publishedAt")
         );
 
         Page<Notice> noticePage = (category == null)
-                ? noticeRepository.findAll(pageable)
-                : noticeRepository.findByCategory(category, pageable);
+                ? noticeRepository.findByTarget(target, pageable)
+                : noticeRepository.findByTargetAndCategory(target, category, pageable);
 
         List<NoticeResponse> noticeResponses = new ArrayList<>();
         for (Notice notice : noticePage.getContent()) {
@@ -47,6 +47,7 @@ public class NoticeService {
                 && notice.getPublishedAt().isAfter(OffsetDateTime.now().minusDays(NEW_DAYS));
         return new NoticeResponse(
                 notice.getNotificationId(),
+                notice.getTarget(),
                 notice.getCategory(),
                 notice.getBadge(),
                 notice.getTitle(),

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeTarget.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeTarget.java
@@ -1,0 +1,7 @@
+// file: C:/Users/user/dev/backend/src/main/java/app/dearobjet/backend/domain/notification/NoticeTarget.java
+package app.dearobjet.backend.domain.notification;
+
+public enum NoticeTarget {
+    USER,          // 일반이용자
+    ARTIST_SHOP    // 작가 / 소품샵
+}


### PR DESCRIPTION
공지사항 API를 일반이용자와 소품샵/작가 대상으로 구분할 수 있도록 target 필드를 추가했습니다.
공지 카테고리를 기획 기준에 맞게 수정했습니다.