### PR TITLE
[FIX] 결제 웹훅 중복 처리 방지 및 취소 상태 처리 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentRepository.java
@@ -1,15 +1,27 @@
 package app.dearobjet.backend.domain.payment;
 
 import app.dearobjet.backend.domain.payment.entity.Payment;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByPaymentKey(String paymentKey);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.paymentKey = :paymentKey")
+    Optional<Payment> findByPaymentKeyForUpdate(@Param("paymentKey") String paymentKey);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.paymentId = :id")
+    Optional<Payment> findByIdForUpdate(@Param("id") Long id);
 
     Page<Payment> findByOrder_User_IdAndCreatedAtBetween(
             Long userId,

--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentService.java
@@ -69,7 +69,7 @@ public class PaymentService {
 
     @Transactional
     public void confirmPayment(Long userId, Long paymentId, ConfirmPaymentRequest req) {
-        Payment payment = paymentRepository.findById(paymentId)
+        Payment payment = paymentRepository.findByIdForUpdate(paymentId)
                 .orElseThrow(() -> new PaymentNotFoundException(paymentId));
 
         Order order = payment.getOrder();
@@ -78,6 +78,9 @@ public class PaymentService {
         }
 
         if (payment.getStatus() == PaymentStatus.DONE) return;
+        if (payment.isTerminal()) {
+            throw new PaymentBadRequestException("이미 처리 완료된 결제입니다. status=" + payment.getStatus());
+        }
 
         if (!order.getOrderNumber().equals(req.getOrderId())) {
             throw new PaymentBadRequestException("orderId가 주문번호와 다릅니다.");
@@ -122,10 +125,10 @@ public class PaymentService {
     public void handleWebhookToss(String paymentKey) {
         if (paymentKey == null || paymentKey.isBlank()) return;
 
-        Payment payment = paymentRepository.findByPaymentKey(paymentKey).orElse(null);
+        Payment payment = paymentRepository.findByPaymentKeyForUpdate(paymentKey).orElse(null);
         if (payment == null) return;
 
-        if (payment.getStatus() == PaymentStatus.DONE) return;
+        if (payment.isTerminal()) return;
 
         TossPaymentResponse tossPayment = tossClient.getPayment(paymentKey);
         String status = tossPayment == null ? null : tossPayment.getStatus();
@@ -140,6 +143,11 @@ public class PaymentService {
         if ("DONE".equals(status)) {
             payment.markDone(paymentKey);
             payment.getOrder().updateStatus(OrderStatus.PAID);
+        } else if ("CANCELED".equals(status)) {
+            payment.markCanceled();
+            payment.getOrder().cancel("WEBHOOK_CANCELED");
+        } else if ("ABORTED".equals(status) || "EXPIRED".equals(status)) {
+            payment.markFailed(status);
         }
     }
 

--- a/src/main/java/app/dearobjet/backend/domain/payment/entity/Payment.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/entity/Payment.java
@@ -43,6 +43,12 @@ public class Payment extends BaseTimeEntity {
     @Column(length = 100)
     private String failReason;
 
+    public boolean isTerminal() {
+        return this.status == PaymentStatus.DONE
+                || this.status == PaymentStatus.CANCELED
+                || this.status == PaymentStatus.FAILED;
+    }
+
     public void markDone(String paymentKey) {
         this.status = PaymentStatus.DONE;
         this.paymentKey = paymentKey;


### PR DESCRIPTION
웹훅이 동시에 여러 번 오거나 confirm과 동시에 실행될 때 중복 처리되는 문제를 비관적 락으로 해결했습니다.
기존에 무시되던 취소(CANCELED), 중단(ABORTED), 만료(EXPIRED) 상태의 웹훅도 처리하도록 수정했습니다.