### PR TITLE
[FEAT] 관리자 공지사항 CRUD API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeController.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeController.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.notification;
 
 import app.dearobjet.backend.global.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,5 +15,34 @@ public class AdminNoticeController {
     @PostMapping("/notices")
     public ApiResponse<NoticeResponse> createNotice(@RequestBody NoticeCreateRequest request) {
         return ApiResponse.of(adminNoticeService.createNotice(request));
+    }
+
+    @GetMapping("/notices")
+    public ApiResponse<NoticeListResponse> getNotices(
+            @RequestParam(required = false) NoticeTarget target,
+            @RequestParam(required = false) NoticeCategory category,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.of(adminNoticeService.getNotices(target, category, page, size));
+    }
+
+    @GetMapping("/notices/{noticeId}")
+    public ApiResponse<NoticeResponse> getNotice(@PathVariable Long noticeId) {
+        return ApiResponse.of(adminNoticeService.getNotice(noticeId));
+    }
+
+    @PutMapping("/notices/{noticeId}")
+    public ApiResponse<NoticeResponse> updateNotice(
+            @PathVariable Long noticeId,
+            @RequestBody NoticeUpdateRequest request
+    ) {
+        return ApiResponse.of(adminNoticeService.updateNotice(noticeId, request));
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/notices/{noticeId}")
+    public void deleteNotice(@PathVariable Long noticeId) {
+        adminNoticeService.deleteNotice(noticeId);
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeService.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeService.java
@@ -1,10 +1,13 @@
 package app.dearobjet.backend.domain.notification;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -12,6 +15,8 @@ import java.time.OffsetDateTime;
 public class AdminNoticeService {
 
     private final NoticeRepository noticeRepository;
+
+    private static final int NEW_DAYS = 7;
 
     public NoticeResponse createNotice(NoticeCreateRequest request) {
         Notice notice = Notice.builder()
@@ -27,19 +32,60 @@ public class AdminNoticeService {
                 )
                 .build();
 
-        Notice savedNotice = noticeRepository.save(notice);
+        return toResponse(noticeRepository.save(notice));
+    }
 
-        boolean isNew = savedNotice.getPublishedAt() != null
-                && savedNotice.getPublishedAt().isAfter(OffsetDateTime.now().minusDays(7));
+    @Transactional(readOnly = true)
+    public NoticeListResponse getNotices(NoticeTarget target, NoticeCategory category, int page, int size) {
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "publishedAt"));
 
+        Page<Notice> noticePage;
+        if (target == null) {
+            noticePage = noticeRepository.findAll(pageable);
+        } else if (category == null) {
+            noticePage = noticeRepository.findByTarget(target, pageable);
+        } else {
+            noticePage = noticeRepository.findByTargetAndCategory(target, category, pageable);
+        }
+
+        List<NoticeResponse> items = noticePage.getContent().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+
+        return new NoticeListResponse(items, page, noticePage.getTotalPages());
+    }
+
+    @Transactional(readOnly = true)
+    public NoticeResponse getNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+        return toResponse(notice);
+    }
+
+    public NoticeResponse updateNotice(Long noticeId, NoticeUpdateRequest request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+        notice.update(request);
+        return toResponse(notice);
+    }
+
+    public void deleteNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeNotFoundException(noticeId));
+        noticeRepository.delete(notice);
+    }
+
+    private NoticeResponse toResponse(Notice notice) {
+        boolean isNew = notice.getPublishedAt() != null
+                && notice.getPublishedAt().isAfter(OffsetDateTime.now().minusDays(NEW_DAYS));
         return new NoticeResponse(
-                savedNotice.getNotificationId(),
-                savedNotice.getTarget(),
-                savedNotice.getCategory(),
-                savedNotice.getBadge(),
-                savedNotice.getTitle(),
-                savedNotice.getBody(),
-                savedNotice.getPublishedAt(),
+                notice.getNotificationId(),
+                notice.getTarget(),
+                notice.getCategory(),
+                notice.getBadge(),
+                notice.getTitle(),
+                notice.getBody(),
+                notice.getPublishedAt(),
                 isNew
         );
     }

--- a/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
@@ -36,4 +36,13 @@ public class Notice {
 
     @Column(nullable = false)
     private OffsetDateTime publishedAt;
+
+    public void update(NoticeUpdateRequest request) {
+        if (request.getTarget() != null) this.target = request.getTarget();
+        if (request.getCategory() != null) this.category = request.getCategory();
+        if (request.getBadge() != null) this.badge = request.getBadge();
+        if (request.getTitle() != null) this.title = request.getTitle();
+        if (request.getBody() != null) this.body = request.getBody();
+        if (request.getPublishedAt() != null) this.publishedAt = request.getPublishedAt();
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeNotFoundException.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeNotFoundException.java
@@ -1,7 +1,10 @@
 package app.dearobjet.backend.domain.notification;
 
-public class NoticeNotFoundException extends RuntimeException {
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+
+public class NoticeNotFoundException extends EntityNotFoundException {
     public NoticeNotFoundException(Long noticeId) {
-        super("해당 공지사항을 찾을 수 없습니다. noticeId=" + noticeId);
+        super(ErrorCode.NOTICE_NOT_FOUND, "해당 공지사항을 찾을 수 없습니다. noticeId=" + noticeId);
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeUpdateRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeUpdateRequest.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.domain.notification;
+
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+public class NoticeUpdateRequest {
+    private NoticeTarget target;
+    private NoticeCategory category;
+    private String badge;
+    private String title;
+    private String body;
+    private OffsetDateTime publishedAt;
+}


### PR DESCRIPTION
관리자가 공지사항을 직접 조회, 수정, 삭제할 수 있도록 CRUD API를 추가했습니다.
기존에 작성만 가능했던 관리자 공지 API에 목록/단건 조회, 수정, 삭제 기능을 보완하였습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)