### PR TITLE
[FIX] 채팅 실시간 상태 동기화 보정

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/dto/ChatRoomResponse.java
@@ -78,6 +78,7 @@ public class ChatRoomResponse {
         private String nickname;
         private String profileImageUrl;
         private LocalDateTime joinedAt;
+        private LocalDateTime lastReadAt;
 
         public static ParticipantResponse from(ChatParticipant participant) {
             return ParticipantResponse.builder()
@@ -85,6 +86,7 @@ public class ChatRoomResponse {
                     .nickname(participant.getUser().getName())
                     .profileImageUrl(participant.getUser().getProfileImage())
                     .joinedAt(participant.getJoinedAt())
+                    .lastReadAt(participant.getLastReadAt())
                     .build();
         }
     }

--- a/src/main/java/app/dearobjet/backend/domain/chat/dto/RedisChatMessageDto.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/dto/RedisChatMessageDto.java
@@ -38,14 +38,15 @@ public class RedisChatMessageDto {
     private String content;
     private MessageType messageType;
     private LocalDateTime timestamp;
+    private Boolean typing;
 
     /**
      * 일반 메시지 생성
      */
     public static RedisChatMessageDto ofMessage(String roomId, Long messageId, Long senderId,
-                                              String senderName, String senderProfileImage,
-                                              String content,
-                                              MessageType messageType, LocalDateTime timestamp) {
+                                                String senderName, String senderProfileImage,
+                                                String content,
+                                                MessageType messageType, LocalDateTime timestamp) {
         return RedisChatMessageDto.builder()
                 .eventType(EventType.MESSAGE)
                 .roomId(roomId)
@@ -62,12 +63,13 @@ public class RedisChatMessageDto {
     /**
      * 타이핑 이벤트 생성
      */
-    public static RedisChatMessageDto ofTyping(String roomId, Long senderId, String senderName) {
+    public static RedisChatMessageDto ofTyping(String roomId, Long senderId, String senderName, boolean typing) {
         return RedisChatMessageDto.builder()
                 .eventType(EventType.TYPING)
                 .roomId(roomId)
                 .senderId(senderId)
                 .senderName(senderName)
+                .typing(typing)
                 .timestamp(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/app/dearobjet/backend/domain/chat/dto/TypingIndicatorDto.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/dto/TypingIndicatorDto.java
@@ -17,14 +17,14 @@ public class TypingIndicatorDto {
     private String roomId;
     private Long userId;
     private String userName;
-    private boolean isTyping;
+    private boolean typing;
 
-    public static TypingIndicatorDto of(String roomId, Long userId, String userName, boolean isTyping) {
+    public static TypingIndicatorDto of(String roomId, Long userId, String userName, boolean typing) {
         return TypingIndicatorDto.builder()
                 .roomId(roomId)
                 .userId(userId)
                 .userName(userName)
-                .isTyping(isTyping)
+                .typing(typing)
                 .build();
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/entity/ChatRoom.java
@@ -7,10 +7,7 @@ import lombok.*;
 import org.springframework.util.DigestUtils;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -137,10 +134,12 @@ public class ChatRoom extends BaseTimeEntity {
      * 특정 사용자를 제외한 모든 참여자의 읽지 않은 메시지 수 증가
      *
      * @param senderUserId 메시지 발신자 ID (이 사용자는 제외)
+     * @param activeUsers 현재 접속중인 사용자
      */
-    public void incrementUnreadCount(Long senderUserId) {
-        participants.stream()
+    public void incrementUnreadCountExcluding(Long senderUserId, Set<Long> activeUsers) {
+        this.getParticipants().stream()
                 .filter(p -> !p.getUser().getId().equals(senderUserId))
+                .filter(p -> !activeUsers.contains(p.getUser().getId()))
                 .forEach(ChatParticipant::incrementUnreadCount);
     }
 

--- a/src/main/java/app/dearobjet/backend/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/service/ChatMessageService.java
@@ -13,6 +13,7 @@ import app.dearobjet.backend.domain.chat.repository.ChatRoomRepository;
 import app.dearobjet.backend.domain.chat.service.redis.ChatMessagePublisher;
 import app.dearobjet.backend.domain.chat.service.redis.MessageCacheRedisService;
 import app.dearobjet.backend.domain.chat.service.redis.UnreadCountRedisService;
+import app.dearobjet.backend.domain.chat.service.redis.PresenceRedisService;
 import app.dearobjet.backend.domain.user.entity.User;
 import app.dearobjet.backend.domain.user.repository.UserRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
@@ -50,6 +51,7 @@ public class ChatMessageService {
     private final ChatMessagePublisher messagePublisher;
     private final UnreadCountRedisService unreadCountRedisService;
     private final MessageCacheRedisService messageCacheRedisService;
+    private final PresenceRedisService presenceRedisService;
 
     /**
      * 메시지 전송
@@ -97,10 +99,19 @@ public class ChatMessageService {
         Set<Long> participantIds = chatRoom.getParticipants().stream()
                 .map(p -> p.getUser().getId())
                 .collect(Collectors.toSet());
-        unreadCountRedisService.incrementForParticipants(roomId, participantIds, senderId);
+
+        // 현재 채팅방에 접속 중인 유저 조회
+        Set<Long> activeUsers = presenceRedisService.getOnlineUsersInRoom(roomId);
+
+        // 접속 중인 유저는 unread 증가 제외
+        for (Long participantId : participantIds) {
+            if (!participantId.equals(senderId) && !activeUsers.contains(participantId)) {
+                unreadCountRedisService.incrementUnreadCount(participantId, roomId);
+            }
+        }
 
         // DB에도 unread 카운트 증가 (정합성 유지)
-        chatRoom.incrementUnreadCount(senderId);
+        chatRoom.incrementUnreadCountExcluding(senderId, activeUsers);
 
         // Redis 캐시에 메시지 추가
         messageCacheRedisService.addRecentMessage(message, senderId);

--- a/src/main/java/app/dearobjet/backend/domain/chat/service/redis/ChatMessageSubscriber.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/service/redis/ChatMessageSubscriber.java
@@ -14,6 +14,7 @@ import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Redis Pub/Sub 메시지 구독 서비스
@@ -43,8 +44,8 @@ public class ChatMessageSubscriber implements MessageListener {
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
-            String channel = new String(message.getChannel());
-            String body = new String(message.getBody());
+            String channel = new String(message.getChannel(), StandardCharsets.UTF_8);
+            String body = new String(message.getBody(), StandardCharsets.UTF_8);
 
             RedisChatMessageDto redisMessage = chatObjectMapper.readValue(body, RedisChatMessageDto.class);
             log.debug("Received message from channel {}: {}", channel, redisMessage.getEventType());
@@ -77,7 +78,7 @@ public class ChatMessageSubscriber implements MessageListener {
             case TYPING -> {
                 // 타이핑 상태 전달
                 TypingIndicatorDto dto = TypingIndicatorDto.of(
-                        roomId, message.getSenderId(), message.getSenderName(), true);
+                        roomId, message.getSenderId(), message.getSenderName(), message.getTyping());
                 messagingTemplate.convertAndSend(destination + "/typing", dto);
             }
             case READ -> {

--- a/src/main/java/app/dearobjet/backend/domain/chat/websocket/ChatWebSocketController.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/websocket/ChatWebSocketController.java
@@ -87,7 +87,7 @@ public class ChatWebSocketController {
         validateParticipant(roomId, userId);
 
         // 타이핑 이벤트를 Redis Pub/Sub으로 브로드캐스트
-        RedisChatMessageDto typingEvent = RedisChatMessageDto.ofTyping(roomId, userId, typing.getUserName());
+        RedisChatMessageDto typingEvent = RedisChatMessageDto.ofTyping(roomId, userId, typing.getUserName(), typing.isTyping());
         messagePublisher.publishToRoom(typingEvent);
 
         log.debug("Typing event - roomId: {}, userId: {}", roomId, userId);

--- a/src/main/java/app/dearobjet/backend/domain/chat/websocket/WebSocketEventListener.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/websocket/WebSocketEventListener.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import app.dearobjet.backend.domain.chat.repository.ChatParticipantRepository;
 
 import java.security.Principal;
 
@@ -27,6 +28,7 @@ public class WebSocketEventListener {
 
     private final SessionRedisService sessionRedisService;
     private final PresenceRedisService presenceRedisService;
+    private final ChatParticipantRepository chatParticipantRepository;
 
     @Value("${spring.application.name:backend}")
     private String serverId;
@@ -65,6 +67,11 @@ public class WebSocketEventListener {
             // 오프라인 상태 설정
             presenceRedisService.setOffline(userId);
 
+            // 참여 중인 모든 채팅방에서 presence 제거
+            chatParticipantRepository.findMyParticipationsWithDetails(userId)
+                    .forEach(p ->
+                            presenceRedisService.leaveRoom(p.getChatRoom().getRoomId(), userId)
+                    );
             log.info("WebSocket disconnected - userId: {}, sessionId: {}", userId, sessionId);
         }
     }
@@ -82,7 +89,6 @@ public class WebSocketEventListener {
             // 채팅방 구독 시 해당 방에 입장 처리
             String roomId = extractRoomIdFromDestination(destination);
             if (roomId != null) {
-                presenceRedisService.joinRoom(roomId, userId);
                 sessionRedisService.setActiveRoom(userId, roomId);
                 log.debug("User {} subscribed to room {}", userId, roomId);
             }


### PR DESCRIPTION
## 변경 내용
  - 타이핑 이벤트에 실제 `typing` 상태를 포함하도록 DTO와 WebSocket 브로드캐스트 흐름을 수정했습니다.
  - 메시지 전송 시 현재 채팅방 접속 중인 사용자는 unread count 증가 대상에서 제외하도록 보정했습니다.
  - WebSocket disconnect 시 사용자가 참여 중이던 채팅방 presence 정보를 정리하도록 변경했습니다.
  - 채팅방 응답에 participant의 `lastReadAt`을 포함하도록 확장했습니다.
  - Redis Pub/Sub 메시지 디코딩 시 UTF-8을 명시적으로 사용하도록 보완했습니다.

  ## 변경 이유
  - 기존 타이핑 이벤트는 항상 `true`로만 전달되어 실제 입력 종료 상태를 반영하지 못했습니다.
  - 접속 중인 사용자까지 unread count가 증가하면 읽음 상태와 UI 표시가 어긋날 수 있었습니다.
  - disconnect 이후 room presence가 남아 있으면 온라인 사용자 집계가 부정확해질 수 있었습니다.
  - participant별 마지막 읽은 시각이 응답에 없어서 클라이언트가 읽음 상태를 정밀하게 표현하기 어려웠습니다.

  ## 영향 범위
  - 채팅 메시지 전송
  - 채팅방 타이핑 표시
  - WebSocket 연결/해제 시 presence 관리
  - 채팅방 participant 응답 스키마