### PR TITLE
feat: 계약서 발송용 작가 계정 검색 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
+import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
@@ -55,6 +56,15 @@ public class ContractController {
             @RequestParam(required = false) Long userId
     ) {
         return ApiResponse.of(contractService.getArtistSuggestions(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/artists/search")
+    public ApiResponse<ArtistAccountSearchResponse> searchArtistAccounts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @RequestParam String keyword
+    ) {
+        return ApiResponse.of(contractService.searchArtistAccounts(resolveUserId(userDetails, userId), keyword));
     }
 
     @GetMapping("/artists/{contractId}")

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -1,13 +1,15 @@
 package app.dearobjet.backend.domain.contract;
 
-import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.enums.UserStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -129,6 +131,7 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
     @Query("""
             select a.id as artistId,
                    u.id as userId,
+                   u.name as name,
                    bp.businessName as artistName,
                    u.profileUrl as artistImageUrl,
                    bp.specialty as specialty,
@@ -151,5 +154,42 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             @Param("artistRole") Role artistRole,
             @Param("activeStatus") UserStatus activeStatus,
             @Param("excludedStatuses") List<ContractStatus> excludedStatuses
+    );
+
+    @Query("""
+            select a.id as artistId,
+                   u.id as userId,
+                   u.name as name,
+                   bp.businessName as artistName,
+                   u.profileUrl as artistImageUrl,
+                   bp.specialty as specialty,
+                   a.instagramId as instagramId,
+                   u.email as email
+            from Artist a
+            join a.user u
+            join a.businessProfile bp
+            where u.role = :artistRole
+              and u.userStatus = :activeStatus
+              and (
+                  lower(bp.businessName) like :keyword
+                  or lower(u.name) like :keyword
+                  or lower(u.email) like :keyword
+              )
+              and not exists (
+                  select 1
+                  from ShopArtistContract c
+                  where c.shop.shopId = :shopId
+                    and c.artist = a
+                    and c.contractStatus in :excludedStatuses
+              )
+            order by bp.businessName asc, a.id desc
+            """)
+    List<ArtistAccountSearchRow> searchArtistAccountRows(
+            @Param("shopId") Long shopId,
+            @Param("artistRole") Role artistRole,
+            @Param("activeStatus") UserStatus activeStatus,
+            @Param("excludedStatuses") List<ContractStatus> excludedStatuses,
+            @Param("keyword") String keyword,
+            Pageable pageable
     );
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
+import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
@@ -30,6 +31,7 @@ import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
 import app.dearobjet.backend.global.exception.InvalidInputException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +47,8 @@ public class ContractService {
 
     private static final int TERMINATION_GRACE_PERIOD_DAYS = 14;
     private static final int ARTIST_SUGGESTION_LIMIT = 10;
+    private static final int ARTIST_ACCOUNT_SEARCH_LIMIT = 10;
+    private static final int MIN_ARTIST_ACCOUNT_SEARCH_KEYWORD_LENGTH = 2;
 
     private static final List<ContractStatus> MANAGED_ARTIST_CONTRACT_STATUSES = List.of(
             ContractStatus.PENDING,
@@ -106,6 +110,26 @@ public class ContractService {
                 rows.stream()
                         .limit(ARTIST_SUGGESTION_LIMIT)
                         .toList()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ArtistAccountSearchResponse searchArtistAccounts(Long userId, String keyword) {
+        Shop shop = getShopByUserId(userId);
+        String normalizedKeyword = normalizeSearchKeyword(keyword);
+        if (normalizedKeyword.length() < MIN_ARTIST_ACCOUNT_SEARCH_KEYWORD_LENGTH) {
+            return ArtistAccountSearchResponse.from(List.of());
+        }
+
+        return ArtistAccountSearchResponse.from(
+                contractRepository.searchArtistAccountRows(
+                        shop.getShopId(),
+                        Role.ARTIST,
+                        UserStatus.ACTIVE,
+                        ARTIST_SUGGESTION_EXCLUDED_STATUSES,
+                        "%" + normalizedKeyword + "%",
+                        PageRequest.of(0, ARTIST_ACCOUNT_SEARCH_LIMIT)
+                )
         );
     }
 
@@ -256,6 +280,13 @@ public class ContractService {
 
         LocalDate endDate = contract.getContractEndDate();
         return endDate != null && !today.isBefore(endDate.plusDays(TERMINATION_GRACE_PERIOD_DAYS));
+    }
+
+    private String normalizeSearchKeyword(String keyword) {
+        if (keyword == null) {
+            return "";
+        }
+        return keyword.trim().toLowerCase();
     }
 
     private ContractProductStockMovement applyMovement(

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistAccountSearchItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistAccountSearchItemResponse.java
@@ -1,0 +1,34 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistAccountSearchItemResponse {
+
+    private final Long artistId;
+    private final Long userId;
+    private final String userName;
+    private final String artistName;
+    private final String artistImageUrl;
+    private final Specialty specialty;
+    private final String instagramId;
+    private final String email;
+
+    public static ArtistAccountSearchItemResponse from(ArtistAccountSearchRow row) {
+        return new ArtistAccountSearchItemResponse(
+                row.getArtistId(),
+                row.getUserId(),
+                row.getName(),
+                row.getArtistName(),
+                row.getArtistImageUrl(),
+                row.getSpecialty(),
+                row.getInstagramId(),
+                row.getEmail()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistAccountSearchResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ArtistAccountSearchResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistAccountSearchResponse {
+
+    private final List<ArtistAccountSearchItemResponse> items;
+
+    public static ArtistAccountSearchResponse from(List<ArtistAccountSearchRow> rows) {
+        return new ArtistAccountSearchResponse(
+                rows.stream()
+                        .map(ArtistAccountSearchItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistAccountSearchRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistAccountSearchRow.java
@@ -1,0 +1,14 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.user.enums.Specialty;
+
+public interface ArtistAccountSearchRow {
+    Long getArtistId();
+    Long getUserId();
+    String getName();
+    String getArtistName();
+    String getArtistImageUrl();
+    Specialty getSpecialty();
+    String getInstagramId();
+    String getEmail();
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
@@ -374,6 +376,166 @@ class ContractProductRepositoryTest {
                 .isEqualTo(eligibleArtist.getUser().getId());
     }
 
+    @Test
+    @DisplayName("계약서 발송용 작가 계정 검색은 상호명, 사용자 이름, 이메일로 검색한다")
+    void givenKeyword_whenSearchArtistAccounts_thenReturnMatchedActiveArtists() {
+        User shopUser = createUser(
+                "search-shop@test.com",
+                "검색 소품샵",
+                Role.SHOP,
+                "01094000001",
+                null
+        );
+        Shop shop = createShop(shopUser, "검색 테스트 소품샵", Specialty.LIVING_GOODS);
+        Artist businessNameMatchedArtist = createArtist(
+                createUser("search-business@test.com", "비즈니스 매칭 사용자", Role.ARTIST, "01094000002", null),
+                "Postman 세라믹 스튜디오",
+                Specialty.CERAMIC
+        );
+        Artist userNameMatchedArtist = createArtist(
+                createUser("search-name@test.com", "Postman 이름 작가", Role.ARTIST, "01094000003", null),
+                "이름 검색 스튜디오",
+                Specialty.HANDMADE_CRAFT
+        );
+        Artist emailMatchedArtist = createArtist(
+                createUser("postman-email@test.com", "이메일 검색 작가", Role.ARTIST, "01094000004", null),
+                "이메일 검색 스튜디오",
+                Specialty.FABRIC_TEXTILE
+        );
+        createArtist(
+                createUser("search-customer@test.com", "Postman 일반 회원", Role.CUSTOMER, "01094000005", null),
+                "일반 회원 스튜디오",
+                Specialty.INTERIOR_DECOR
+        );
+        User inactiveUser = createUser(
+                "search-inactive@test.com",
+                "Postman 비활성 작가",
+                Role.ARTIST,
+                "01094000006",
+                null
+        );
+        inactiveUser.deactivate();
+        createArtist(inactiveUser, "비활성 스튜디오", Specialty.CERAMIC);
+        flushAndClear();
+
+        var rows = contractRepository.searchArtistAccountRows(
+                shop.getShopId(),
+                Role.ARTIST,
+                UserStatus.ACTIVE,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                "%postman%",
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(rows).extracting("artistName")
+                .contains(
+                        "Postman 세라믹 스튜디오",
+                        "이름 검색 스튜디오",
+                        "이메일 검색 스튜디오"
+                )
+                .doesNotContain(
+                        "일반 회원 스튜디오",
+                        "비활성 스튜디오"
+                );
+        assertThat(findAccountSearchRow(rows, "Postman 세라믹 스튜디오").getArtistId())
+                .isEqualTo(businessNameMatchedArtist.getId());
+        assertThat(findAccountSearchRow(rows, "이름 검색 스튜디오").getUserId())
+                .isEqualTo(userNameMatchedArtist.getUser().getId());
+        assertThat(findAccountSearchRow(rows, "이름 검색 스튜디오").getName())
+                .isEqualTo("Postman 이름 작가");
+        assertThat(findAccountSearchRow(rows, "이메일 검색 스튜디오").getEmail())
+                .isEqualTo(emailMatchedArtist.getUser().getEmail());
+    }
+
+    @Test
+    @DisplayName("계약서 발송용 작가 계정 검색은 현재 소품샵의 진행중 계약 작가를 제외한다")
+    void givenCurrentShopContracts_whenSearchArtistAccounts_thenExcludePendingApprovedEndedOnly() {
+        User shopUser = createUser(
+                "search-contract-shop@test.com",
+                "계약 검색 소품샵",
+                Role.SHOP,
+                "01095000001",
+                null
+        );
+        User otherShopUser = createUser(
+                "search-contract-other-shop@test.com",
+                "계약 검색 다른샵",
+                Role.SHOP,
+                "01095000002",
+                null
+        );
+        Shop shop = createShop(shopUser, "계약 검색 테스트 소품샵", Specialty.LIVING_GOODS);
+        Shop otherShop = createShop(otherShopUser, "계약 검색 다른 소품샵", Specialty.LIVING_GOODS);
+
+        Artist eligibleArtist = createArtist(
+                createUser("account-eligible@test.com", "검색 가능 작가", Role.ARTIST, "01095000003", null),
+                "계약 검색 가능 작가",
+                Specialty.CERAMIC
+        );
+        Artist rejectedArtist = createArtist(
+                createUser("account-rejected@test.com", "검색 거절 이력 작가", Role.ARTIST, "01095000004", null),
+                "계약 검색 거절 이력 작가",
+                Specialty.HANDMADE_CRAFT
+        );
+        Artist terminatedArtist = createArtist(
+                createUser("account-terminated@test.com", "검색 해지 이력 작가", Role.ARTIST, "01095000005", null),
+                "계약 검색 해지 이력 작가",
+                Specialty.FABRIC_TEXTILE
+        );
+        Artist otherShopContractArtist = createArtist(
+                createUser("account-other-shop@test.com", "검색 다른샵 계약 작가", Role.ARTIST, "01095000006", null),
+                "계약 검색 다른샵 계약 작가",
+                Specialty.INTERIOR_DECOR
+        );
+        Artist pendingArtist = createArtist(
+                createUser("account-pending@test.com", "검색 대기 제외 작가", Role.ARTIST, "01095000007", null),
+                "계약 검색 대기 제외 작가",
+                Specialty.CERAMIC
+        );
+        Artist approvedArtist = createArtist(
+                createUser("account-approved@test.com", "검색 승인 제외 작가", Role.ARTIST, "01095000008", null),
+                "계약 검색 승인 제외 작가",
+                Specialty.CERAMIC
+        );
+        Artist endedArtist = createArtist(
+                createUser("account-ended@test.com", "검색 만료 제외 작가", Role.ARTIST, "01095000009", null),
+                "계약 검색 만료 제외 작가",
+                Specialty.CERAMIC
+        );
+
+        createContract(rejectedArtist, shop, ContractStatus.REJECTED, ContractRequestType.NONE, null, null);
+        createContract(terminatedArtist, shop, ContractStatus.TERMINATED, ContractRequestType.NONE, null, null);
+        createContract(otherShopContractArtist, otherShop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+        createContract(pendingArtist, shop, ContractStatus.PENDING, ContractRequestType.EXTENSION, null, null);
+        createContract(approvedArtist, shop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+        createContract(endedArtist, shop, ContractStatus.ENDED, ContractRequestType.NONE, null, null);
+        flushAndClear();
+
+        var rows = contractRepository.searchArtistAccountRows(
+                shop.getShopId(),
+                Role.ARTIST,
+                UserStatus.ACTIVE,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                "%계약 검색%",
+                PageRequest.of(0, 10)
+        );
+
+        assertThat(rows).extracting("artistName")
+                .contains(
+                        "계약 검색 가능 작가",
+                        "계약 검색 거절 이력 작가",
+                        "계약 검색 해지 이력 작가",
+                        "계약 검색 다른샵 계약 작가"
+                )
+                .doesNotContain(
+                        "계약 검색 대기 제외 작가",
+                        "계약 검색 승인 제외 작가",
+                        "계약 검색 만료 제외 작가"
+                );
+        assertThat(findAccountSearchRow(rows, "계약 검색 가능 작가").getArtistId())
+                .isEqualTo(eligibleArtist.getId());
+    }
+
     private InventoryFixture createInventoryFixture() {
         User shopUser = createUser(
                 "postman-shop@test.com",
@@ -611,6 +773,13 @@ class ContractProductRepositoryTest {
     }
 
     private ArtistSuggestionRow findSuggestionRow(List<ArtistSuggestionRow> rows, String artistName) {
+        return rows.stream()
+                .filter(row -> artistName.equals(row.getArtistName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private ArtistAccountSearchRow findAccountSearchRow(List<ArtistAccountSearchRow> rows, String artistName) {
         return rows.stream()
                 .filter(row -> artistName.equals(row.getArtistName()))
                 .findFirst()

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
+import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
@@ -11,6 +12,7 @@ import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResp
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
@@ -156,6 +158,43 @@ class ContractServiceTest {
         assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 추천 작가");
         assertThat(response.getItems().get(0).getArtistImageUrl()).isEqualTo("https://image.test/suggested.png");
         assertThat(response.getItems().get(0).getInstagramId()).isEqualTo("suggested_artist");
+    }
+
+    @Test
+    @DisplayName("계약서 발송용 작가 계정을 검색한다")
+    void givenKeyword_whenSearchArtistAccounts_thenReturnMatchedArtistAccounts() {
+        Shop shop = shopWithId(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.searchArtistAccountRows(
+                SHOP_ID,
+                Role.ARTIST,
+                UserStatus.ACTIVE,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                "%postman%",
+                org.springframework.data.domain.PageRequest.of(0, 10)
+        )).willReturn(List.of(artistAccountSearchRow(ARTIST_ID, USER_ID + 100, "Postman 검색 작가")));
+
+        ArtistAccountSearchResponse response = contractService.searchArtistAccounts(USER_ID, " Postman ");
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getArtistId()).isEqualTo(ARTIST_ID);
+        assertThat(response.getItems().get(0).getUserId()).isEqualTo(USER_ID + 100);
+        assertThat(response.getItems().get(0).getUserName()).isEqualTo("Postman 검색 사용자");
+        assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 검색 작가");
+        assertThat(response.getItems().get(0).getEmail()).isEqualTo("searched-artist@test.com");
+    }
+
+    @Test
+    @DisplayName("계약서 발송용 작가 계정 검색어가 2자 미만이면 빈 목록을 반환한다")
+    void givenShortKeyword_whenSearchArtistAccounts_thenReturnEmptyItems() {
+        Shop shop = shopWithId(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+
+        ArtistAccountSearchResponse response = contractService.searchArtistAccounts(USER_ID, "a");
+
+        assertThat(response.getItems()).isEmpty();
     }
 
     @Test
@@ -453,6 +492,50 @@ class ContractServiceTest {
             @Override
             public String getInstagramId() {
                 return "suggested_artist";
+            }
+        };
+    }
+
+    private ArtistAccountSearchRow artistAccountSearchRow(Long artistId, Long userId, String artistName) {
+        return new ArtistAccountSearchRow() {
+            @Override
+            public Long getArtistId() {
+                return artistId;
+            }
+
+            @Override
+            public Long getUserId() {
+                return userId;
+            }
+
+            @Override
+            public String getName() {
+                return "Postman 검색 사용자";
+            }
+
+            @Override
+            public String getArtistName() {
+                return artistName;
+            }
+
+            @Override
+            public String getArtistImageUrl() {
+                return "https://image.test/searched.png";
+            }
+
+            @Override
+            public Specialty getSpecialty() {
+                return Specialty.CERAMIC;
+            }
+
+            @Override
+            public String getInstagramId() {
+                return "searched_artist";
+            }
+
+            @Override
+            public String getEmail() {
+                return "searched-artist@test.com";
             }
         };
     }


### PR DESCRIPTION
## 요약
  - 소품샵 회원이 계약서 발송 전 특정 작가 계정을 검색할 수 있는 API를 추가했습니다.

  ## 세부 내용
  - `GET /api/v1/contracts/artists/search` 추가
  - 작가 상호명, 사용자 이름, 이메일 기준 검색 지원
  - 활성 ARTIST 회원만 조회
  - 현재 소품샵과 PENDING/APPROVED/ENDED 계약이 있는 작가는 제외
  - 검색 결과에 `artistId`, `userId`, `userName`, `artistName`, `email` 등 반환

  ## 테스트
  - `ContractServiceTest`
  - `ContractProductRepositoryTest`
  - 실행: `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`