### PR TITLE
feat: 입점 작가 제안 리스트 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
+import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
@@ -46,6 +47,14 @@ public class ContractController {
             @RequestParam(required = false) Long userId
     ) {
         return ApiResponse.of(contractService.getManagedArtists(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/artists/suggestions")
+    public ApiResponse<ArtistSuggestionListResponse> getArtistSuggestions(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(contractService.getArtistSuggestions(resolveUserId(userDetails, userId)));
     }
 
     @GetMapping("/artists/{contractId}")

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -1,10 +1,13 @@
 package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -121,5 +124,32 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             @Param("contractId") Long contractId,
             @Param("shopId") Long shopId,
             @Param("contractStatuses") List<ContractStatus> contractStatuses
+    );
+
+    @Query("""
+            select a.id as artistId,
+                   u.id as userId,
+                   bp.businessName as artistName,
+                   u.profileUrl as artistImageUrl,
+                   bp.specialty as specialty,
+                   a.instagramId as instagramId
+            from Artist a
+            join a.user u
+            join a.businessProfile bp
+            where u.role = :artistRole
+              and u.userStatus = :activeStatus
+              and not exists (
+                  select 1
+                  from ShopArtistContract c
+                  where c.shop.shopId = :shopId
+                    and c.artist = a
+                    and c.contractStatus in :excludedStatuses
+              )
+            """)
+    List<ArtistSuggestionRow> findArtistSuggestionRows(
+            @Param("shopId") Long shopId,
+            @Param("artistRole") Role artistRole,
+            @Param("activeStatus") UserStatus activeStatus,
+            @Param("excludedStatuses") List<ContractStatus> excludedStatuses
     );
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
+import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
@@ -21,6 +22,9 @@ import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
 import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
 import app.dearobjet.backend.domain.shop.entity.Shop;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
@@ -31,6 +35,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -38,8 +44,15 @@ import java.util.List;
 public class ContractService {
 
     private static final int TERMINATION_GRACE_PERIOD_DAYS = 14;
+    private static final int ARTIST_SUGGESTION_LIMIT = 10;
 
     private static final List<ContractStatus> MANAGED_ARTIST_CONTRACT_STATUSES = List.of(
+            ContractStatus.PENDING,
+            ContractStatus.APPROVED,
+            ContractStatus.ENDED
+    );
+
+    private static final List<ContractStatus> ARTIST_SUGGESTION_EXCLUDED_STATUSES = List.of(
             ContractStatus.PENDING,
             ContractStatus.APPROVED,
             ContractStatus.ENDED
@@ -75,6 +88,24 @@ public class ContractService {
                         ContractStatus.ENDED
                 ),
                 LocalDate.now()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ArtistSuggestionListResponse getArtistSuggestions(Long userId) {
+        Shop shop = getShopByUserId(userId);
+        List<ArtistSuggestionRow> rows = new ArrayList<>(contractRepository.findArtistSuggestionRows(
+                shop.getShopId(),
+                Role.ARTIST,
+                UserStatus.ACTIVE,
+                ARTIST_SUGGESTION_EXCLUDED_STATUSES
+        ));
+
+        Collections.shuffle(rows);
+        return ArtistSuggestionListResponse.from(
+                rows.stream()
+                        .limit(ARTIST_SUGGESTION_LIMIT)
+                        .toList()
         );
     }
 

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistSuggestionItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistSuggestionItemResponse.java
@@ -1,0 +1,30 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistSuggestionItemResponse {
+
+    private final Long artistId;
+    private final Long userId;
+    private final String artistName;
+    private final String artistImageUrl;
+    private final Specialty specialty;
+    private final String instagramId;
+
+    public static ArtistSuggestionItemResponse from(ArtistSuggestionRow row) {
+        return new ArtistSuggestionItemResponse(
+                row.getArtistId(),
+                row.getUserId(),
+                row.getArtistName(),
+                row.getArtistImageUrl(),
+                row.getSpecialty(),
+                row.getInstagramId()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistSuggestionListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistSuggestionListResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistSuggestionListResponse {
+
+    private final List<ArtistSuggestionItemResponse> items;
+
+    public static ArtistSuggestionListResponse from(List<ArtistSuggestionRow> rows) {
+        return new ArtistSuggestionListResponse(
+                rows.stream()
+                        .map(ArtistSuggestionItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistSuggestionRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistSuggestionRow.java
@@ -1,0 +1,12 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.user.enums.Specialty;
+
+public interface ArtistSuggestionRow {
+    Long getArtistId();
+    Long getUserId();
+    String getArtistName();
+    String getArtistImageUrl();
+    Specialty getSpecialty();
+    String getInstagramId();
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
@@ -284,6 +285,95 @@ class ContractProductRepositoryTest {
         assertThat(notOwned).isEmpty();
     }
 
+    @Test
+    @DisplayName("입점 작가 제안 목록은 현재 진행중 계약이 없는 활성 작가만 반환한다")
+    void givenArtistsAndContracts_whenQuerySuggestions_thenExcludeCurrentShopActiveContractsOnly() {
+        User shopUser = createUser(
+                "suggestion-shop@test.com",
+                "추천 소품샵",
+                Role.SHOP,
+                "01093000001",
+                null
+        );
+        User otherShopUser = createUser(
+                "suggestion-other-shop@test.com",
+                "다른 소품샵",
+                Role.SHOP,
+                "01093000002",
+                null
+        );
+        Shop shop = createShop(shopUser, "추천 테스트 소품샵", Specialty.LIVING_GOODS);
+        Shop otherShop = createShop(otherShopUser, "다른 테스트 소품샵", Specialty.LIVING_GOODS);
+
+        Artist eligibleArtist = createArtist(
+                createUser("suggestion-eligible@test.com", "추천 가능 작가", Role.ARTIST, "01093000003", null),
+                "추천 가능 작가",
+                Specialty.CERAMIC
+        );
+        Artist rejectedArtist = createArtist(
+                createUser("suggestion-rejected@test.com", "거절 이력 작가", Role.ARTIST, "01093000004", null),
+                "거절 이력 작가",
+                Specialty.HANDMADE_CRAFT
+        );
+        Artist terminatedArtist = createArtist(
+                createUser("suggestion-terminated@test.com", "해지 이력 작가", Role.ARTIST, "01093000005", null),
+                "해지 이력 작가",
+                Specialty.FABRIC_TEXTILE
+        );
+        Artist otherShopContractArtist = createArtist(
+                createUser("suggestion-other-contract@test.com", "다른샵 계약 작가", Role.ARTIST, "01093000006", null),
+                "다른샵 계약 작가",
+                Specialty.INTERIOR_DECOR
+        );
+        Artist pendingArtist = createArtist(
+                createUser("suggestion-pending@test.com", "대기 제외 작가", Role.ARTIST, "01093000007", null),
+                "대기 제외 작가",
+                Specialty.CERAMIC
+        );
+        Artist approvedArtist = createArtist(
+                createUser("suggestion-approved@test.com", "계약 제외 작가", Role.ARTIST, "01093000008", null),
+                "계약 제외 작가",
+                Specialty.CERAMIC
+        );
+        Artist endedArtist = createArtist(
+                createUser("suggestion-ended@test.com", "만료 제외 작가", Role.ARTIST, "01093000009", null),
+                "만료 제외 작가",
+                Specialty.CERAMIC
+        );
+
+        createContract(rejectedArtist, shop, ContractStatus.REJECTED, ContractRequestType.NONE, null, null);
+        createContract(terminatedArtist, shop, ContractStatus.TERMINATED, ContractRequestType.NONE, null, null);
+        createContract(otherShopContractArtist, otherShop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+        createContract(pendingArtist, shop, ContractStatus.PENDING, ContractRequestType.EXTENSION, null, null);
+        createContract(approvedArtist, shop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+        createContract(endedArtist, shop, ContractStatus.ENDED, ContractRequestType.NONE, null, null);
+        flushAndClear();
+
+        var rows = contractRepository.findArtistSuggestionRows(
+                shop.getShopId(),
+                Role.ARTIST,
+                UserStatus.ACTIVE,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        );
+
+        assertThat(rows).extracting("artistName")
+                .contains(
+                        "추천 가능 작가",
+                        "거절 이력 작가",
+                        "해지 이력 작가",
+                        "다른샵 계약 작가"
+                )
+                .doesNotContain(
+                        "대기 제외 작가",
+                        "계약 제외 작가",
+                        "만료 제외 작가"
+                );
+        assertThat(findSuggestionRow(rows, "추천 가능 작가").getArtistId())
+                .isEqualTo(eligibleArtist.getId());
+        assertThat(findSuggestionRow(rows, "추천 가능 작가").getUserId())
+                .isEqualTo(eligibleArtist.getUser().getId());
+    }
+
     private InventoryFixture createInventoryFixture() {
         User shopUser = createUser(
                 "postman-shop@test.com",
@@ -514,6 +604,13 @@ class ContractProductRepositoryTest {
             List<app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow> rows,
             String artistName
     ) {
+        return rows.stream()
+                .filter(row -> artistName.equals(row.getArtistName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private ArtistSuggestionRow findSuggestionRow(List<ArtistSuggestionRow> rows, String artistName) {
         return rows.stream()
                 .filter(row -> artistName.equals(row.getArtistName()))
                 .findFirst()

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
+import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
@@ -10,6 +11,7 @@ import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResp
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
@@ -26,6 +28,8 @@ import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.user.entity.BusinessProfile;
 import app.dearobjet.backend.domain.user.entity.User;
 import app.dearobjet.backend.domain.user.enums.Specialty;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.InvalidInputException;
@@ -97,6 +101,61 @@ class ContractServiceTest {
         assertThat(response.getItems().get(0).getContractId()).isEqualTo(CONTRACT_ID);
         assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 도자기 작가");
         assertThat(response.getItems().get(0).getInboundConfirmed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("입점 작가 제안 목록에서 랜덤 최대 10명을 조회한다")
+    void givenEligibleArtists_whenGetArtistSuggestions_thenReturnUpToTenArtists() {
+        Shop shop = shopWithId(SHOP_ID);
+        List<ArtistSuggestionRow> rows = java.util.stream.LongStream.rangeClosed(1, 12)
+                .mapToObj(index -> artistSuggestionRow(
+                        ARTIST_ID + index,
+                        USER_ID + index,
+                        "추천 작가 " + index
+                ))
+                .toList();
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findArtistSuggestionRows(
+                SHOP_ID,
+                Role.ARTIST,
+                UserStatus.ACTIVE,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(rows);
+
+        ArtistSuggestionListResponse response = contractService.getArtistSuggestions(USER_ID);
+
+        assertThat(response.getItems()).hasSize(10);
+        assertThat(response.getItems())
+                .allSatisfy(item -> {
+                    assertThat(item.getArtistId()).isNotNull();
+                    assertThat(item.getUserId()).isNotNull();
+                    assertThat(item.getArtistName()).startsWith("추천 작가 ");
+                    assertThat(item.getSpecialty()).isEqualTo(Specialty.CERAMIC);
+                });
+    }
+
+    @Test
+    @DisplayName("입점 작가 제안 목록에 채팅방 생성용 사용자 ID를 포함한다")
+    void givenEligibleArtist_whenGetArtistSuggestions_thenReturnArtistAndUserIdentifiers() {
+        Shop shop = shopWithId(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findArtistSuggestionRows(
+                SHOP_ID,
+                Role.ARTIST,
+                UserStatus.ACTIVE,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(List.of(artistSuggestionRow(ARTIST_ID, USER_ID + 100, "Postman 추천 작가")));
+
+        ArtistSuggestionListResponse response = contractService.getArtistSuggestions(USER_ID);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getArtistId()).isEqualTo(ARTIST_ID);
+        assertThat(response.getItems().get(0).getUserId()).isEqualTo(USER_ID + 100);
+        assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 추천 작가");
+        assertThat(response.getItems().get(0).getArtistImageUrl()).isEqualTo("https://image.test/suggested.png");
+        assertThat(response.getItems().get(0).getInstagramId()).isEqualTo("suggested_artist");
     }
 
     @Test
@@ -360,6 +419,40 @@ class ContractServiceTest {
             @Override
             public Boolean getInboundConfirmed() {
                 return false;
+            }
+        };
+    }
+
+    private ArtistSuggestionRow artistSuggestionRow(Long artistId, Long userId, String artistName) {
+        return new ArtistSuggestionRow() {
+            @Override
+            public Long getArtistId() {
+                return artistId;
+            }
+
+            @Override
+            public Long getUserId() {
+                return userId;
+            }
+
+            @Override
+            public String getArtistName() {
+                return artistName;
+            }
+
+            @Override
+            public String getArtistImageUrl() {
+                return "https://image.test/suggested.png";
+            }
+
+            @Override
+            public Specialty getSpecialty() {
+                return Specialty.CERAMIC;
+            }
+
+            @Override
+            public String getInstagramId() {
+                return "suggested_artist";
             }
         };
     }


### PR DESCRIPTION
## 변경 사항
  - 입점 작가 제안 리스트 조회 API 추가
    - `GET /api/v1/contracts/artists/suggestions`
  - 활성 상태의 작가 회원 중 랜덤 최대 10명 반환
  - 현재 소품샵과 진행 중 계약이 있는 작가 제외
    - 제외 상태: `PENDING`, `APPROVED`, `ENDED`
    - 포함 가능: `REJECTED`, `TERMINATED`, 다른 소품샵과의 계약
  - 프론트가 기존 채팅방 생성 API에 바로 연결할 수 있도록 응답에 `userId` 포함
    - 채팅방 이동은 기존 POST /api/chat/rooms/direct/{partnerId}를 재사용하도록 응답에
  userId를 포함

  ## 테스트
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`