### PR TITLE
feat: 소품샵 계약 작가별 재고관리 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/entity/Artist.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/entity/Artist.java
@@ -30,21 +30,6 @@ public class Artist extends BaseTimeEntity {
     @Column(name = "instagram_id")
     private String instagramId;
 
-    @Column(columnDefinition = "TEXT")
-    private String bio;
-
-    @Column(name = "portfolio_url")
-    private String portfolioUrl;
-
-    // 비즈니스 메서드
-    public void updateProfile(String businessName, String bio, String portfolioUrl) {
-        if (businessName != null && businessProfile != null) {
-            businessProfile.changeBusinessName(businessName);
-        }
-        this.bio = bio;
-        this.portfolioUrl = portfolioUrl;
-    }
-
     public void changeInstagramId(String instagramId) {
         this.instagramId = instagramId;
     }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -1,11 +1,24 @@
 package app.dearobjet.backend.domain.contract;
 
+import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
+import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,8 +31,87 @@ public class ContractController {
 
     @GetMapping("/pending-count")
     public ApiResponse<ContractApplicationCountResponse> getPendingApplicationCount(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
     ) {
-        return ApiResponse.of(contractService.getPendingApplicationCount(userDetails.getUserId()));
+        return ApiResponse.of(contractService.getPendingApplicationCount(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/inventory")
+    public ApiResponse<ContractInventoryListResponse> getInventory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(contractService.getInventory(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/inventory/{contractId}/products")
+    public ApiResponse<ContractInventoryDetailResponse> getInventoryProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.getInventoryProducts(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
+
+    @PatchMapping("/inventory/{contractId}/memo")
+    public ApiResponse<ContractMemoResponse> updateInventoryMemo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId,
+            @Valid @RequestBody UpdateContractMemoRequest request
+    ) {
+        return ApiResponse.of(
+                contractService.updateInventoryMemo(
+                        resolveUserId(userDetails, userId),
+                        contractId,
+                        request
+                )
+        );
+    }
+
+    @PatchMapping("/inventory/{contractId}/inbound-confirmation")
+    public ApiResponse<ContractInboundConfirmResponse> confirmRecentInbound(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.confirmRecentInbound(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
+
+    @PostMapping("/inventory/{contractProductId}/stock-movements")
+    public ApiResponse<AdjustContractInventoryResponse> adjustInventory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractProductId,
+            @Valid @RequestBody AdjustContractInventoryRequest request
+    ) {
+        return ApiResponse.of(
+                contractService.adjustInventory(
+                        resolveUserId(userDetails, userId),
+                        contractProductId,
+                        request
+                )
+        );
+    }
+
+    private Long resolveUserId(CustomUserDetails userDetails, Long userId) {
+        if (userDetails != null) {
+            return userDetails.getUserId();
+        }
+        if (userId != null) {
+            return userId;
+        }
+        throw new IllegalArgumentException("인증 정보가 없으면 userId 쿼리 파라미터가 필요합니다.");
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -1,21 +1,19 @@
 package app.dearobjet.backend.domain.contract;
 
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ContractRepository extends JpaRepository<ShopArtistContract, Long> {
 
-    @Query("""
-            select count(c)
-            from ShopArtistContract c
-            where c.shop.user.id = :userId
-              and c.contractStatus = 'PENDING'
-            """)
-    long countPendingApplicationsByShopUserId(@Param("userId") Long userId);
+    long countByShopUserIdAndContractStatus(Long userId, ContractStatus contractStatus);
 
     @Query("""
             select coalesce(nullif(trim(bp.businessName), ''), nullif(trim(u.name), ''), 'UNKNOWN')
@@ -24,8 +22,57 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             join a.businessProfile bp
             join a.user u
             where c.shop.user.id = :userId
-              and c.contractStatus = 'PENDING'
+              and c.contractStatus = :contractStatus
             order by c.shopArtistContractsId desc
             """)
-    List<String> findPendingApplicationArtistNamesByShopUserId(@Param("userId") Long userId);
+    List<String> findPendingApplicationArtistNamesByShopUserId(
+            @Param("userId") Long userId,
+            @Param("contractStatus") ContractStatus contractStatus
+    );
+
+    @Query("""
+            select c.shopArtistContractsId as contractId,
+                   u.profileUrl as artistImageUrl,
+                   bp.businessName as artistName,
+                   bp.specialty as specialty,
+                   max(cp.recentStockedAt) as recentStockedAt,
+                   c.recentInboundConfirmed as inboundConfirmed
+            from ShopArtistContract c
+            join c.artist a
+            join a.user u
+            join a.businessProfile bp
+            left join ContractProduct cp
+                on cp.shopArtistContract = c
+               and cp.listingStatus = :listingStatus
+            where c.shop.shopId = :shopId
+              and c.contractStatus = :contractStatus
+            group by c.shopArtistContractsId,
+                     u.profileUrl,
+                     bp.businessName,
+                     bp.specialty,
+                     c.recentInboundConfirmed
+            order by case when max(cp.recentStockedAt) is null then 1 else 0 end,
+                     max(cp.recentStockedAt) desc,
+                     c.shopArtistContractsId desc
+            """)
+    List<ContractInventoryRow> findInventoryRowsByShopId(
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("listingStatus") ContractProductListingStatus listingStatus
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
+            join fetch c.artist a
+            join fetch a.businessProfile
+            where c.shopArtistContractsId = :contractId
+              and c.shop.shopId = :shopId
+              and c.contractStatus = :contractStatus
+            """)
+    Optional<ShopArtistContract> findApprovedByIdAndShopId(
+            @Param("contractId") Long contractId,
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus
+    );
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -1,11 +1,30 @@
 package app.dearobjet.backend.domain.contract;
 
+import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
+import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
+import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
+import app.dearobjet.backend.domain.shop.entity.Shop;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -13,15 +32,159 @@ import java.util.List;
 public class ContractService {
 
     private final ContractRepository contractRepository;
+    private final ContractProductRepository contractProductRepository;
+    private final ContractProductStockMovementRepository contractProductStockMovementRepository;
     private final ShopRepository shopRepository;
 
     @Transactional(readOnly = true)
     public ContractApplicationCountResponse getPendingApplicationCount(Long userId) {
-        shopRepository.findByUser_Id(userId)
-                .orElseThrow(() -> new IllegalArgumentException("Shop not found for user: " + userId));
+        getShopByUserId(userId);
 
-        long applicationCount = contractRepository.countPendingApplicationsByShopUserId(userId);
-        List<String> artistNames = contractRepository.findPendingApplicationArtistNamesByShopUserId(userId);
+        long applicationCount = contractRepository.countByShopUserIdAndContractStatus(userId, ContractStatus.PENDING);
+        List<String> artistNames = contractRepository.findPendingApplicationArtistNamesByShopUserId(
+                userId,
+                ContractStatus.PENDING
+        );
         return new ContractApplicationCountResponse(applicationCount, artistNames);
+    }
+
+    @Transactional(readOnly = true)
+    public ContractInventoryListResponse getInventory(Long userId) {
+        Shop shop = getShopByUserId(userId);
+
+        return ContractInventoryListResponse.from(
+                contractRepository.findInventoryRowsByShopId(
+                        shop.getShopId(),
+                        ContractStatus.APPROVED,
+                        ContractProductListingStatus.ACTIVE
+                )
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ContractInventoryDetailResponse getInventoryProducts(Long userId, Long contractId) {
+        Shop shop = getShopByUserId(userId);
+        ShopArtistContract contract = getApprovedContract(contractId, shop.getShopId());
+
+        return ContractInventoryDetailResponse.from(
+                contract,
+                contractProductRepository.findInventoryProductRowsByContractId(
+                        contractId,
+                        shop.getShopId(),
+                        ContractStatus.APPROVED,
+                        ContractProductListingStatus.ACTIVE,
+                        ContractProductStockMovementType.INBOUND
+                )
+        );
+    }
+
+    @Transactional
+    public ContractMemoResponse updateInventoryMemo(
+            Long userId,
+            Long contractId,
+            UpdateContractMemoRequest request
+    ) {
+        Shop shop = getShopByUserId(userId);
+        ShopArtistContract contract = getApprovedContract(contractId, shop.getShopId());
+        contract.updateMemo(request.getMemo());
+
+        return ContractMemoResponse.from(contract);
+    }
+
+    @Transactional
+    public ContractInboundConfirmResponse confirmRecentInbound(Long userId, Long contractId) {
+        Shop shop = getShopByUserId(userId);
+        ShopArtistContract contract = getApprovedContract(contractId, shop.getShopId());
+        contract.confirmRecentInbound(userId, LocalDateTime.now());
+
+        return ContractInboundConfirmResponse.from(contract);
+    }
+
+    @Transactional
+    public AdjustContractInventoryResponse adjustInventory(
+            Long userId,
+            Long contractProductId,
+            AdjustContractInventoryRequest request
+    ) {
+        Shop shop = getShopByUserId(userId);
+        ContractProduct contractProduct = contractProductRepository.findOwnedInventoryById(
+                        contractProductId,
+                        shop.getShopId(),
+                        ContractStatus.APPROVED,
+                        ContractProductListingStatus.ACTIVE
+                )
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "재고 품목을 찾을 수 없습니다."
+                ));
+
+        ContractProductStockMovement movement = applyMovement(userId, contractProduct, request);
+        if (movement.getMovementType() == ContractProductStockMovementType.INBOUND) {
+            contractProduct.getShopArtistContract().markRecentInboundPending();
+        }
+        contractProductStockMovementRepository.save(movement);
+
+        return AdjustContractInventoryResponse.from(contractProduct, movement);
+    }
+
+    private Shop getShopByUserId(Long userId) {
+        return shopRepository.findByUser_Id(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Shop not found for user: " + userId));
+    }
+
+    private ShopArtistContract getApprovedContract(Long contractId, Long shopId) {
+        return contractRepository.findApprovedByIdAndShopId(contractId, shopId, ContractStatus.APPROVED)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "계약된 작가를 찾을 수 없습니다."
+                ));
+    }
+
+    private ContractProductStockMovement applyMovement(
+            Long userId,
+            ContractProduct contractProduct,
+            AdjustContractInventoryRequest request
+    ) {
+        ContractProductStockMovementType movementType = request.getMovementType();
+        int quantity = request.getQuantity();
+
+        return switch (movementType) {
+            case INBOUND -> contractProduct.applyInbound(
+                    quantity,
+                    request.getOccurredAt(),
+                    userId,
+                    request.getMemo()
+            );
+            case ADJUSTMENT_INCREASE -> contractProduct.applyAdjustmentIncrease(
+                    quantity,
+                    request.getOccurredAt(),
+                    userId,
+                    request.getMemo()
+            );
+            case ADJUSTMENT_DECREASE -> contractProduct.applyAdjustmentDecrease(
+                    quantity,
+                    request.getOccurredAt(),
+                    userId,
+                    request.getMemo()
+            );
+            case SALE_DECREASE -> contractProduct.applySaleDecrease(
+                    quantity,
+                    request.getOccurredAt(),
+                    userId,
+                    request.getMemo()
+            );
+            case RETURN_INCREASE -> contractProduct.applyReturnIncrease(
+                    quantity,
+                    request.getOccurredAt(),
+                    userId,
+                    request.getMemo()
+            );
+            case CANCEL_RESTORE -> contractProduct.applyCancelRestore(
+                    quantity,
+                    request.getOccurredAt(),
+                    userId,
+                    request.getMemo()
+            );
+        };
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/AdjustContractInventoryRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/AdjustContractInventoryRequest.java
@@ -1,0 +1,26 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class AdjustContractInventoryRequest {
+
+    @NotNull(message = "재고 변경 타입은 필수입니다.")
+    private ContractProductStockMovementType movementType;
+
+    @NotNull(message = "재고 변경 수량은 필수입니다.")
+    @Min(value = 1, message = "재고 변경 수량은 1 이상이어야 합니다.")
+    private Integer quantity;
+
+    @NotNull(message = "재고 변경 시각은 필수입니다.")
+    private LocalDateTime occurredAt;
+
+    private String memo;
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/AdjustContractInventoryResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/AdjustContractInventoryResponse.java
@@ -1,0 +1,38 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AdjustContractInventoryResponse {
+
+    private final Long contractProductId;
+    private final ContractProductStockMovementType movementType;
+    private final Integer quantityDelta;
+    private final Integer stockQuantity;
+    private final Integer soldQuantity;
+    private final LocalDateTime recentStockedAt;
+    private final LocalDateTime occurredAt;
+
+    public static AdjustContractInventoryResponse from(
+            ContractProduct contractProduct,
+            ContractProductStockMovement movement
+    ) {
+        return new AdjustContractInventoryResponse(
+                contractProduct.getContractProductsId(),
+                movement.getMovementType(),
+                movement.getQuantityDelta(),
+                contractProduct.getStockQuantity(),
+                contractProduct.getSoldQuantity(),
+                contractProduct.getRecentStockedAt(),
+                movement.getOccurredAt()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInboundConfirmResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInboundConfirmResponse.java
@@ -1,0 +1,25 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractInboundConfirmResponse {
+
+    private final Long contractId;
+    private final Boolean inboundConfirmed;
+    private final LocalDateTime confirmedAt;
+
+    public static ContractInboundConfirmResponse from(ShopArtistContract contract) {
+        return new ContractInboundConfirmResponse(
+                contract.getShopArtistContractsId(),
+                Boolean.TRUE.equals(contract.getRecentInboundConfirmed()),
+                contract.getRecentInboundConfirmedAt()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryDetailResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryDetailResponse.java
@@ -1,0 +1,33 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractInventoryDetailResponse {
+
+    private final Long contractId;
+    private final String artistName;
+    private final String memo;
+    private final List<ContractInventoryProductResponse> items;
+
+    public static ContractInventoryDetailResponse from(
+            ShopArtistContract contract,
+            List<ContractInventoryProductRow> rows
+    ) {
+        return new ContractInventoryDetailResponse(
+                contract.getShopArtistContractsId(),
+                contract.getArtist().getBusinessProfile().getBusinessName(),
+                contract.getMemo() == null ? "" : contract.getMemo(),
+                rows.stream()
+                        .map(ContractInventoryProductResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryItemResponse.java
@@ -1,0 +1,32 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractInventoryItemResponse {
+
+    private final Long contractId;
+    private final String artistImageUrl;
+    private final String artistName;
+    private final Specialty specialty;
+    private final LocalDateTime recentStockedAt;
+    private final Boolean inboundConfirmed;
+
+    public static ContractInventoryItemResponse from(ContractInventoryRow row) {
+        return new ContractInventoryItemResponse(
+                row.getContractId(),
+                row.getArtistImageUrl(),
+                row.getArtistName(),
+                row.getSpecialty(),
+                row.getRecentStockedAt(),
+                Boolean.TRUE.equals(row.getInboundConfirmed())
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryListResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractInventoryListResponse {
+
+    private final List<ContractInventoryItemResponse> items;
+
+    public static ContractInventoryListResponse from(List<ContractInventoryRow> rows) {
+        return new ContractInventoryListResponse(
+                rows.stream()
+                        .map(ContractInventoryItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryProductResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractInventoryProductResponse.java
@@ -1,0 +1,45 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractInventoryProductResponse {
+
+    private final Long contractProductId;
+    private final Long totalQuantity;
+    private final String productImageUrl;
+    private final String productName;
+    private final BigDecimal sellingPrice;
+    private final Integer stockQuantity;
+    private final CommissionType commissionType;
+    private final BigDecimal commissionValue;
+    private final BigDecimal marginAmount;
+    private final BigDecimal unitSettlementAmount;
+    private final String artistName;
+    private final LocalDateTime recentStockedAt;
+
+    public static ContractInventoryProductResponse from(ContractInventoryProductRow row) {
+        return new ContractInventoryProductResponse(
+                row.getContractProductId(),
+                row.getTotalQuantity(),
+                row.getProductImageUrl(),
+                row.getProductName(),
+                row.getSellingPrice(),
+                row.getStockQuantity(),
+                row.getCommissionType(),
+                row.getCommissionValue(),
+                row.getMarginAmount(),
+                row.getUnitSettlementAmount(),
+                row.getArtistName(),
+                row.getRecentStockedAt()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractMemoResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractMemoResponse.java
@@ -1,0 +1,21 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractMemoResponse {
+
+    private final Long contractId;
+    private final String memo;
+
+    public static ContractMemoResponse from(ShopArtistContract contract) {
+        return new ContractMemoResponse(
+                contract.getShopArtistContractsId(),
+                contract.getMemo() == null ? "" : contract.getMemo()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/UpdateContractMemoRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/UpdateContractMemoRequest.java
@@ -1,0 +1,13 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateContractMemoRequest {
+
+    @NotNull(message = "메모는 필수입니다.")
+    private String memo;
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ContractInventoryProductRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ContractInventoryProductRow.java
@@ -1,0 +1,21 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public interface ContractInventoryProductRow {
+    Long getContractProductId();
+    Long getTotalQuantity();
+    String getProductImageUrl();
+    String getProductName();
+    BigDecimal getSellingPrice();
+    Integer getStockQuantity();
+    CommissionType getCommissionType();
+    BigDecimal getCommissionValue();
+    BigDecimal getMarginAmount();
+    BigDecimal getUnitSettlementAmount();
+    String getArtistName();
+    LocalDateTime getRecentStockedAt();
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ContractInventoryRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ContractInventoryRow.java
@@ -1,0 +1,14 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.user.enums.Specialty;
+
+import java.time.LocalDateTime;
+
+public interface ContractInventoryRow {
+    Long getContractId();
+    String getArtistImageUrl();
+    String getArtistName();
+    Specialty getSpecialty();
+    LocalDateTime getRecentStockedAt();
+    Boolean getInboundConfirmed();
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ContractProduct.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ContractProduct.java
@@ -1,20 +1,38 @@
 package app.dearobjet.backend.domain.contract.entity;
 
-import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.shop.entity.Product;
-import app.dearobjet.backend.domain.shop.entity.Shop;
 import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
+/**
+ * 샵의 현재 재고 스냅샷
+ */
 @Entity
-@Table(name = "contract_products")
+@Table(
+        name = "contract_products",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_contract_products_contract_product",
+                        columnNames = {"shop_artist_contracts_id", "products_id"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ContractProduct extends BaseTimeEntity {
+
+    private static final int ZERO_STOCK_QUANTITY = 0;
+    private static final int MIN_MOVEMENT_QUANTITY = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,28 +43,224 @@ public class ContractProduct extends BaseTimeEntity {
     @JoinColumn(name = "shop_artist_contracts_id", nullable = false)
     private ShopArtistContract shopArtistContract;
 
-    @Column(name = "listing_status")
-    private String listingStatus;
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "listing_status", nullable = false, length = 20)
+    private ContractProductListingStatus listingStatus = ContractProductListingStatus.ACTIVE;
 
-    @Column(name = "listed_at")
-    private java.time.LocalDateTime listedAt;
+    @Builder.Default
+    @Column(name = "sold_quantity", nullable = false)
+    private Integer soldQuantity = ZERO_STOCK_QUANTITY;
 
-    @Column(name = "ended_at")
-    private java.time.LocalDateTime endedAt;
-
-    @Column(name = "last_modified_at")
-    private java.time.LocalDateTime lastModifiedAt;
-
-    @Column(name = "sold_quantity")
-    private Integer soldQuantity;
-
-    @Column(name = "stock_quantity")
-    private Integer stockQuantity;
+    @Builder.Default
+    @Column(name = "stock_quantity", nullable = false)
+    private Integer stockQuantity = ZERO_STOCK_QUANTITY;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "products_id")
-    private Product products;
+    @JoinColumn(name = "products_id", nullable = false)
+    private Product product;
 
-    @Column(name = "selling_price")
-    private Double sellingPrice;
+    @Column(name = "selling_price", precision = 19, scale = 2)
+    private BigDecimal sellingPrice;
+
+    @Column(name = "margin_amount", precision = 19, scale = 2)
+    private BigDecimal marginAmount; // 마진금액
+
+    @Column(name = "unit_settlement_amount", precision = 19, scale = 2)
+    private BigDecimal unitSettlementAmount; // 개당 정산금액
+
+    @Column(name = "recent_stocked_at")
+    private LocalDateTime recentStockedAt; // 최근입고일
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    /**
+     * 정산 관련 금액은 재고 이력과 분리해서 관리한다.
+     */
+    public void updateInventoryManagement(
+            BigDecimal marginAmount,
+            BigDecimal unitSettlementAmount
+    ) {
+        this.marginAmount = marginAmount;
+        this.unitSettlementAmount = unitSettlementAmount;
+    }
+
+    public ContractProductStockMovement applyInbound(
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo
+    ) {
+        return applyIncreaseMovement(
+                ContractProductStockMovementType.INBOUND,
+                quantity,
+                occurredAt,
+                createdByUserId,
+                memo,
+                true
+        );
+    }
+
+    public ContractProductStockMovement applyAdjustmentIncrease(
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo
+    ) {
+        return applyIncreaseMovement(
+                ContractProductStockMovementType.ADJUSTMENT_INCREASE,
+                quantity,
+                occurredAt,
+                createdByUserId,
+                memo,
+                false
+        );
+    }
+
+    public ContractProductStockMovement applyAdjustmentDecrease(
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo
+    ) {
+        return applyDecreaseMovement(
+                ContractProductStockMovementType.ADJUSTMENT_DECREASE,
+                quantity,
+                occurredAt,
+                createdByUserId,
+                memo,
+                false
+        );
+    }
+
+    public ContractProductStockMovement applySaleDecrease(
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo
+    ) {
+        ContractProductStockMovement movement = applyDecreaseMovement(
+                ContractProductStockMovementType.SALE_DECREASE,
+                quantity,
+                occurredAt,
+                createdByUserId,
+                memo,
+                false
+        );
+        this.soldQuantity += quantity;
+        return movement;
+    }
+
+    public ContractProductStockMovement applyReturnIncrease(
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo
+    ) {
+        return applyIncreaseMovement(
+                ContractProductStockMovementType.RETURN_INCREASE,
+                quantity,
+                occurredAt,
+                createdByUserId,
+                memo,
+                false
+        );
+    }
+
+    public ContractProductStockMovement applyCancelRestore(
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo
+    ) {
+        if (this.soldQuantity < quantity) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "복구할 판매 수량이 현재 판매 수량보다 많습니다.");
+        }
+
+        ContractProductStockMovement movement = applyIncreaseMovement(
+                ContractProductStockMovementType.CANCEL_RESTORE,
+                quantity,
+                occurredAt,
+                createdByUserId,
+                memo,
+                false
+        );
+        this.soldQuantity -= quantity;
+        return movement;
+    }
+
+    private ContractProductStockMovement applyIncreaseMovement(
+            ContractProductStockMovementType movementType,
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo,
+            boolean updateRecentStockedAt
+    ) {
+        validateMovementMetadata(quantity, occurredAt, createdByUserId);
+        this.stockQuantity += quantity;
+        if (updateRecentStockedAt) {
+            this.recentStockedAt = occurredAt;
+        }
+        return createMovement(movementType, quantity, occurredAt, createdByUserId, memo);
+    }
+
+    private ContractProductStockMovement applyDecreaseMovement(
+            ContractProductStockMovementType movementType,
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo,
+            boolean updateRecentStockedAt
+    ) {
+        validateMovementMetadata(quantity, occurredAt, createdByUserId);
+        if (this.stockQuantity < quantity) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "현재 재고보다 많은 수량을 차감할 수 없습니다.");
+        }
+
+        this.stockQuantity -= quantity;
+        if (updateRecentStockedAt) {
+            this.recentStockedAt = occurredAt;
+        }
+        return createMovement(movementType, -quantity, occurredAt, createdByUserId, memo);
+    }
+
+    /**
+     * 현재 재고 스냅샷과 이력 원본이 항상 같은 결과를 보도록 한 규칙으로 movement를 만든다.
+     */
+    private ContractProductStockMovement createMovement(
+            ContractProductStockMovementType movementType,
+            int quantityDelta,
+            LocalDateTime occurredAt,
+            Long createdByUserId,
+            String memo
+    ) {
+        return ContractProductStockMovement.create(
+                this,
+                movementType,
+                quantityDelta,
+                this.stockQuantity,
+                occurredAt,
+                memo,
+                createdByUserId
+        );
+    }
+
+    private void validateMovementMetadata(
+            int quantity,
+            LocalDateTime occurredAt,
+            Long createdByUserId
+    ) {
+        if (quantity < MIN_MOVEMENT_QUANTITY) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "재고 변경 수량은 1 이상이어야 합니다.");
+        }
+        if (occurredAt == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "재고 변경 시각은 필수입니다.");
+        }
+        if (createdByUserId == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "재고 변경 사용자 ID는 필수입니다.");
+        }
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ContractProductStockMovement.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ContractProductStockMovement.java
@@ -1,0 +1,84 @@
+package app.dearobjet.backend.domain.contract.entity;
+
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 샵의 재고 입고/조정 이력
+ */
+@Entity
+@Table(
+        name = "contract_product_stock_movements",
+        indexes = {
+                @Index(
+                        name = "idx_contract_product_stock_movements_contract_product",
+                        columnList = "contract_products_id"
+                ),
+                @Index(
+                        name = "idx_contract_product_stock_movements_occurred_at",
+                        columnList = "occurred_at"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class ContractProductStockMovement extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "contract_product_stock_movement_id")
+    private Long contractProductStockMovementId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "contract_products_id", nullable = false)
+    private ContractProduct contractProduct;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "movement_type", nullable = false, length = 30)
+    private ContractProductStockMovementType movementType;
+
+    @Column(name = "quantity_delta", nullable = false)
+    private Integer quantityDelta;
+
+    @Column(name = "result_stock_quantity", nullable = false)
+    private Integer resultStockQuantity;
+
+    @Column(name = "occurred_at", nullable = false)
+    private LocalDateTime occurredAt;
+
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo;
+
+    @Column(name = "created_by_user_id", nullable = false)
+    private Long createdByUserId;
+
+    public static ContractProductStockMovement create(
+            ContractProduct contractProduct,
+            ContractProductStockMovementType movementType,
+            Integer quantityDelta,
+            Integer resultStockQuantity,
+            LocalDateTime occurredAt,
+            String memo,
+            Long createdByUserId
+    ) {
+        return ContractProductStockMovement.builder()
+                .contractProduct(contractProduct)
+                .movementType(movementType)
+                .quantityDelta(quantityDelta)
+                .resultStockQuantity(resultStockQuantity)
+                .occurredAt(occurredAt)
+                .memo(memo)
+                .createdByUserId(createdByUserId)
+                .build();
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
@@ -1,13 +1,20 @@
 package app.dearobjet.backend.domain.contract.entity;
 
 import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.shop.entity.Shop;
 import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 /**
- * 샵-작가 계약 엔티티
+ * 샵-작가 사이의 입점 계약 엔티티
  */
 @Entity
 @Table(name = "shop_artist_contracts")
@@ -30,30 +37,52 @@ public class ShopArtistContract extends BaseTimeEntity {
     @JoinColumn(name = "shop_id")
     private Shop shop;
 
-    @Column(name = "contract_status")
-    private String contractStatus;
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contract_status", nullable = false, length = 20)
+    private ContractStatus contractStatus = ContractStatus.PENDING;
 
-    @Column(name = "applied_at")
-    private java.time.LocalDateTime appliedAt;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "commission_type", length = 20)
+    private CommissionType commissionType;
 
-    @Column(name = "approved_at")
-    private java.time.LocalDateTime approvedAt;
+    @Column(name = "commission_value", precision = 19, scale = 4)
+    private BigDecimal commissionValue;
 
-    @Column(name = "ended_at")
-    private java.time.LocalDateTime endedAt;
+    @Builder.Default
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo = "";
 
-    @Column(name = "reject_reason")
-    private String rejectReason;
+    @Builder.Default
+    @Column(name = "recent_inbound_confirmed")
+    private Boolean recentInboundConfirmed = false;
 
-    @Column(name = "last_modified_at")
-    private java.time.LocalDateTime lastModifiedAt;
+    @Column(name = "recent_inbound_confirmed_at")
+    private LocalDateTime recentInboundConfirmedAt;
 
-    @Column(name = "commission_type")
-    private String commissionType;
+    @Column(name = "recent_inbound_confirmed_by_user_id")
+    private Long recentInboundConfirmedByUserId;
 
-    @Column(name = "commission_value")
-    private Double commissionValue;
+    public void updateMemo(String memo) {
+        this.memo = memo == null ? "" : memo;
+    }
 
-    @Column(name = "contract_url")
-    private String contractUrl;
+    public void markRecentInboundPending() {
+        this.recentInboundConfirmed = false;
+        this.recentInboundConfirmedAt = null;
+        this.recentInboundConfirmedByUserId = null;
+    }
+
+    public void confirmRecentInbound(Long confirmedByUserId, LocalDateTime confirmedAt) {
+        if (confirmedByUserId == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "입고확인 사용자 ID는 필수입니다.");
+        }
+        if (confirmedAt == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "입고확인 시각은 필수입니다.");
+        }
+
+        this.recentInboundConfirmed = true;
+        this.recentInboundConfirmedAt = confirmedAt;
+        this.recentInboundConfirmedByUserId = confirmedByUserId;
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/enums/CommissionType.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/enums/CommissionType.java
@@ -1,0 +1,6 @@
+package app.dearobjet.backend.domain.contract.enums;
+
+public enum CommissionType {
+    RATE,
+    FIXED_AMOUNT
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractProductListingStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractProductListingStatus.java
@@ -1,0 +1,6 @@
+package app.dearobjet.backend.domain.contract.enums;
+
+public enum ContractProductListingStatus {
+    ACTIVE,
+    ENDED
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractProductStockMovementType.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractProductStockMovementType.java
@@ -1,0 +1,10 @@
+package app.dearobjet.backend.domain.contract.enums;
+
+public enum ContractProductStockMovementType {
+    INBOUND,
+    ADJUSTMENT_INCREASE,
+    ADJUSTMENT_DECREASE,
+    SALE_DECREASE,
+    RETURN_INCREASE,
+    CANCEL_RESTORE
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractStatus.java
@@ -1,0 +1,8 @@
+package app.dearobjet.backend.domain.contract.enums;
+
+public enum ContractStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    ENDED
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
@@ -1,0 +1,78 @@
+package app.dearobjet.backend.domain.contract.repository;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ContractProductRepository extends JpaRepository<ContractProduct, Long> {
+
+    @Query("""
+            select cp.contractProductsId as contractProductId,
+                   coalesce(sum(m.quantityDelta), 0) as totalQuantity,
+                   p.productUrl as productImageUrl,
+                   p.productName as productName,
+                   cp.sellingPrice as sellingPrice,
+                   cp.stockQuantity as stockQuantity,
+                   sac.commissionType as commissionType,
+                   sac.commissionValue as commissionValue,
+                   cp.marginAmount as marginAmount,
+                   cp.unitSettlementAmount as unitSettlementAmount,
+                   bp.businessName as artistName,
+                   cp.recentStockedAt as recentStockedAt
+            from ContractProduct cp
+            join cp.shopArtistContract sac
+            join sac.artist a
+            join a.businessProfile bp
+            join cp.product p
+            left join ContractProductStockMovement m
+                on m.contractProduct = cp
+               and m.movementType = :inboundType
+            where sac.shopArtistContractsId = :contractId
+              and sac.shop.shopId = :shopId
+              and sac.contractStatus = :contractStatus
+              and cp.listingStatus = :listingStatus
+            group by cp.contractProductsId,
+                     p.productUrl,
+                     p.productName,
+                     cp.sellingPrice,
+                     cp.stockQuantity,
+                     sac.commissionType,
+                     sac.commissionValue,
+                     cp.marginAmount,
+                     cp.unitSettlementAmount,
+                     bp.businessName,
+                     cp.recentStockedAt
+            order by cp.recentStockedAt desc, cp.contractProductsId desc
+            """)
+    List<ContractInventoryProductRow> findInventoryProductRowsByContractId(
+            @Param("contractId") Long contractId,
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("listingStatus") ContractProductListingStatus listingStatus,
+            @Param("inboundType") ContractProductStockMovementType inboundType
+    );
+
+    @Query("""
+            select cp
+            from ContractProduct cp
+            join fetch cp.shopArtistContract sac
+            where cp.contractProductsId = :contractProductId
+              and sac.shop.shopId = :shopId
+              and sac.contractStatus = :contractStatus
+              and cp.listingStatus = :listingStatus
+            """)
+    Optional<ContractProduct> findOwnedInventoryById(
+            @Param("contractProductId") Long contractProductId,
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("listingStatus") ContractProductListingStatus listingStatus
+    );
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductStockMovementRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductStockMovementRepository.java
@@ -1,0 +1,7 @@
+package app.dearobjet.backend.domain.contract.repository;
+
+import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContractProductStockMovementRepository extends JpaRepository<ContractProductStockMovement, Long> {
+}

--- a/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
@@ -1,10 +1,16 @@
 package app.dearobjet.backend.domain.shop.entity;
 
 import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
 import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
+/**
+ * 작가의 품목 관리 엔티티
+ */
 @Entity
 @Table(name = "products")
 @Getter
@@ -25,15 +31,13 @@ public class Product extends BaseTimeEntity {
     @Column(name = "product_name")
     private String productName;
 
-    @Column(columnDefinition = "TEXT")
-    private String description;
+    @Column(precision = 19, scale = 2)
+    private BigDecimal price;
 
-    private Double price;
-
-    private String status;
-
-    @Column(name = "available_quantity")
-    private Integer availableQuantity;
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ProductStatus status = ProductStatus.ACTIVE;
 
     @Column(name = "product_url")
     private String productUrl;

--- a/src/main/java/app/dearobjet/backend/domain/shop/enums/ProductStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/enums/ProductStatus.java
@@ -1,0 +1,6 @@
+package app.dearobjet.backend.domain.shop.enums;
+
+public enum ProductStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -1,0 +1,478 @@
+package app.dearobjet.backend.domain.contract;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
+import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
+import app.dearobjet.backend.domain.shop.entity.Product;
+import app.dearobjet.backend.domain.shop.entity.Shop;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
+import app.dearobjet.backend.domain.user.entity.BusinessProfile;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.BusinessCategory;
+import app.dearobjet.backend.domain.user.enums.BusinessType;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.domain.user.repository.BusinessProfileRepository;
+import app.dearobjet.backend.domain.user.repository.ShopRepository;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import app.dearobjet.backend.global.common.config.JpaConfig;
+import app.dearobjet.backend.global.exception.InvalidInputException;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+class ContractProductRepositoryTest {
+
+    private static final BusinessType DEFAULT_BUSINESS_TYPE = BusinessType.WHOLESALE_RETAIL;
+    private static final BusinessCategory DEFAULT_BUSINESS_CATEGORY = BusinessCategory.CRAFT_RETAIL;
+    private static final Specialty DEFAULT_SPECIALTY = Specialty.HANDMADE_CRAFT;
+    private static final int INITIAL_STOCK_QUANTITY = 5;
+    private static final int INBOUND_QUANTITY = 7;
+    private static final int SALE_QUANTITY = 3;
+    private static final int RETURN_QUANTITY = 2;
+    private static final int ADJUSTMENT_QUANTITY = 2;
+    private static final int OVERSELL_EXTRA_QUANTITY = 1;
+    private static final long ACTOR_USER_ID = 101L;
+    private static final BigDecimal DEFAULT_PRODUCT_PRICE = new BigDecimal("10000.00");
+    private static final BigDecimal DEFAULT_SELLING_PRICE = new BigDecimal("12000.00");
+    private static final BigDecimal DEFAULT_COMMISSION_VALUE = new BigDecimal("20.0000");
+    private static final BigDecimal UPDATED_MARGIN_AMOUNT = new BigDecimal("3000.00");
+    private static final BigDecimal UPDATED_UNIT_SETTLEMENT_AMOUNT = new BigDecimal("9000.00");
+    private static final LocalDateTime BASE_STOCKED_AT = LocalDateTime.of(2026, 4, 8, 10, 30);
+    private static final LocalDateTime INBOUND_AT = LocalDateTime.of(2026, 4, 10, 9, 15);
+    private static final LocalDateTime SALE_AT = LocalDateTime.of(2026, 4, 11, 14, 20);
+    private static final LocalDateTime RETURN_AT = LocalDateTime.of(2026, 4, 12, 11, 0);
+    private static final LocalDateTime ADJUSTMENT_AT = LocalDateTime.of(2026, 4, 13, 16, 5);
+
+    @Autowired
+    private ContractProductRepository contractProductRepository;
+
+    @Autowired
+    private ContractProductStockMovementRepository contractProductStockMovementRepository;
+
+    @Autowired
+    private ContractRepository contractRepository;
+
+    @Autowired
+    private ArtistRepository artistRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Autowired
+    private BusinessProfileRepository businessProfileRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("ENUM과 BigDecimal 필드를 저장하고 다시 조회할 수 있다")
+    void givenInventoryEntities_whenPersist_thenSaveEnumAndBigDecimalFields() {
+        User artistUser = createUser("artist1@example.com", "작가1", Role.ARTIST, "010-1111-1111", "https://image.test/artist1.png");
+        User shopUser = createUser("shop1@example.com", "상점1", Role.SHOP, "010-9999-9999", null);
+        Artist artist = createArtist(artistUser, "작가 상호");
+        Shop shop = createShop(shopUser, "입점 상점");
+        ShopArtistContract contract = createContract(artist, shop, ContractStatus.APPROVED);
+        Product product = createProduct(artist, "도자기 컵");
+
+        ContractProduct contractProduct = ContractProduct.builder()
+                .shopArtistContract(contract)
+                .product(product)
+                .sellingPrice(DEFAULT_SELLING_PRICE)
+                .build();
+        contractProduct.updateInventoryManagement(UPDATED_MARGIN_AMOUNT, UPDATED_UNIT_SETTLEMENT_AMOUNT);
+        ContractProductStockMovement inboundMovement = contractProduct.applyInbound(
+                INBOUND_QUANTITY,
+                BASE_STOCKED_AT,
+                ACTOR_USER_ID,
+                "초기 입고"
+        );
+
+        ContractProduct saved = contractProductRepository.save(contractProduct);
+        contractProductStockMovementRepository.save(inboundMovement);
+        flushAndClear();
+
+        ContractProduct found = contractProductRepository.findById(saved.getContractProductsId()).orElseThrow();
+        ContractProductStockMovement savedMovement = contractProductStockMovementRepository.findAll().get(0);
+
+        assertThat(found.getProduct().getStatus()).isEqualTo(ProductStatus.ACTIVE);
+        assertThat(found.getShopArtistContract().getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+        assertThat(found.getShopArtistContract().getCommissionType()).isEqualTo(CommissionType.RATE);
+        assertThat(found.getListingStatus()).isEqualTo(ContractProductListingStatus.ACTIVE);
+        assertThat(found.getProduct().getPrice()).isEqualByComparingTo(DEFAULT_PRODUCT_PRICE);
+        assertThat(found.getSellingPrice()).isEqualByComparingTo(DEFAULT_SELLING_PRICE);
+        assertThat(found.getMarginAmount()).isEqualByComparingTo(UPDATED_MARGIN_AMOUNT);
+        assertThat(found.getUnitSettlementAmount()).isEqualByComparingTo(UPDATED_UNIT_SETTLEMENT_AMOUNT);
+        assertThat(found.getRecentStockedAt()).isEqualTo(BASE_STOCKED_AT);
+        assertThat(found.getStockQuantity()).isEqualTo(INBOUND_QUANTITY);
+        assertThat(found.getVersion()).isNotNull();
+        assertThat(savedMovement.getMovementType()).isEqualTo(ContractProductStockMovementType.INBOUND);
+        assertThat(savedMovement.getResultStockQuantity()).isEqualTo(INBOUND_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("같은 계약의 같은 품목은 하나의 현재 재고 행만 가질 수 있다")
+    void givenDuplicateContractProduct_whenPersist_thenThrowConstraintViolation() {
+        User artistUser = createUser("artist2@example.com", "작가2", Role.ARTIST, "010-2222-2222", null);
+        User shopUser = createUser("shop2@example.com", "상점2", Role.SHOP, "010-8888-8888", null);
+        Artist artist = createArtist(artistUser, "작가 상호2");
+        Shop shop = createShop(shopUser, "입점 상점2");
+        ShopArtistContract contract = createContract(artist, shop, ContractStatus.APPROVED);
+        Product product = createProduct(artist, "유리 화병");
+
+        contractProductRepository.save(ContractProduct.builder()
+                .shopArtistContract(contract)
+                .product(product)
+                .sellingPrice(DEFAULT_SELLING_PRICE)
+                .build());
+        flushAndClear();
+
+        ContractProduct duplicate = ContractProduct.builder()
+                .shopArtistContract(contract)
+                .product(product)
+                .sellingPrice(DEFAULT_SELLING_PRICE)
+                .build();
+
+        assertThatThrownBy(() -> {
+            contractProductRepository.saveAndFlush(duplicate);
+            entityManager.clear();
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("입고와 판매 차감 이력을 적용하면 현재 재고 스냅샷과 movement 결과가 일치한다")
+    void givenInboundAndSale_whenApplyMovements_thenKeepSnapshotAndMovementConsistent() {
+        ContractProduct contractProduct = createPersistedContractProduct("artist3@example.com", "shop3@example.com", "엽서 세트");
+
+        ContractProductStockMovement inboundMovement = contractProduct.applyInbound(
+                INITIAL_STOCK_QUANTITY,
+                INBOUND_AT,
+                ACTOR_USER_ID,
+                "1차 입고"
+        );
+        ContractProductStockMovement saleMovement = contractProduct.applySaleDecrease(
+                SALE_QUANTITY,
+                SALE_AT,
+                ACTOR_USER_ID,
+                "판매 차감"
+        );
+
+        contractProductRepository.saveAndFlush(contractProduct);
+        contractProductStockMovementRepository.save(inboundMovement);
+        contractProductStockMovementRepository.save(saleMovement);
+        flushAndClear();
+
+        ContractProduct found = contractProductRepository.findById(contractProduct.getContractProductsId()).orElseThrow();
+        List<ContractProductStockMovement> movements = contractProductStockMovementRepository.findAll();
+
+        assertThat(found.getStockQuantity()).isEqualTo(INITIAL_STOCK_QUANTITY - SALE_QUANTITY);
+        assertThat(found.getSoldQuantity()).isEqualTo(SALE_QUANTITY);
+        assertThat(found.getRecentStockedAt()).isEqualTo(INBOUND_AT);
+        assertThat(movements).hasSize(2);
+        assertThat(movements.get(0).getResultStockQuantity()).isEqualTo(INITIAL_STOCK_QUANTITY);
+        assertThat(movements.get(1).getQuantityDelta()).isEqualTo(-SALE_QUANTITY);
+        assertThat(movements.get(1).getResultStockQuantity()).isEqualTo(INITIAL_STOCK_QUANTITY - SALE_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("반품 증가와 재고 조정은 최근입고일을 바꾸지 않는다")
+    void givenReturnAndAdjustment_whenApplyMovements_thenKeepRecentStockedAt() {
+        ContractProduct contractProduct = createPersistedContractProduct("artist4@example.com", "shop4@example.com", "마스킹 테이프");
+        contractProduct.applyInbound(INITIAL_STOCK_QUANTITY, INBOUND_AT, ACTOR_USER_ID, "1차 입고");
+
+        ContractProductStockMovement returnMovement = contractProduct.applyReturnIncrease(
+                RETURN_QUANTITY,
+                RETURN_AT,
+                ACTOR_USER_ID,
+                "반품 복원"
+        );
+        ContractProductStockMovement adjustmentMovement = contractProduct.applyAdjustmentDecrease(
+                ADJUSTMENT_QUANTITY,
+                ADJUSTMENT_AT,
+                ACTOR_USER_ID,
+                "재고 조정"
+        );
+
+        contractProductRepository.saveAndFlush(contractProduct);
+        contractProductStockMovementRepository.save(returnMovement);
+        contractProductStockMovementRepository.save(adjustmentMovement);
+        flushAndClear();
+
+        ContractProduct found = contractProductRepository.findById(contractProduct.getContractProductsId()).orElseThrow();
+
+        assertThat(found.getRecentStockedAt()).isEqualTo(INBOUND_AT);
+        assertThat(found.getStockQuantity()).isEqualTo(INITIAL_STOCK_QUANTITY + RETURN_QUANTITY - ADJUSTMENT_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("현재 재고보다 많이 차감하면 예외가 발생한다")
+    void givenInsufficientStock_whenApplySaleDecrease_thenThrowInvalidInputException() {
+        ContractProduct contractProduct = createPersistedContractProduct("artist5@example.com", "shop5@example.com", "패브릭 파우치");
+        contractProduct.applyInbound(INITIAL_STOCK_QUANTITY, INBOUND_AT, ACTOR_USER_ID, "1차 입고");
+
+        assertThatThrownBy(() -> contractProduct.applySaleDecrease(
+                INITIAL_STOCK_QUANTITY + OVERSELL_EXTRA_QUANTITY,
+                SALE_AT,
+                ACTOR_USER_ID,
+                "과다 차감"
+        )).isInstanceOf(InvalidInputException.class);
+    }
+
+    @Test
+    @DisplayName("재고관리 목록 조회 시 승인 계약 작가는 품목이 없어도 반환한다")
+    void givenApprovedContracts_whenQueryByShop_thenReturnContractedArtists() {
+        User artistUser = createUser("artist6@example.com", "작가6", Role.ARTIST, "010-6666-6666", "https://image.test/artist6.png");
+        User anotherArtistUser = createUser("artist7@example.com", "작가7", Role.ARTIST, "010-7777-7777", "https://image.test/artist7.png");
+        User noProductArtistUser = createUser("artist8@example.com", "작가8", Role.ARTIST, "010-7777-7778", "https://image.test/artist8.png");
+        User shopUser = createUser("shop6@example.com", "상점6", Role.SHOP, "010-5555-5555", null);
+        Artist activeArtist = createArtist(artistUser, "활성 작가");
+        Artist endedArtist = createArtist(anotherArtistUser, "종료 작가");
+        Artist noProductArtist = createArtist(noProductArtistUser, "무품목 작가");
+        Shop shop = createShop(shopUser, "조회 상점");
+        ShopArtistContract activeContract = createContract(activeArtist, shop, ContractStatus.APPROVED);
+        ShopArtistContract endedContract = createContract(endedArtist, shop, ContractStatus.ENDED);
+        ShopArtistContract noProductContract = createContract(noProductArtist, shop, ContractStatus.APPROVED);
+        Product activeProduct = createProduct(activeArtist, "도자기 접시");
+        Product endedProduct = createProduct(endedArtist, "종료 품목");
+
+        ContractProduct activeContractProduct = ContractProduct.builder()
+                .shopArtistContract(activeContract)
+                .product(activeProduct)
+                .sellingPrice(DEFAULT_SELLING_PRICE)
+                .build();
+        activeContractProduct.applyInbound(INITIAL_STOCK_QUANTITY, INBOUND_AT, ACTOR_USER_ID, "입고");
+
+        ContractProduct endedContractProduct = ContractProduct.builder()
+                .shopArtistContract(endedContract)
+                .product(endedProduct)
+                .sellingPrice(DEFAULT_SELLING_PRICE)
+                .listingStatus(ContractProductListingStatus.ENDED)
+                .build();
+        endedContractProduct.applyInbound(INITIAL_STOCK_QUANTITY, BASE_STOCKED_AT, ACTOR_USER_ID, "종료 입고");
+
+        contractProductRepository.save(activeContractProduct);
+        contractProductRepository.save(endedContractProduct);
+        flushAndClear();
+
+        List<ContractInventoryRow> rows = contractRepository.findInventoryRowsByShopId(
+                shop.getShopId(),
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE
+        );
+
+        assertThat(rows).hasSize(2);
+        ContractInventoryRow row = rows.stream()
+                .filter(inventoryRow -> "활성 작가".equals(inventoryRow.getArtistName()))
+                .findFirst()
+                .orElseThrow();
+        ContractInventoryRow noProductRow = rows.stream()
+                .filter(inventoryRow -> "무품목 작가".equals(inventoryRow.getArtistName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(row.getContractId()).isEqualTo(activeContract.getShopArtistContractsId());
+        assertThat(row.getArtistImageUrl()).isEqualTo("https://image.test/artist6.png");
+        assertThat(row.getArtistName()).isEqualTo("활성 작가");
+        assertThat(row.getSpecialty()).isEqualTo(DEFAULT_SPECIALTY);
+        assertThat(row.getRecentStockedAt()).isEqualTo(INBOUND_AT);
+        assertThat(row.getInboundConfirmed()).isFalse();
+        assertThat(noProductRow.getContractId()).isEqualTo(noProductContract.getShopArtistContractsId());
+        assertThat(noProductRow.getRecentStockedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("작가별 재고 상세 조회 시 총 입고 수량과 정산 필드를 반환한다")
+    void givenContractProducts_whenQueryDetailRows_thenReturnInventoryProductRows() {
+        User artistUser = createUser("artist9@example.com", "작가9", Role.ARTIST, "010-9999-0001", "https://image.test/artist9.png");
+        User shopUser = createUser("shop9@example.com", "상점9", Role.SHOP, "010-9999-0002", null);
+        Artist artist = createArtist(artistUser, "상세 작가");
+        Shop shop = createShop(shopUser, "상세 상점");
+        ShopArtistContract contract = createContract(artist, shop, ContractStatus.APPROVED);
+        Product product = createProduct(artist, "유리 컵");
+
+        ContractProduct contractProduct = ContractProduct.builder()
+                .shopArtistContract(contract)
+                .product(product)
+                .sellingPrice(DEFAULT_SELLING_PRICE)
+                .build();
+        contractProduct.updateInventoryManagement(UPDATED_MARGIN_AMOUNT, UPDATED_UNIT_SETTLEMENT_AMOUNT);
+        ContractProductStockMovement firstInbound = contractProduct.applyInbound(
+                INITIAL_STOCK_QUANTITY,
+                INBOUND_AT,
+                ACTOR_USER_ID,
+                "1차 입고"
+        );
+        ContractProductStockMovement secondInbound = contractProduct.applyInbound(
+                INBOUND_QUANTITY,
+                ADJUSTMENT_AT,
+                ACTOR_USER_ID,
+                "2차 입고"
+        );
+        ContractProductStockMovement sale = contractProduct.applySaleDecrease(
+                SALE_QUANTITY,
+                SALE_AT,
+                ACTOR_USER_ID,
+                "판매"
+        );
+
+        contractProductRepository.save(contractProduct);
+        contractProductStockMovementRepository.save(firstInbound);
+        contractProductStockMovementRepository.save(secondInbound);
+        contractProductStockMovementRepository.save(sale);
+        flushAndClear();
+
+        List<ContractInventoryProductRow> rows = contractProductRepository.findInventoryProductRowsByContractId(
+                contract.getShopArtistContractsId(),
+                shop.getShopId(),
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE,
+                ContractProductStockMovementType.INBOUND
+        );
+
+        assertThat(rows).hasSize(1);
+        ContractInventoryProductRow row = rows.get(0);
+        assertThat(row.getTotalQuantity()).isEqualTo((long) INITIAL_STOCK_QUANTITY + INBOUND_QUANTITY);
+        assertThat(row.getProductImageUrl()).isEqualTo("https://example.com/products/유리 컵");
+        assertThat(row.getProductName()).isEqualTo("유리 컵");
+        assertThat(row.getSellingPrice()).isEqualByComparingTo(DEFAULT_SELLING_PRICE);
+        assertThat(row.getStockQuantity()).isEqualTo(INITIAL_STOCK_QUANTITY + INBOUND_QUANTITY - SALE_QUANTITY);
+        assertThat(row.getCommissionType()).isEqualTo(CommissionType.RATE);
+        assertThat(row.getCommissionValue()).isEqualByComparingTo(DEFAULT_COMMISSION_VALUE);
+        assertThat(row.getMarginAmount()).isEqualByComparingTo(UPDATED_MARGIN_AMOUNT);
+        assertThat(row.getUnitSettlementAmount()).isEqualByComparingTo(UPDATED_UNIT_SETTLEMENT_AMOUNT);
+        assertThat(row.getArtistName()).isEqualTo("상세 작가");
+        assertThat(row.getRecentStockedAt()).isEqualTo(ADJUSTMENT_AT);
+    }
+
+    private ContractProduct createPersistedContractProduct(String artistEmail, String shopEmail, String productName) {
+        User artistUser = createUser(artistEmail, artistEmail, Role.ARTIST, uniquePhoneFor(artistEmail), null);
+        User shopUser = createUser(shopEmail, shopEmail, Role.SHOP, uniquePhoneFor(shopEmail), null);
+        Artist artist = createArtist(artistUser, productName + " 작가");
+        Shop shop = createShop(shopUser, productName + " 상점");
+        ShopArtistContract contract = createContract(artist, shop, ContractStatus.APPROVED);
+        Product product = createProduct(artist, productName);
+
+        ContractProduct contractProduct = ContractProduct.builder()
+                .shopArtistContract(contract)
+                .product(product)
+                .sellingPrice(DEFAULT_SELLING_PRICE)
+                .build();
+
+        return contractProductRepository.saveAndFlush(contractProduct);
+    }
+
+    private User createUser(String email, String name, Role role, String phoneNumber, String profileUrl) {
+        User user = User.builder()
+                .email(email)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .profileUrl(profileUrl)
+                .role(role)
+                .userStatus(UserStatus.ACTIVE)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private Artist createArtist(User user, String businessName) {
+        BusinessProfile businessProfile = createBusinessProfile(user, "ART-" + user.getId(), businessName, "서울시 성동구");
+        Artist artist = Artist.builder()
+                .user(user)
+                .businessProfile(businessProfile)
+                .build();
+        return artistRepository.save(artist);
+    }
+
+    private Shop createShop(User user, String shopName) {
+        BusinessProfile businessProfile = createBusinessProfile(user, "SHOP-" + user.getId(), shopName, "서울시 마포구");
+        Shop shop = Shop.builder()
+                .user(user)
+                .businessProfile(businessProfile)
+                .shopName(shopName)
+                .shopDescription(shopName + " 설명")
+                .build();
+        return shopRepository.save(shop);
+    }
+
+    private BusinessProfile createBusinessProfile(
+            User user,
+            String businessNumber,
+            String businessName,
+            String businessAddress
+    ) {
+        BusinessProfile businessProfile = BusinessProfile.builder()
+                .user(user)
+                .businessType(DEFAULT_BUSINESS_TYPE)
+                .businessNumber(businessNumber)
+                .businessName(businessName)
+                .ownerName(user.getName())
+                .businessAddress(businessAddress)
+                .businessLicenseUrl("https://example.com/license/" + user.getId())
+                .businessCategory(DEFAULT_BUSINESS_CATEGORY)
+                .specialty(DEFAULT_SPECIALTY)
+                .reviewDataAgreement(Boolean.TRUE)
+                .build();
+        return businessProfileRepository.save(businessProfile);
+    }
+
+    private ShopArtistContract createContract(Artist artist, Shop shop, ContractStatus contractStatus) {
+        ShopArtistContract contract = ShopArtistContract.builder()
+                .artist(artist)
+                .shop(shop)
+                .contractStatus(contractStatus)
+                .commissionType(CommissionType.RATE)
+                .commissionValue(DEFAULT_COMMISSION_VALUE)
+                .build();
+        return contractRepository.save(contract);
+    }
+
+    private Product createProduct(Artist artist, String productName) {
+        Product product = Product.builder()
+                .artist(artist)
+                .productName(productName)
+                .price(DEFAULT_PRODUCT_PRICE)
+                .status(ProductStatus.ACTIVE)
+                .productUrl("https://example.com/products/" + productName)
+                .build();
+        entityManager.persist(product);
+        return product;
+    }
+
+    private String uniquePhoneFor(String seed) {
+        int hash = Math.floorMod(seed.hashCode(), 100_000_000);
+        return "010" + String.format("%08d", hash);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -1,0 +1,338 @@
+package app.dearobjet.backend.domain.contract;
+
+import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
+import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
+import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
+import app.dearobjet.backend.domain.shop.entity.Shop;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.repository.ShopRepository;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("ContractService 테스트")
+@ExtendWith(MockitoExtension.class)
+class ContractServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long SHOP_ID = 10L;
+    private static final Long CONTRACT_ID = 50L;
+    private static final Long CONTRACT_PRODUCT_ID = 100L;
+    private static final LocalDateTime OCCURRED_AT = LocalDateTime.of(2026, 4, 27, 12, 30);
+
+    @InjectMocks
+    private ContractService contractService;
+
+    @Mock
+    private ContractRepository contractRepository;
+
+    @Mock
+    private ContractProductRepository contractProductRepository;
+
+    @Mock
+    private ContractProductStockMovementRepository contractProductStockMovementRepository;
+
+    @Mock
+    private ShopRepository shopRepository;
+
+    @Nested
+    @DisplayName("getInventory")
+    class GetInventoryTest {
+
+        @Test
+        @DisplayName("샵이 없으면 curl에서 본 것과 같은 메시지로 예외가 발생한다")
+        void givenMissingShop_whenGetInventory_thenThrowIllegalArgumentException() {
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> contractService.getInventory(USER_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Shop not found for user: 1");
+        }
+
+        @Test
+        @DisplayName("샵이 있으면 승인 계약 작가 목록을 반환한다")
+        void givenShop_whenGetInventory_thenReturnInventoryList() {
+            Shop shop = shopWithId(SHOP_ID);
+            ContractInventoryRow row = new ContractInventoryRow() {
+                @Override
+                public Long getContractId() {
+                    return CONTRACT_ID;
+                }
+
+                @Override
+                public String getArtistImageUrl() {
+                    return "https://image.test/a.png";
+                }
+
+                @Override
+                public String getArtistName() {
+                    return "작가";
+                }
+
+                @Override
+                public app.dearobjet.backend.domain.user.enums.Specialty getSpecialty() {
+                    return app.dearobjet.backend.domain.user.enums.Specialty.HANDMADE_CRAFT;
+                }
+
+                @Override
+                public LocalDateTime getRecentStockedAt() {
+                    return OCCURRED_AT;
+                }
+
+                @Override
+                public Boolean getInboundConfirmed() {
+                    return true;
+                }
+            };
+
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+            given(contractRepository.findInventoryRowsByShopId(
+                    SHOP_ID,
+                    ContractStatus.APPROVED,
+                    ContractProductListingStatus.ACTIVE
+            )).willReturn(List.of(row));
+
+            ContractInventoryListResponse response = contractService.getInventory(USER_ID);
+
+            assertThat(response.getItems()).hasSize(1);
+            assertThat(response.getItems().get(0).getContractId()).isEqualTo(CONTRACT_ID);
+            assertThat(response.getItems().get(0).getInboundConfirmed()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateInventoryMemo")
+    class UpdateInventoryMemoTest {
+
+        @Test
+        @DisplayName("승인 계약이면 메모를 공백 포함 그대로 저장한다")
+        void givenApprovedContract_whenUpdateMemo_thenReturnUpdatedMemo() {
+            Shop shop = shopWithId(SHOP_ID);
+            ShopArtistContract contract = contractWithId(CONTRACT_ID);
+            UpdateContractMemoRequest request = new UpdateContractMemoRequest();
+            setField(request, "memo", "다음 입고 때 진열대 위치 조정");
+
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+            given(contractRepository.findApprovedByIdAndShopId(CONTRACT_ID, SHOP_ID, ContractStatus.APPROVED))
+                    .willReturn(Optional.of(contract));
+
+            ContractMemoResponse response = contractService.updateInventoryMemo(USER_ID, CONTRACT_ID, request);
+
+            assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+            assertThat(response.getMemo()).isEqualTo("다음 입고 때 진열대 위치 조정");
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmRecentInbound")
+    class ConfirmRecentInboundTest {
+
+        @Test
+        @DisplayName("승인 계약이면 최근 입고확인 상태를 저장한다")
+        void givenApprovedContract_whenConfirmRecentInbound_thenReturnConfirmedStatus() {
+            Shop shop = shopWithId(SHOP_ID);
+            ShopArtistContract contract = contractWithId(CONTRACT_ID);
+
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+            given(contractRepository.findApprovedByIdAndShopId(CONTRACT_ID, SHOP_ID, ContractStatus.APPROVED))
+                    .willReturn(Optional.of(contract));
+
+            ContractInboundConfirmResponse response = contractService.confirmRecentInbound(USER_ID, CONTRACT_ID);
+
+            assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+            assertThat(response.getInboundConfirmed()).isTrue();
+            assertThat(response.getConfirmedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("getPendingApplicationCount")
+    class GetPendingApplicationCountTest {
+
+        @Test
+        @DisplayName("샵이 없으면 대기 계약 건수 조회도 같은 메시지로 실패한다")
+        void givenMissingShop_whenGetPendingApplicationCount_thenThrowIllegalArgumentException() {
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> contractService.getPendingApplicationCount(USER_ID))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Shop not found for user: 1");
+            verify(contractRepository, never()).countByShopUserIdAndContractStatus(any(), any());
+        }
+
+        @Test
+        @DisplayName("샵이 있으면 대기 계약 건수와 작가 이름을 반환한다")
+        void givenShop_whenGetPendingApplicationCount_thenReturnCountAndNames() {
+            Shop shop = shopWithId(SHOP_ID);
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+            given(contractRepository.countByShopUserIdAndContractStatus(USER_ID, ContractStatus.PENDING))
+                    .willReturn(2L);
+            given(contractRepository.findPendingApplicationArtistNamesByShopUserId(USER_ID, ContractStatus.PENDING))
+                    .willReturn(List.of("작가 A", "작가 B"));
+
+            ContractApplicationCountResponse response = contractService.getPendingApplicationCount(USER_ID);
+
+            assertThat(response.getApplicationCount()).isEqualTo(2L);
+            assertThat(response.getArtistNames()).containsExactly("작가 A", "작가 B");
+        }
+    }
+
+    @Nested
+    @DisplayName("adjustInventory")
+    class AdjustInventoryTest {
+
+        @Test
+        @DisplayName("샵 소유 재고 품목이면 movement를 저장하고 갱신된 스냅샷을 반환한다")
+        void givenOwnedInventory_whenAdjustInventory_thenSaveMovementAndReturnSnapshot() {
+            Shop shop = shopWithId(SHOP_ID);
+            ContractProduct contractProduct = contractProductWithId(CONTRACT_PRODUCT_ID);
+            AdjustContractInventoryRequest request = request(
+                    ContractProductStockMovementType.INBOUND,
+                    4,
+                    OCCURRED_AT,
+                    "추가 입고"
+            );
+
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+            given(contractProductRepository.findOwnedInventoryById(
+                    CONTRACT_PRODUCT_ID,
+                    SHOP_ID,
+                    ContractStatus.APPROVED,
+                    ContractProductListingStatus.ACTIVE
+            ))
+                    .willReturn(Optional.of(contractProduct));
+
+            AdjustContractInventoryResponse response = contractService.adjustInventory(
+                    USER_ID,
+                    CONTRACT_PRODUCT_ID,
+                    request
+            );
+
+            ArgumentCaptor<ContractProductStockMovement> movementCaptor =
+                    ArgumentCaptor.forClass(ContractProductStockMovement.class);
+            verify(contractProductStockMovementRepository).save(movementCaptor.capture());
+
+            assertThat(response.getContractProductId()).isEqualTo(CONTRACT_PRODUCT_ID);
+            assertThat(response.getMovementType()).isEqualTo(ContractProductStockMovementType.INBOUND);
+            assertThat(response.getQuantityDelta()).isEqualTo(4);
+            assertThat(response.getStockQuantity()).isEqualTo(4);
+            assertThat(response.getRecentStockedAt()).isEqualTo(OCCURRED_AT);
+            assertThat(contractProduct.getShopArtistContract().getRecentInboundConfirmed()).isFalse();
+            assertThat(movementCaptor.getValue().getResultStockQuantity()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("샵 소유 재고 품목이 아니면 찾을 수 없다고 응답한다")
+        void givenNotOwnedInventory_whenAdjustInventory_thenThrowEntityNotFoundException() {
+            Shop shop = shopWithId(SHOP_ID);
+            AdjustContractInventoryRequest request = request(
+                    ContractProductStockMovementType.INBOUND,
+                    4,
+                    OCCURRED_AT,
+                    "추가 입고"
+            );
+
+            given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+            given(contractProductRepository.findOwnedInventoryById(
+                    CONTRACT_PRODUCT_ID,
+                    SHOP_ID,
+                    ContractStatus.APPROVED,
+                    ContractProductListingStatus.ACTIVE
+            ))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> contractService.adjustInventory(USER_ID, CONTRACT_PRODUCT_ID, request))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("재고 품목을 찾을 수 없습니다.");
+        }
+    }
+
+    private Shop shopWithId(Long shopId) {
+        User user = User.builder()
+                .id(USER_ID)
+                .build();
+        return Shop.builder()
+                .shopId(shopId)
+                .user(user)
+                .build();
+    }
+
+    private ContractProduct contractProductWithId(Long contractProductId) {
+        ShopArtistContract contract = contractWithId(CONTRACT_ID);
+        contract.confirmRecentInbound(USER_ID, OCCURRED_AT.minusDays(1));
+        ContractProduct contractProduct = ContractProduct.builder()
+                .contractProductsId(contractProductId)
+                .shopArtistContract(contract)
+                .sellingPrice(new BigDecimal("12000.00"))
+                .build();
+        setField(contractProduct, "stockQuantity", 0);
+        setField(contractProduct, "soldQuantity", 0);
+        return contractProduct;
+    }
+
+    private ShopArtistContract contractWithId(Long contractId) {
+        return ShopArtistContract.builder()
+                .shopArtistContractsId(contractId)
+                .contractStatus(ContractStatus.APPROVED)
+                .commissionType(CommissionType.RATE)
+                .commissionValue(new BigDecimal("20.0000"))
+                .build();
+    }
+
+    private AdjustContractInventoryRequest request(
+            ContractProductStockMovementType movementType,
+            int quantity,
+            LocalDateTime occurredAt,
+            String memo
+    ) {
+        AdjustContractInventoryRequest request = new AdjustContractInventoryRequest();
+        setField(request, "movementType", movementType);
+        setField(request, "quantity", quantity);
+        setField(request, "occurredAt", occurredAt);
+        setField(request, "memo", memo);
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("테스트 필드 주입에 실패했습니다: " + fieldName, exception);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
  - 승인된 소품샵-작가 계약 기준 재고관리 목록 API를 추가했습니다.
  - 계약 작가별 품목 상세, 메모 수정, 최근 입고확인 API를 추가했습니다.
  - INBOUND 입고 발생 시 최근 입고확인 상태가 미확인으로 초기화되도록 처리했습니다.
  - 요구사항 외 미사용 엔티티 필드/메서드를 정리했습니다.

  ## 주요 변경
  - `ShopArtistContract`에 계약별 메모와 최근 입고확인 상태 추가
  - `ContractProduct`, `ContractProductStockMovement` 기반 재고 스냅샷/이력 처리
  - 계약 작가 목록은 품목이 없어도 승인 계약이면 반환
  - 작가별 상세에서 총 입고 수량, 상품 이미지, 판매가, 재고, 수수료, 마진/정산금액 반환

  ## 테스트
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.*"` 통과
  - 전체 테스트는 기존 unrelated 실패 2건 존재