### PR TITLE
[FIX] SMS 발송 로직 순서 변경

### DIFF
--- a/src/main/java/app/dearobjet/backend/global/sms/service/SmsAuthService.java
+++ b/src/main/java/app/dearobjet/backend/global/sms/service/SmsAuthService.java
@@ -15,18 +15,18 @@ public class SmsAuthService {
     public void sendVerificationCode(String phone) {
 
         if (redisService.isCooldown(phone)) {
-            throw new IllegalStateException("잠시 후 다시 요청하세요");
+            throw new IllegalStateException("잠시 후 다시 요청해주세요.");
         }
 
         String code = VerificationCodeGenerator.generate();
-
-        redisService.saveCode(phone, code);
-        redisService.applyCooldown(phone);
 
         smsService.sendSms(
                 phone,
                 "인증번호는 " + code + " 입니다. (3분 이내 입력)"
         );
+
+        redisService.saveCode(phone, code);
+        redisService.applyCooldown(phone);
     }
 
     public void verifyCode(String phone, String inputCode) {
@@ -34,40 +34,31 @@ public class SmsAuthService {
         String savedCode = redisService.getCode(phone);
 
         if (savedCode == null) {
-            throw new IllegalStateException("인증번호가 만료되었거나 요청되지 않았습니다");
+            throw new IllegalStateException("인증번호가 만료되었거나 요청되지 않았습니다.");
         }
 
         int attempt = redisService.increaseAttempt(phone);
 
         if (attempt > SmsPolicy.MAX_ATTEMPT) {
             redisService.deleteCode(phone);
-            throw new IllegalStateException("인증 시도 횟수를 초과했습니다");
+            throw new IllegalStateException("인증 시도 횟수를 초과했습니다.");
         }
 
         if (!savedCode.equals(inputCode)) {
-            throw new IllegalArgumentException("인증번호가 일치하지 않습니다");
+            throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
         }
 
         redisService.markVerified(phone);
-
         redisService.deleteCode(phone);
     }
 
-    /**
-     * 민감 기능 전에 호출
-     */
     public void assertVerified(String phone) {
         if (!redisService.isVerified(phone)) {
-            throw new IllegalStateException("휴대폰 인증이 필요합니다");
+            throw new IllegalStateException("휴대폰 인증이 필요합니다.");
         }
     }
 
-    /**
-     * 사용 후 재사용 방지
-     */
     public void consumeVerified(String phone) {
         redisService.clearVerified(phone);
     }
 }
-
-

--- a/src/test/java/app/dearobjet/backend/global/sms/service/SmsAuthServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/global/sms/service/SmsAuthServiceTest.java
@@ -3,6 +3,8 @@ package app.dearobjet.backend.global.sms.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,13 +31,28 @@ class SmsAuthServiceTest {
 
         smsAuthService.sendVerificationCode("01012345678");
 
+        verify(smsService).sendSms(any(), contains("인증번호"));
         verify(redisService).saveCode(any(), any());
         verify(redisService).applyCooldown(any());
-        verify(smsService).sendSms(any(), contains("인증번호"));
     }
 
     @Test
-    void 쿨타임중이면_차단() {
+    void 문자_발송_실패_시_Redis_상태를_남기지_않음() {
+
+        doThrow(new IllegalStateException("send failed"))
+                .when(smsService)
+                .sendSms(any(), any());
+
+        assertThatThrownBy(() ->
+                smsAuthService.sendVerificationCode("01012345678")
+        ).isInstanceOf(IllegalStateException.class);
+
+        verify(redisService, never()).saveCode(any(), any());
+        verify(redisService, never()).applyCooldown(any());
+    }
+
+    @Test
+    void 쿨다운_중이면_차단() {
 
         when(redisService.isCooldown("01012345678")).thenReturn(true);
 
@@ -68,4 +85,3 @@ class SmsAuthServiceTest {
         verify(redisService).deleteCode("01012345678");
     }
 }
-


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR번호} [{이슈번호}]

## **⚡ Content**

- SMS 발송 로직 변경

## **🌟 Point**

- 기존 문자를 보내기 전 redis에 시도 count를 먼저 올렸던 점이 있었습니다. 문자 발송이 실패했을 경우에도 올리는 문제점을 해결 하기 위해 먼저 발송을 하고 count하도록 변경하였습니다.

## ❓ Question

- 없음.