### PR TITLE
feat: 입점관리 작가 리스트 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ src/main/resources/logback.xml
 # AI tools
 .claude/
 .agents/
+AGENTS.md

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -7,6 +7,8 @@ import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.security.CustomUserDetails;
@@ -35,6 +37,28 @@ public class ContractController {
             @RequestParam(required = false) Long userId
     ) {
         return ApiResponse.of(contractService.getPendingApplicationCount(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/artists")
+    public ApiResponse<ManagedArtistContractListResponse> getManagedArtists(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(contractService.getManagedArtists(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/artists/{contractId}")
+    public ApiResponse<ManagedArtistContractDetailResponse> getManagedArtistContract(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.getManagedArtistContract(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
     }
 
     @GetMapping("/inventory")

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
@@ -74,5 +75,50 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             @Param("contractId") Long contractId,
             @Param("shopId") Long shopId,
             @Param("contractStatus") ContractStatus contractStatus
+    );
+
+    @Query("""
+            select c.shopArtistContractsId as contractId,
+                   a.id as artistId,
+                   bp.businessName as artistName,
+                   c.contractStartDate as contractStartDate,
+                   c.contractEndDate as contractEndDate,
+                   c.contractStatus as contractStatus
+            from ShopArtistContract c
+            join c.artist a
+            join a.businessProfile bp
+            where c.shop.shopId = :shopId
+              and c.contractStatus in :contractStatuses
+            order by case
+                        when c.contractStatus = :pendingStatus then 0
+                        when c.contractStatus = :approvedStatus then 1
+                        when c.contractStatus = :endedStatus then 2
+                        else 3
+                     end,
+                     c.shopArtistContractsId desc
+            """)
+    List<ManagedArtistContractRow> findManagedArtistRowsByShopId(
+            @Param("shopId") Long shopId,
+            @Param("contractStatuses") List<ContractStatus> contractStatuses,
+            @Param("pendingStatus") ContractStatus pendingStatus,
+            @Param("approvedStatus") ContractStatus approvedStatus,
+            @Param("endedStatus") ContractStatus endedStatus
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
+            join fetch c.artist a
+            join fetch a.businessProfile
+            join fetch c.shop s
+            join fetch s.businessProfile
+            where c.shopArtistContractsId = :contractId
+              and c.shop.shopId = :shopId
+              and c.contractStatus in :contractStatuses
+            """)
+    Optional<ShopArtistContract> findManagedArtistContractByIdAndShopId(
+            @Param("contractId") Long contractId,
+            @Param("shopId") Long shopId,
+            @Param("contractStatuses") List<ContractStatus> contractStatuses
     );
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -7,6 +7,8 @@ import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
@@ -31,6 +33,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ContractService {
 
+    private static final List<ContractStatus> MANAGED_ARTIST_CONTRACT_STATUSES = List.of(
+            ContractStatus.PENDING,
+            ContractStatus.APPROVED,
+            ContractStatus.ENDED
+    );
+
     private final ContractRepository contractRepository;
     private final ContractProductRepository contractProductRepository;
     private final ContractProductStockMovementRepository contractProductStockMovementRepository;
@@ -46,6 +54,38 @@ public class ContractService {
                 ContractStatus.PENDING
         );
         return new ContractApplicationCountResponse(applicationCount, artistNames);
+    }
+
+    @Transactional(readOnly = true)
+    public ManagedArtistContractListResponse getManagedArtists(Long userId) {
+        Shop shop = getShopByUserId(userId);
+
+        return ManagedArtistContractListResponse.from(
+                contractRepository.findManagedArtistRowsByShopId(
+                        shop.getShopId(),
+                        MANAGED_ARTIST_CONTRACT_STATUSES,
+                        ContractStatus.PENDING,
+                        ContractStatus.APPROVED,
+                        ContractStatus.ENDED
+                )
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ManagedArtistContractDetailResponse getManagedArtistContract(Long userId, Long contractId) {
+        Shop shop = getShopByUserId(userId);
+
+        ShopArtistContract contract = contractRepository.findManagedArtistContractByIdAndShopId(
+                        contractId,
+                        shop.getShopId(),
+                        MANAGED_ARTIST_CONTRACT_STATUSES
+                )
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "계약서 정보를 찾을 수 없습니다."
+                ));
+
+        return ManagedArtistContractDetailResponse.from(contract);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractStatusActionResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractStatusActionResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractStatusActionResponse {
+
+    private final String code;
+    private final String label;
+
+    public static ContractStatusActionResponse from(ContractStatus status) {
+        return switch (status) {
+            case PENDING -> new ContractStatusActionResponse("CONTRACT_APPROVE", "계약 승인");
+            case APPROVED -> new ContractStatusActionResponse("RELEASE_APPROVE", "해제 승인");
+            case ENDED -> new ContractStatusActionResponse("CONTRACTING", "계약중");
+            case REJECTED -> new ContractStatusActionResponse("NONE", "변경 불가");
+        };
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractDetailResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractDetailResponse.java
@@ -1,0 +1,44 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedArtistContractDetailResponse {
+
+    private final Long contractId;
+    private final Long shopId;
+    private final String shopName;
+    private final Long artistId;
+    private final String artistName;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final ContractStatus contractStatus;
+    private final CommissionType commissionType;
+    private final BigDecimal commissionValue;
+    private final String memo;
+
+    public static ManagedArtistContractDetailResponse from(ShopArtistContract contract) {
+        return new ManagedArtistContractDetailResponse(
+                contract.getShopArtistContractsId(),
+                contract.getShop().getShopId(),
+                contract.getShop().getBusinessName(),
+                contract.getArtist().getId(),
+                contract.getArtist().getBusinessProfile().getBusinessName(),
+                contract.getContractStartDate(),
+                contract.getContractEndDate(),
+                contract.getContractStatus(),
+                contract.getCommissionType(),
+                contract.getCommissionValue(),
+                contract.getMemo() == null ? "" : contract.getMemo()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractItemResponse.java
@@ -1,0 +1,49 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedArtistContractItemResponse {
+
+    private final Long contractId;
+    private final Long artistId;
+    private final String artistName;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final ContractStatus contractStatus;
+    private final String contractStatusLabel;
+    private final ContractStatusActionResponse nextAction;
+    private final Boolean detailAvailable;
+
+    public static ManagedArtistContractItemResponse from(ManagedArtistContractRow row) {
+        ContractStatus status = row.getContractStatus();
+
+        return new ManagedArtistContractItemResponse(
+                row.getContractId(),
+                row.getArtistId(),
+                row.getArtistName(),
+                row.getContractStartDate(),
+                row.getContractEndDate(),
+                status,
+                statusLabel(status),
+                ContractStatusActionResponse.from(status),
+                true
+        );
+    }
+
+    private static String statusLabel(ContractStatus status) {
+        return switch (status) {
+            case PENDING -> "계약 대기";
+            case APPROVED -> "계약중";
+            case ENDED -> "계약 만료";
+            case REJECTED -> "계약 거절";
+        };
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractListResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedArtistContractListResponse {
+
+    private final List<ManagedArtistContractItemResponse> items;
+
+    public static ManagedArtistContractListResponse from(List<ManagedArtistContractRow> rows) {
+        return new ManagedArtistContractListResponse(
+                rows.stream()
+                        .map(ManagedArtistContractItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
@@ -1,0 +1,14 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+
+import java.time.LocalDate;
+
+public interface ManagedArtistContractRow {
+    Long getContractId();
+    Long getArtistId();
+    String getArtistName();
+    LocalDate getContractStartDate();
+    LocalDate getContractEndDate();
+    ContractStatus getContractStatus();
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
@@ -11,6 +11,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
@@ -48,6 +49,12 @@ public class ShopArtistContract extends BaseTimeEntity {
 
     @Column(name = "commission_value", precision = 19, scale = 4)
     private BigDecimal commissionValue;
+
+    @Column(name = "contract_start_date")
+    private LocalDate contractStartDate;
+
+    @Column(name = "contract_end_date")
+    private LocalDate contractEndDate;
 
     @Builder.Default
     @Column(name = "memo", columnDefinition = "TEXT")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: backend
 
   profiles:
-    active: prod # 인증인가가 필요하다면 prod로 변경
+    active: dev # 인증인가가 필요하다면 prod로 변경
 
   config:
     import: optional:file:.env[.properties]
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update # update로 수정해야함
+      ddl-auto: create # update로 수정해야함
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -60,6 +61,8 @@ class ContractProductRepositoryTest {
     private static final BigDecimal DEFAULT_COMMISSION_VALUE = new BigDecimal("20.0000");
     private static final BigDecimal CUP_MARGIN_AMOUNT = new BigDecimal("2400.00");
     private static final BigDecimal CUP_UNIT_SETTLEMENT_AMOUNT = new BigDecimal("9600.00");
+    private static final LocalDate CONTRACT_START_DATE = LocalDate.of(2026, 5, 1);
+    private static final LocalDate CONTRACT_END_DATE = LocalDate.of(2026, 12, 31);
     private static final LocalDateTime CUP_INBOUND_AT = LocalDateTime.of(2026, 4, 28, 10, 0);
     private static final LocalDateTime CUP_SALE_AT = LocalDateTime.of(2026, 4, 28, 12, 0);
     private static final LocalDateTime PLATE_INBOUND_AT = LocalDateTime.of(2026, 4, 27, 14, 30);
@@ -145,6 +148,126 @@ class ContractProductRepositoryTest {
         assertThat(plateRow.getTotalQuantity()).isEqualTo((long) PLATE_INBOUND_QUANTITY);
         assertThat(plateRow.getStockQuantity()).isEqualTo(PLATE_INBOUND_QUANTITY - PLATE_SALE_QUANTITY);
         assertThat(plateRow.getRecentStockedAt()).isEqualTo(PLATE_INBOUND_AT);
+    }
+
+    @Test
+    @DisplayName("입점관리 작가 목록은 대기, 승인, 만료 계약만 반환한다")
+    void givenManagedContracts_whenQueryByShop_thenReturnPendingApprovedEndedOnly() {
+        User shopUser = createUser(
+                "managed-shop@test.com",
+                "입점관리 소품샵",
+                Role.SHOP,
+                "01091000001",
+                "https://image.test/managed-shop.png"
+        );
+        Shop shop = createShop(shopUser, "입점관리 테스트 소품샵", Specialty.LIVING_GOODS);
+        Artist pendingArtist = createArtist(
+                createUser("managed-pending@test.com", "대기 작가", Role.ARTIST, "01091000002", null),
+                "대기 작가",
+                Specialty.CERAMIC
+        );
+        Artist approvedArtist = createArtist(
+                createUser("managed-approved@test.com", "계약 작가", Role.ARTIST, "01091000003", null),
+                "계약 작가",
+                Specialty.HANDMADE_CRAFT
+        );
+        Artist endedArtist = createArtist(
+                createUser("managed-ended@test.com", "만료 작가", Role.ARTIST, "01091000004", null),
+                "만료 작가",
+                Specialty.FABRIC_TEXTILE
+        );
+        Artist rejectedArtist = createArtist(
+                createUser("managed-rejected@test.com", "거절 작가", Role.ARTIST, "01091000005", null),
+                "거절 작가",
+                Specialty.INTERIOR_DECOR
+        );
+
+        ShopArtistContract pendingContract = createContract(
+                pendingArtist,
+                shop,
+                ContractStatus.PENDING,
+                null,
+                null
+        );
+        ShopArtistContract approvedContract = createContract(
+                approvedArtist,
+                shop,
+                ContractStatus.APPROVED,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+        ShopArtistContract endedContract = createContract(
+                endedArtist,
+                shop,
+                ContractStatus.ENDED,
+                CONTRACT_START_DATE.minusYears(1),
+                CONTRACT_END_DATE.minusYears(1)
+        );
+        createContract(rejectedArtist, shop, ContractStatus.REJECTED, null, null);
+        flushAndClear();
+
+        var rows = contractRepository.findManagedArtistRowsByShopId(
+                shop.getShopId(),
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                ContractStatus.ENDED
+        );
+
+        assertThat(rows).hasSize(3);
+        assertThat(rows).extracting("contractId")
+                .containsExactly(
+                        pendingContract.getShopArtistContractsId(),
+                        approvedContract.getShopArtistContractsId(),
+                        endedContract.getShopArtistContractsId()
+                );
+        assertThat(findManagedArtistRow(rows, "계약 작가").getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
+        assertThat(findManagedArtistRow(rows, "계약 작가").getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
+        assertThat(findManagedArtistRow(rows, "계약 작가").getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("입점관리 계약서 상세는 해당 소품샵 계약만 조회한다")
+    void givenManagedContract_whenQueryDetailByShop_thenReturnOwnedContract() {
+        User shopUser = createUser(
+                "managed-detail-shop@test.com",
+                "상세 소품샵",
+                Role.SHOP,
+                "01092000001",
+                "https://image.test/detail-shop.png"
+        );
+        Shop shop = createShop(shopUser, "상세 테스트 소품샵", Specialty.LIVING_GOODS);
+        Artist artist = createArtist(
+                createUser("managed-detail-artist@test.com", "상세 작가", Role.ARTIST, "01092000002", null),
+                "상세 작가",
+                Specialty.CERAMIC
+        );
+        ShopArtistContract contract = createContract(
+                artist,
+                shop,
+                ContractStatus.APPROVED,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+        flushAndClear();
+
+        var found = contractRepository.findManagedArtistContractByIdAndShopId(
+                contract.getShopArtistContractsId(),
+                shop.getShopId(),
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        );
+        var notOwned = contractRepository.findManagedArtistContractByIdAndShopId(
+                contract.getShopArtistContractsId(),
+                shop.getShopId() + 1,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        );
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getArtist().getBusinessProfile().getBusinessName()).isEqualTo("상세 작가");
+        assertThat(found.get().getShop().getBusinessName()).isEqualTo("상세 테스트 소품샵");
+        assertThat(found.get().getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
+        assertThat(found.get().getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
+        assertThat(notOwned).isEmpty();
     }
 
     private InventoryFixture createInventoryFixture() {
@@ -290,10 +413,22 @@ class ContractProductRepositoryTest {
     }
 
     private ShopArtistContract createContract(Artist artist, Shop shop) {
+        return createContract(artist, shop, ContractStatus.APPROVED, null, null);
+    }
+
+    private ShopArtistContract createContract(
+            Artist artist,
+            Shop shop,
+            ContractStatus contractStatus,
+            LocalDate contractStartDate,
+            LocalDate contractEndDate
+    ) {
         ShopArtistContract contract = ShopArtistContract.builder()
                 .artist(artist)
                 .shop(shop)
-                .contractStatus(ContractStatus.APPROVED)
+                .contractStatus(contractStatus)
+                .contractStartDate(contractStartDate)
+                .contractEndDate(contractEndDate)
                 .commissionType(CommissionType.RATE)
                 .commissionValue(DEFAULT_COMMISSION_VALUE)
                 .build();
@@ -345,6 +480,16 @@ class ContractProductRepositoryTest {
     ) {
         return rows.stream()
                 .filter(row -> productName.equals(row.getProductName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow findManagedArtistRow(
+            List<app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow> rows,
+            String artistName
+    ) {
+        return rows.stream()
+                .filter(row -> artistName.equals(row.getArtistName()))
                 .findFirst()
                 .orElseThrow();
     }

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -5,8 +5,11 @@ import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
@@ -17,9 +20,12 @@ import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
 import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
 import app.dearobjet.backend.domain.shop.entity.Shop;
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.user.entity.BusinessProfile;
 import app.dearobjet.backend.domain.user.entity.User;
 import app.dearobjet.backend.domain.user.enums.Specialty;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,11 +36,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -46,6 +54,9 @@ class ContractServiceTest {
     private static final Long SHOP_ID = 10L;
     private static final Long CONTRACT_ID = 50L;
     private static final Long CONTRACT_PRODUCT_ID = 100L;
+    private static final Long ARTIST_ID = 20L;
+    private static final LocalDate CONTRACT_START_DATE = LocalDate.of(2026, 5, 1);
+    private static final LocalDate CONTRACT_END_DATE = LocalDate.of(2026, 12, 31);
     private static final LocalDateTime OCCURRED_AT = LocalDateTime.of(2026, 4, 28, 16, 0);
     private static final String UPDATED_MEMO = "Postman에서 수정한 계약 작가 메모";
 
@@ -83,6 +94,79 @@ class ContractServiceTest {
         assertThat(response.getItems().get(0).getContractId()).isEqualTo(CONTRACT_ID);
         assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 도자기 작가");
         assertThat(response.getItems().get(0).getInboundConfirmed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("입점관리 작가 목록에서 계약 대기, 계약중, 계약 만료 작가를 조회한다")
+    void givenManagedContracts_whenGetManagedArtists_thenReturnArtistRowsWithNextAction() {
+        Shop shop = shopWithId(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistRowsByShopId(
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                ContractStatus.ENDED
+        )).willReturn(List.of(
+                managedArtistRow(1L, ContractStatus.PENDING, "대기 작가"),
+                managedArtistRow(2L, ContractStatus.APPROVED, "계약 작가"),
+                managedArtistRow(3L, ContractStatus.ENDED, "만료 작가")
+        ));
+
+        ManagedArtistContractListResponse response = contractService.getManagedArtists(USER_ID);
+
+        assertThat(response.getItems()).hasSize(3);
+        assertThat(response.getItems().get(0).getContractStatusLabel()).isEqualTo("계약 대기");
+        assertThat(response.getItems().get(0).getNextAction().getCode()).isEqualTo("CONTRACT_APPROVE");
+        assertThat(response.getItems().get(1).getContractStatusLabel()).isEqualTo("계약중");
+        assertThat(response.getItems().get(1).getNextAction().getCode()).isEqualTo("RELEASE_APPROVE");
+        assertThat(response.getItems().get(2).getContractStatusLabel()).isEqualTo("계약 만료");
+        assertThat(response.getItems().get(2).getNextAction().getCode()).isEqualTo("CONTRACTING");
+        assertThat(response.getItems().get(2).getDetailAvailable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("입점관리 계약서 상세를 조회한다")
+    void givenOwnedManagedContract_whenGetManagedArtistContract_thenReturnDetail() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = contractWithArtistAndShop(CONTRACT_ID, ContractStatus.APPROVED);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistContractByIdAndShopId(
+                CONTRACT_ID,
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(Optional.of(contract));
+
+        ManagedArtistContractDetailResponse response =
+                contractService.getManagedArtistContract(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getShopId()).isEqualTo(SHOP_ID);
+        assertThat(response.getShopName()).isEqualTo("Postman 테스트 소품샵");
+        assertThat(response.getArtistId()).isEqualTo(ARTIST_ID);
+        assertThat(response.getArtistName()).isEqualTo("Postman 도자기 작가");
+        assertThat(response.getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
+        assertThat(response.getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("입점관리 계약서 상세가 해당 소품샵 소유가 아니면 예외를 던진다")
+    void givenNotOwnedManagedContract_whenGetManagedArtistContract_thenThrowException() {
+        Shop shop = shopWithId(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistContractByIdAndShopId(
+                CONTRACT_ID,
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> contractService.getManagedArtistContract(USER_ID, CONTRACT_ID))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("계약서 정보를 찾을 수 없습니다.");
     }
 
     @Test
@@ -188,13 +272,55 @@ class ContractServiceTest {
         };
     }
 
+    private ManagedArtistContractRow managedArtistRow(
+            Long contractId,
+            ContractStatus contractStatus,
+            String artistName
+    ) {
+        return new ManagedArtistContractRow() {
+            @Override
+            public Long getContractId() {
+                return contractId;
+            }
+
+            @Override
+            public Long getArtistId() {
+                return ARTIST_ID + contractId;
+            }
+
+            @Override
+            public String getArtistName() {
+                return artistName;
+            }
+
+            @Override
+            public LocalDate getContractStartDate() {
+                return CONTRACT_START_DATE;
+            }
+
+            @Override
+            public LocalDate getContractEndDate() {
+                return CONTRACT_END_DATE;
+            }
+
+            @Override
+            public ContractStatus getContractStatus() {
+                return contractStatus;
+            }
+        };
+    }
+
     private Shop shopWithId(Long shopId) {
         User user = User.builder()
                 .id(USER_ID)
                 .build();
+        BusinessProfile businessProfile = BusinessProfile.builder()
+                .businessName("Postman 테스트 소품샵")
+                .build();
         return Shop.builder()
                 .shopId(shopId)
                 .user(user)
+                .businessProfile(businessProfile)
                 .build();
     }
 
@@ -217,6 +343,33 @@ class ContractServiceTest {
                 .contractStatus(ContractStatus.APPROVED)
                 .commissionType(CommissionType.RATE)
                 .commissionValue(new BigDecimal("20.0000"))
+                .build();
+    }
+
+    private ShopArtistContract contractWithArtistAndShop(Long contractId, ContractStatus contractStatus) {
+        User artistUser = User.builder()
+                .id(ARTIST_ID)
+                .name("Postman 작가 A")
+                .build();
+        BusinessProfile artistBusinessProfile = BusinessProfile.builder()
+                .businessName("Postman 도자기 작가")
+                .build();
+        Artist artist = Artist.builder()
+                .id(ARTIST_ID)
+                .user(artistUser)
+                .businessProfile(artistBusinessProfile)
+                .build();
+
+        return ShopArtistContract.builder()
+                .shopArtistContractsId(contractId)
+                .artist(artist)
+                .shop(shopWithId(SHOP_ID))
+                .contractStatus(contractStatus)
+                .contractStartDate(CONTRACT_START_DATE)
+                .contractEndDate(CONTRACT_END_DATE)
+                .commissionType(CommissionType.RATE)
+                .commissionValue(new BigDecimal("20.0000"))
+                .memo("계약서 테스트 메모")
                 .build();
     }
 


### PR DESCRIPTION
## 변경 사항
  - 입점관리 작가 목록 조회 API 추가
    - `GET /api/v1/contracts/artists`
    - 계약 대기, 계약중, 계약 만료 상태의 작가 목록 반환
  - 계약서 상세 조회 API 추가
    - `GET /api/v1/contracts/artists/{contractId}`
    - 특정 소품샵-작가 계약 정보 반환
  - `ShopArtistContract`에 계약 시작일/종료일 필드 추가
  - 상태별 프론트 표시용 라벨 및 다음 액션 정보 응답 추가
  - 서비스/리포지토리 테스트 추가

  ## 테스트
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`
