### PR TITLE
feat: 입점관리 작가 계약 상태 관리 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -7,6 +7,7 @@ import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
@@ -55,6 +56,20 @@ public class ContractController {
     ) {
         return ApiResponse.of(
                 contractService.getManagedArtistContract(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
+
+    @PatchMapping("/artists/{contractId}/termination")
+    public ApiResponse<ContractTerminationResponse> terminateManagedArtistContract(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.terminateManagedArtistContract(
                         resolveUserId(userDetails, userId),
                         contractId
                 )

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -83,7 +83,8 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
                    bp.businessName as artistName,
                    c.contractStartDate as contractStartDate,
                    c.contractEndDate as contractEndDate,
-                   c.contractStatus as contractStatus
+                   c.contractStatus as contractStatus,
+                   c.contractRequestType as contractRequestType
             from ShopArtistContract c
             join c.artist a
             join a.businessProfile bp

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -7,6 +7,7 @@ import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
@@ -15,6 +16,7 @@ import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
 import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
@@ -22,16 +24,20 @@ import app.dearobjet.backend.domain.shop.entity.Shop;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ContractService {
+
+    private static final int TERMINATION_GRACE_PERIOD_DAYS = 14;
 
     private static final List<ContractStatus> MANAGED_ARTIST_CONTRACT_STATUSES = List.of(
             ContractStatus.PENDING,
@@ -67,7 +73,8 @@ public class ContractService {
                         ContractStatus.PENDING,
                         ContractStatus.APPROVED,
                         ContractStatus.ENDED
-                )
+                ),
+                LocalDate.now()
         );
     }
 
@@ -86,6 +93,31 @@ public class ContractService {
                 ));
 
         return ManagedArtistContractDetailResponse.from(contract);
+    }
+
+    @Transactional
+    public ContractTerminationResponse terminateManagedArtistContract(Long userId, Long contractId) {
+        Shop shop = getShopByUserId(userId);
+
+        ShopArtistContract contract = contractRepository.findManagedArtistContractByIdAndShopId(
+                        contractId,
+                        shop.getShopId(),
+                        MANAGED_ARTIST_CONTRACT_STATUSES
+                )
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "해지할 계약 정보를 찾을 수 없습니다."
+                ));
+
+        if (!canTerminate(contract, LocalDate.now())) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "해지 승인 또는 계약해지가 가능한 계약이 아닙니다."
+            );
+        }
+
+        contract.terminate();
+        return ContractTerminationResponse.from(contract);
     }
 
     @Transactional(readOnly = true)
@@ -178,6 +210,21 @@ public class ContractService {
                         ErrorCode.ENTITY_NOT_FOUND,
                         "계약된 작가를 찾을 수 없습니다."
                 ));
