### PR TITLE
[FIX] request 없이 이미지 파일만 수정할 수 있도록 변경

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<BusinessProfileDetailResponse>> updateMyBusinessProfile(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestPart("request") UpdateBusinessProfileRequest request,
+            @Valid @RequestPart(value = "request", required = false) UpdateBusinessProfileRequest request,
             @RequestPart(value = "bankbookImage", required = false) MultipartFile bankbookImage,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {

--- a/src/main/java/app/dearobjet/backend/domain/user/dto/UpdateBusinessProfileRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/dto/UpdateBusinessProfileRequest.java
@@ -10,4 +10,7 @@ public record UpdateBusinessProfileRequest(
         String accountHolder,
         String taxInvoiceEmail
 ) {
+    public static UpdateBusinessProfileRequest empty() {
+        return new UpdateBusinessProfileRequest(null, null, null, null, null, null, null, null);
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
@@ -80,6 +80,10 @@ public class UserServiceImpl implements UserService {
             MultipartFile bankbookImage,
             MultipartFile profileImage
     ) {
+        if (request == null) {
+            request = UpdateBusinessProfileRequest.empty();
+        }
+
         User user = getUser(userId);
         BusinessProfile businessProfile = businessProfileRepository.findByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR번호} [{이슈번호}]

## **⚡ Content**

- 문제였던 통장사본 업로드 S3 권한 추가
- 따로 통장사본이나 프로필 사진만 수정할 수 있도록 변경

## **📆 TBD**

- PresignedUrl을 활용한 통장 사본 읽기 기능 구현 필요

## **🌟 Point**

- 업로드가 잘되는지
- 통장 사본만 수정이 가능한 지

## ❓ Question

- 없음