+    }
+
+    private boolean canTerminate(ShopArtistContract contract, LocalDate today) {
+        if (contract.getContractStatus() == ContractStatus.PENDING) {
+            return contract.getContractRequestType() == ContractRequestType.RELEASE;
+        }
+        if (contract.getContractStatus() == ContractStatus.ENDED) {
+            return true;
+        }
+        if (contract.getContractStatus() != ContractStatus.APPROVED) {
+            return false;
+        }
+
+        LocalDate endDate = contract.getContractEndDate();
+        return endDate != null && !today.isBefore(endDate.plusDays(TERMINATION_GRACE_PERIOD_DAYS));
     }
 
     private ContractProductStockMovement applyMovement(

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractStatusActionResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractStatusActionResponse.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.domain.contract.dto;
 
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,12 +13,22 @@ public class ContractStatusActionResponse {
     private final String code;
     private final String label;
 
-    public static ContractStatusActionResponse from(ContractStatus status) {
+    public static ContractStatusActionResponse from(
+            ContractStatus status,
+            ContractRequestType requestType,
+            boolean terminable
+    ) {
+        if (status == ContractStatus.PENDING && requestType == ContractRequestType.RELEASE) {
+            return new ContractStatusActionResponse("RELEASE_APPROVE", "해제 승인");
+        }
+        if (status == ContractStatus.APPROVED && terminable) {
+            return new ContractStatusActionResponse("TERMINATE_CONTRACT", "계약해지");
+        }
+
         return switch (status) {
             case PENDING -> new ContractStatusActionResponse("CONTRACT_APPROVE", "계약 승인");
-            case APPROVED -> new ContractStatusActionResponse("RELEASE_APPROVE", "해제 승인");
-            case ENDED -> new ContractStatusActionResponse("CONTRACTING", "계약중");
-            case REJECTED -> new ContractStatusActionResponse("NONE", "변경 불가");
+            case ENDED -> new ContractStatusActionResponse("TERMINATE_CONTRACT", "계약해지");
+            case APPROVED, REJECTED, TERMINATED -> new ContractStatusActionResponse("NONE", "변경 불가");
         };
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractTerminationResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractTerminationResponse.java
@@ -1,0 +1,22 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractTerminationResponse {
+
+    private final Long contractId;
+    private final ContractStatus contractStatus;
+
+    public static ContractTerminationResponse from(ShopArtistContract contract) {
+        return new ContractTerminationResponse(
+                contract.getShopArtistContractsId(),
+                contract.getContractStatus()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractDetailResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractDetailResponse.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract.dto;
 
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,7 @@ public class ManagedArtistContractDetailResponse {
     private final LocalDate contractStartDate;
     private final LocalDate contractEndDate;
     private final ContractStatus contractStatus;
+    private final ContractRequestType contractRequestType;
     private final CommissionType commissionType;
     private final BigDecimal commissionValue;
     private final String memo;
@@ -36,6 +38,7 @@ public class ManagedArtistContractDetailResponse {
                 contract.getContractStartDate(),
                 contract.getContractEndDate(),
                 contract.getContractStatus(),
+                contract.getContractRequestType(),
                 contract.getCommissionType(),
                 contract.getCommissionValue(),
                 contract.getMemo() == null ? "" : contract.getMemo()

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractItemResponse.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.domain.contract.dto;
 
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import lombok.AccessLevel;
@@ -22,8 +23,9 @@ public class ManagedArtistContractItemResponse {
     private final ContractStatusActionResponse nextAction;
     private final Boolean detailAvailable;
 
-    public static ManagedArtistContractItemResponse from(ManagedArtistContractRow row) {
-        ContractStatus status = row.getContractStatus();
+    public static ManagedArtistContractItemResponse from(ManagedArtistContractRow row, LocalDate today) {
+        ContractStatus displayStatus = displayStatus(row, today);
+        boolean terminable = isTerminable(row, today);
 
         return new ManagedArtistContractItemResponse(
                 row.getContractId(),
@@ -31,11 +33,33 @@ public class ManagedArtistContractItemResponse {
                 row.getArtistName(),
                 row.getContractStartDate(),
                 row.getContractEndDate(),
-                status,
-                statusLabel(status),
-                ContractStatusActionResponse.from(status),
+                displayStatus,
+                statusLabel(displayStatus),
+                ContractStatusActionResponse.from(
+                        row.getContractStatus(),
+                        row.getContractRequestType(),
+                        terminable
+                ),
                 true
         );
+    }
+
+    private static ContractStatus displayStatus(ManagedArtistContractRow row, LocalDate today) {
+        if (row.getContractStatus() == ContractStatus.APPROVED && isTerminable(row, today)) {
+            return ContractStatus.ENDED;
+        }
+
+        return row.getContractStatus();
+    }
+
+    private static boolean isTerminable(ManagedArtistContractRow row, LocalDate today) {
+        LocalDate endDate = row.getContractEndDate();
+        if (endDate == null || today == null) {
+            return false;
+        }
+
+        // 계약 종료일 이후 작가 응답이 없는 경우, 14일째부터 소품샵 해지를 노출한다.
+        return !today.isBefore(endDate.plusDays(14));
     }
 
     private static String statusLabel(ContractStatus status) {
@@ -44,6 +68,7 @@ public class ManagedArtistContractItemResponse {
             case APPROVED -> "계약중";
             case ENDED -> "계약 만료";
             case REJECTED -> "계약 거절";
+            case TERMINATED -> "계약 해지";
         };
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractListResponse.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -13,10 +14,10 @@ public class ManagedArtistContractListResponse {
 
     private final List<ManagedArtistContractItemResponse> items;
 
-    public static ManagedArtistContractListResponse from(List<ManagedArtistContractRow> rows) {
+    public static ManagedArtistContractListResponse from(List<ManagedArtistContractRow> rows, LocalDate today) {
         return new ManagedArtistContractListResponse(
                 rows.stream()
-                        .map(ManagedArtistContractItemResponse::from)
+                        .map(row -> ManagedArtistContractItemResponse.from(row, today))
                         .toList()
         );
     }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.domain.contract.dto.projection;
 
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 
 import java.time.LocalDate;
 
@@ -11,4 +12,5 @@ public interface ManagedArtistContractRow {
     LocalDate getContractStartDate();
     LocalDate getContractEndDate();
     ContractStatus getContractStatus();
+    ContractRequestType getContractRequestType();
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract.entity;
 
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.shop.entity.Shop;
 import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
@@ -57,6 +58,11 @@ public class ShopArtistContract extends BaseTimeEntity {
     private LocalDate contractEndDate;
 
     @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contract_request_type", nullable = false, length = 20)
+    private ContractRequestType contractRequestType = ContractRequestType.NONE;
+
+    @Builder.Default
     @Column(name = "memo", columnDefinition = "TEXT")
     private String memo = "";
 
@@ -78,6 +84,11 @@ public class ShopArtistContract extends BaseTimeEntity {
         this.recentInboundConfirmed = false;
         this.recentInboundConfirmedAt = null;
         this.recentInboundConfirmedByUserId = null;
+    }
+
+    public void terminate() {
+        this.contractStatus = ContractStatus.TERMINATED;
+        this.contractRequestType = ContractRequestType.NONE;
     }
 
     public void confirmRecentInbound(Long confirmedByUserId, LocalDateTime confirmedAt) {

--- a/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractRequestType.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractRequestType.java
@@ -1,0 +1,7 @@
+package app.dearobjet.backend.domain.contract.enums;
+
+public enum ContractRequestType {
+    NONE,
+    EXTENSION,
+    RELEASE
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractStatus.java
@@ -4,5 +4,6 @@ public enum ContractStatus {
     PENDING,
     APPROVED,
     REJECTED,
-    ENDED
+    ENDED,
+    TERMINATED
 }

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -7,6 +7,7 @@ import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
@@ -176,8 +177,13 @@ class ContractProductRepositoryTest {
                 "만료 작가",
                 Specialty.FABRIC_TEXTILE
         );
+        Artist terminatedArtist = createArtist(
+                createUser("managed-terminated@test.com", "해지 작가", Role.ARTIST, "01091000005", null),
+                "해지 작가",
+                Specialty.INTERIOR_DECOR
+        );
         Artist rejectedArtist = createArtist(
-                createUser("managed-rejected@test.com", "거절 작가", Role.ARTIST, "01091000005", null),
+                createUser("managed-rejected@test.com", "거절 작가", Role.ARTIST, "01091000006", null),
                 "거절 작가",
                 Specialty.INTERIOR_DECOR
         );
@@ -186,6 +192,7 @@ class ContractProductRepositoryTest {
                 pendingArtist,
                 shop,
                 ContractStatus.PENDING,
+                ContractRequestType.EXTENSION,
                 null,
                 null
         );
@@ -193,6 +200,7 @@ class ContractProductRepositoryTest {
                 approvedArtist,
                 shop,
                 ContractStatus.APPROVED,
+                ContractRequestType.NONE,
                 CONTRACT_START_DATE,
                 CONTRACT_END_DATE
         );
@@ -200,9 +208,11 @@ class ContractProductRepositoryTest {
                 endedArtist,
                 shop,
                 ContractStatus.ENDED,
+                ContractRequestType.NONE,
                 CONTRACT_START_DATE.minusYears(1),
                 CONTRACT_END_DATE.minusYears(1)
         );
+        createContract(terminatedArtist, shop, ContractStatus.TERMINATED, ContractRequestType.NONE, null, null);
         createContract(rejectedArtist, shop, ContractStatus.REJECTED, null, null);
         flushAndClear();
 
@@ -224,6 +234,8 @@ class ContractProductRepositoryTest {
         assertThat(findManagedArtistRow(rows, "계약 작가").getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
         assertThat(findManagedArtistRow(rows, "계약 작가").getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
         assertThat(findManagedArtistRow(rows, "계약 작가").getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+        assertThat(findManagedArtistRow(rows, "대기 작가").getContractRequestType())
+                .isEqualTo(ContractRequestType.EXTENSION);
     }
 
     @Test
@@ -246,6 +258,7 @@ class ContractProductRepositoryTest {
                 artist,
                 shop,
                 ContractStatus.APPROVED,
+                ContractRequestType.RELEASE,
                 CONTRACT_START_DATE,
                 CONTRACT_END_DATE
         );
@@ -267,6 +280,7 @@ class ContractProductRepositoryTest {
         assertThat(found.get().getShop().getBusinessName()).isEqualTo("상세 테스트 소품샵");
         assertThat(found.get().getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
         assertThat(found.get().getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
+        assertThat(found.get().getContractRequestType()).isEqualTo(ContractRequestType.RELEASE);
         assertThat(notOwned).isEmpty();
     }
 
@@ -423,10 +437,22 @@ class ContractProductRepositoryTest {
             LocalDate contractStartDate,
             LocalDate contractEndDate
     ) {
+        return createContract(artist, shop, contractStatus, ContractRequestType.NONE, contractStartDate, contractEndDate);
+    }
+
+    private ShopArtistContract createContract(
+            Artist artist,
+            Shop shop,
+            ContractStatus contractStatus,
+            ContractRequestType contractRequestType,
+            LocalDate contractStartDate,
+            LocalDate contractEndDate
+    ) {
         ShopArtistContract contract = ShopArtistContract.builder()
                 .artist(artist)
                 .shop(shop)
                 .contractStatus(contractStatus)
+                .contractRequestType(contractRequestType)
                 .contractStartDate(contractStartDate)
                 .contractEndDate(contractEndDate)
                 .commissionType(CommissionType.RATE)

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -5,6 +5,7 @@ import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
@@ -14,6 +15,7 @@ import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
@@ -26,6 +28,7 @@ import app.dearobjet.backend.domain.user.entity.User;
 import app.dearobjet.backend.domain.user.enums.Specialty;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -109,21 +112,31 @@ class ContractServiceTest {
                 ContractStatus.APPROVED,
                 ContractStatus.ENDED
         )).willReturn(List.of(
-                managedArtistRow(1L, ContractStatus.PENDING, "대기 작가"),
-                managedArtistRow(2L, ContractStatus.APPROVED, "계약 작가"),
-                managedArtistRow(3L, ContractStatus.ENDED, "만료 작가")
+                managedArtistRow(1L, ContractStatus.PENDING, ContractRequestType.EXTENSION, "연장 대기 작가"),
+                managedArtistRow(2L, ContractStatus.PENDING, ContractRequestType.RELEASE, "해제 대기 작가"),
+                managedArtistRow(3L, ContractStatus.APPROVED, ContractRequestType.NONE, "계약 작가"),
+                managedArtistRow(
+                        4L,
+                        ContractStatus.APPROVED,
+                        ContractRequestType.NONE,
+                        "해지 가능 작가",
+                        LocalDate.now().minusDays(14)
+                )
         ));
 
         ManagedArtistContractListResponse response = contractService.getManagedArtists(USER_ID);
 
-        assertThat(response.getItems()).hasSize(3);
+        assertThat(response.getItems()).hasSize(4);
         assertThat(response.getItems().get(0).getContractStatusLabel()).isEqualTo("계약 대기");
         assertThat(response.getItems().get(0).getNextAction().getCode()).isEqualTo("CONTRACT_APPROVE");
-        assertThat(response.getItems().get(1).getContractStatusLabel()).isEqualTo("계약중");
+        assertThat(response.getItems().get(1).getContractStatusLabel()).isEqualTo("계약 대기");
         assertThat(response.getItems().get(1).getNextAction().getCode()).isEqualTo("RELEASE_APPROVE");
-        assertThat(response.getItems().get(2).getContractStatusLabel()).isEqualTo("계약 만료");
-        assertThat(response.getItems().get(2).getNextAction().getCode()).isEqualTo("CONTRACTING");
-        assertThat(response.getItems().get(2).getDetailAvailable()).isTrue();
+        assertThat(response.getItems().get(2).getContractStatusLabel()).isEqualTo("계약중");
+        assertThat(response.getItems().get(2).getNextAction().getCode()).isEqualTo("NONE");
+        assertThat(response.getItems().get(3).getContractStatus()).isEqualTo(ContractStatus.ENDED);
+        assertThat(response.getItems().get(3).getContractStatusLabel()).isEqualTo("계약 만료");
+        assertThat(response.getItems().get(3).getNextAction().getCode()).isEqualTo("TERMINATE_CONTRACT");
+        assertThat(response.getItems().get(3).getDetailAvailable()).isTrue();
     }
 
     @Test
@@ -150,6 +163,7 @@ class ContractServiceTest {
         assertThat(response.getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
         assertThat(response.getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
         assertThat(response.getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+        assertThat(response.getContractRequestType()).isEqualTo(ContractRequestType.NONE);
     }
 
     @Test
@@ -167,6 +181,84 @@ class ContractServiceTest {
         assertThatThrownBy(() -> contractService.getManagedArtistContract(USER_ID, CONTRACT_ID))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("계약서 정보를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("작가 해제 신청 계약을 해지 처리한다")
+    void givenReleaseRequestedContract_whenTerminateManagedArtistContract_thenChangeStatusToTerminated() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = contractWithArtistAndShop(
+                CONTRACT_ID,
+                ContractStatus.PENDING,
+                ContractRequestType.RELEASE,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistContractByIdAndShopId(
+                CONTRACT_ID,
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(Optional.of(contract));
+
+        ContractTerminationResponse response =
+                contractService.terminateManagedArtistContract(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.TERMINATED);
+        assertThat(contract.getContractStatus()).isEqualTo(ContractStatus.TERMINATED);
+        assertThat(contract.getContractRequestType()).isEqualTo(ContractRequestType.NONE);
+    }
+
+    @Test
+    @DisplayName("계약 종료일 14일 이후 계약을 해지 처리한다")
+    void givenExpiredContractAfterGracePeriod_whenTerminateManagedArtistContract_thenChangeStatusToTerminated() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = contractWithArtistAndShop(
+                CONTRACT_ID,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE,
+                LocalDate.now().minusDays(14)
+        );
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistContractByIdAndShopId(
+                CONTRACT_ID,
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(Optional.of(contract));
+
+        ContractTerminationResponse response =
+                contractService.terminateManagedArtistContract(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.TERMINATED);
+        assertThat(contract.getContractStatus()).isEqualTo(ContractStatus.TERMINATED);
+    }
+
+    @Test
+    @DisplayName("해지 조건이 아닌 계약은 해지 처리할 수 없다")
+    void givenNotTerminableContract_whenTerminateManagedArtistContract_thenThrowException() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = contractWithArtistAndShop(
+                CONTRACT_ID,
+                ContractStatus.PENDING,
+                ContractRequestType.EXTENSION,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistContractByIdAndShopId(
+                CONTRACT_ID,
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(Optional.of(contract));
+
+        assertThatThrownBy(() -> contractService.terminateManagedArtistContract(USER_ID, CONTRACT_ID))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessageContaining("해지 승인 또는 계약해지가 가능한 계약이 아닙니다.");
     }
 
     @Test
@@ -275,7 +367,18 @@ class ContractServiceTest {
     private ManagedArtistContractRow managedArtistRow(
             Long contractId,
             ContractStatus contractStatus,
+            ContractRequestType requestType,
             String artistName
+    ) {
+        return managedArtistRow(contractId, contractStatus, requestType, artistName, CONTRACT_END_DATE);
+    }
+
+    private ManagedArtistContractRow managedArtistRow(
+            Long contractId,
+            ContractStatus contractStatus,
+            ContractRequestType requestType,
+            String artistName,
+            LocalDate contractEndDate
     ) {
         return new ManagedArtistContractRow() {
             @Override
@@ -300,12 +403,17 @@ class ContractServiceTest {
 
             @Override
             public LocalDate getContractEndDate() {
-                return CONTRACT_END_DATE;
+                return contractEndDate;
             }
 
             @Override
             public ContractStatus getContractStatus() {
                 return contractStatus;
+            }
+
+            @Override
+            public ContractRequestType getContractRequestType() {
+                return requestType;
             }
         };
     }
@@ -347,6 +455,22 @@ class ContractServiceTest {
     }
 
     private ShopArtistContract contractWithArtistAndShop(Long contractId, ContractStatus contractStatus) {
+        return contractWithArtistAndShop(
+                contractId,
+                contractStatus,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+    }
+
+    private ShopArtistContract contractWithArtistAndShop(
+            Long contractId,
+            ContractStatus contractStatus,
+            ContractRequestType contractRequestType,
+            LocalDate contractStartDate,
+            LocalDate contractEndDate
+    ) {
         User artistUser = User.builder()
                 .id(ARTIST_ID)
                 .name("Postman 작가 A")
@@ -365,8 +489,9 @@ class ContractServiceTest {
                 .artist(artist)
                 .shop(shopWithId(SHOP_ID))
                 .contractStatus(contractStatus)
-                .contractStartDate(CONTRACT_START_DATE)
-                .contractEndDate(CONTRACT_END_DATE)
+                .contractRequestType(contractRequestType)
+                .contractStartDate(contractStartDate)
+                .contractEndDate(contractEndDate)
                 .commissionType(CommissionType.RATE)
                 .commissionValue(new BigDecimal("20.0000"))
                 .memo("계약서 테스트 메모")


### PR DESCRIPTION
Related to #57 

## 변경 사항
  - 입점관리 작가 리스트/계약서 조회 API 추가
  - 계약 요청 유형 추가
    - `EXTENSION`: 계약 연장 신청
    - `RELEASE`: 해제 신청
    - `NONE`: 요청 없음
  - 계약 상태에 `TERMINATED` 추가
  - 작가 리스트 응답의 계약 상태/액션 표시 로직 보정
    - 계약 연장 신청: 계약 대기 / 계약 승인
    - 해제 신청: 계약 대기 / 해제 승인
    - 계약 종료 후 14일 경과: 계약 만료 / 계약해지
  - 계약 해지 실행 API 추가
    - `PATCH /api/v1/contracts/artists/{contractId}/termination`
    - 성공 시 `TERMINATED`로 변경되어 목록에서 제외

  ## 테스트
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`