### PR TITLE
[FEAT] CURSOR 기반 랜덤 작가 목록 조회 기능 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistController.java
@@ -1,0 +1,31 @@
+package app.dearobjet.backend.domain.artist.controller;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistListResponse;
+import app.dearobjet.backend.domain.artist.service.ArtistService;
+import app.dearobjet.backend.global.api.ApiResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/artists")
+public class ArtistController {
+
+    private final ArtistService artistService;
+
+    @GetMapping
+    public ApiResponse<ArtistListResponse> getArtists(
+            @RequestParam(required = false) Long seed,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "15") @Min(1) @Max(50) int size
+    ) {
+        return ApiResponse.of(artistService.getArtists(seed, cursor, size));
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistListResponse.java
@@ -1,0 +1,11 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import java.util.List;
+
+public record ArtistListResponse(
+        List<ArtistResponse> artists,
+        Long seed,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistResponse.java
@@ -1,0 +1,17 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+
+public record ArtistResponse(
+        Long artistId,
+        String profileUrl,
+        String name
+) {
+    public static ArtistResponse from(Artist artist) {
+        return new ArtistResponse(
+                artist.getId(),
+                artist.getUser().getProfileUrl(),
+                artist.getUser().getName()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistService.java
@@ -1,0 +1,8 @@
+package app.dearobjet.backend.domain.artist.service;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistListResponse;
+
+public interface ArtistService {
+
+    ArtistListResponse getArtists(Long seed, Long cursor, int size);
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistServiceImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistServiceImpl.java
@@ -1,5 +1,5 @@
 package app.dearobjet.backend.domain.artist.service;
-d
+
 import app.dearobjet.backend.domain.artist.dto.ArtistResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistListResponse;
 import app.dearobjet.backend.domain.artist.entity.Artist;

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistServiceImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistServiceImpl.java
@@ -1,0 +1,50 @@
+package app.dearobjet.backend.domain.artist.service;
+d
+import app.dearobjet.backend.domain.artist.dto.ArtistResponse;
+import app.dearobjet.backend.domain.artist.dto.ArtistListResponse;
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.artist.support.ArtistRandomOrder;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistServiceImpl implements ArtistService {
+
+    private final ArtistRepository artistRepository;
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public ArtistListResponse getArtists(Long seed, Long cursor, int size) {
+        if (cursor != null && seed == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "cursor 요청에는 seed가 필요합니다.");
+        }
+
+        long resolvedSeed = seed == null
+                ? ArtistRandomOrder.generateSeed()
+                : ArtistRandomOrder.normalizeSeed(seed);
+
+        List<Artist> artists = artistRepository.findRandomArtists(resolvedSeed, cursor, size + 1);
+        boolean hasNext = artists.size() > size;
+
+        if (hasNext) {
+            artists = artists.subList(0, size);
+        }
+
+        Long nextCursor = hasNext && !artists.isEmpty()
+                ? artists.get(artists.size() - 1).getId()
+                : null;
+
+        List<ArtistResponse> artistResponses = artists.stream()
+                .map(ArtistResponse::from)
+                .toList();
+
+        return new ArtistListResponse(artistResponses, resolvedSeed, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/support/ArtistRandomOrder.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/support/ArtistRandomOrder.java
@@ -4,21 +4,72 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public final class ArtistRandomOrder {
 
-    public static final long MULTIPLIER = 48_271L;
-    public static final long PRIME = 2_147_483_647L;
+    public static final long ORDER_MODULUS = 10_007L;
+
+    private static final long SEED_BOUND = 2_147_483_647L;
+    private static final long LCG_MULTIPLIER = 48_271L;
+    private static final long LCG_INCREMENT = 12_820_163L;
 
     private ArtistRandomOrder() {
     }
 
     public static long generateSeed() {
-        return ThreadLocalRandom.current().nextLong(0, PRIME);
+        return ThreadLocalRandom.current().nextLong(SEED_BOUND);
     }
 
     public static long normalizeSeed(long seed) {
-        return Math.floorMod(seed, PRIME);
+        return Math.floorMod(seed, SEED_BOUND);
+    }
+
+    public static OrderSpec createOrderSpec(long seed) {
+        long normalizedSeed = normalizeSeed(seed);
+        long state1 = nextState(normalizedSeed);
+        long state2 = nextState(state1);
+        long state3 = nextState(state2);
+
+        return new OrderSpec(
+                (state1 % (ORDER_MODULUS - 1)) + 1,
+                (state2 % (ORDER_MODULUS - 1)) + 1,
+                state3 % ORDER_MODULUS
+        );
     }
 
     public static long calculateOrderKey(long seed, long artistId) {
-        return Math.floorMod((artistId * MULTIPLIER) + normalizeSeed(seed), PRIME);
+        OrderSpec orderSpec = createOrderSpec(seed);
+
+        return calculatePolynomialKey(
+                artistId,
+                ORDER_MODULUS,
+                orderSpec.quadratic(),
+                orderSpec.linear(),
+                orderSpec.offset()
+        );
+    }
+
+    private static long nextState(long state) {
+        return Math.floorMod((state * LCG_MULTIPLIER) + LCG_INCREMENT, SEED_BOUND);
+    }
+
+    private static long calculatePolynomialKey(
+            long artistId,
+            long modulus,
+            long quadratic,
+            long linear,
+            long offset
+    ) {
+        long idInModulus = Math.floorMod(artistId, modulus);
+        long squaredTerm = (idInModulus * idInModulus) % modulus;
+
+        return Math.floorMod(
+                (squaredTerm * quadratic) + (idInModulus * linear) + offset,
+                modulus
+        );
+    }
+
+    public record OrderSpec(
+            long quadratic,
+            long linear,
+            long offset
+    ) {
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/artist/support/ArtistRandomOrder.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/support/ArtistRandomOrder.java
@@ -1,0 +1,24 @@
+package app.dearobjet.backend.domain.artist.support;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class ArtistRandomOrder {
+
+    public static final long MULTIPLIER = 48_271L;
+    public static final long PRIME = 2_147_483_647L;
+
+    private ArtistRandomOrder() {
+    }
+
+    public static long generateSeed() {
+        return ThreadLocalRandom.current().nextLong(0, PRIME);
+    }
+
+    public static long normalizeSeed(long seed) {
+        return Math.floorMod(seed, PRIME);
+    }
+
+    public static long calculateOrderKey(long seed, long artistId) {
+        return Math.floorMod((artistId * MULTIPLIER) + normalizeSeed(seed), PRIME);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepository.java
@@ -5,7 +5,7 @@ import app.dearobjet.backend.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ArtistRepository extends JpaRepository<Artist, Long> {
+public interface ArtistRepository extends JpaRepository<Artist, Long>, ArtistRepositoryCustom {
 
     Optional<Artist> findByUser(User user);
 

--- a/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryCustom.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryCustom.java
@@ -1,0 +1,9 @@
+package app.dearobjet.backend.domain.user.repository;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import java.util.List;
+
+public interface ArtistRepositoryCustom {
+
+    List<Artist> findRandomArtists(long seed, Long cursorArtistId, int limit);
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryImpl.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.user.repository;
 
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.artist.support.ArtistRandomOrder;
+import app.dearobjet.backend.domain.artist.support.ArtistRandomOrder.OrderSpec;
 import app.dearobjet.backend.domain.user.enums.UserStatus;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -12,14 +13,21 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
 
-    private static final String ORDER_EXPRESSION =
-            "MOD((a.id * :multiplier) + :seed, :prime)";
+    private static final String ORDER_EXPRESSION = """
+            MOD(
+                (MOD(a.id, :orderModulus) * MOD(a.id, :orderModulus) * :quadratic)
+                + (MOD(a.id, :orderModulus) * :linear)
+                + :offset,
+                :orderModulus
+            )
+            """;
 
     @PersistenceContext
     private EntityManager entityManager;
 
     @Override
     public List<Artist> findRandomArtists(long seed, Long cursorArtistId, int limit) {
+        OrderSpec orderSpec = ArtistRandomOrder.createOrderSpec(seed);
         StringBuilder jpql = new StringBuilder("""
                 select a
                 from Artist a
@@ -45,11 +53,9 @@ public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
                 .append(ORDER_EXPRESSION)
                 .append(" asc, a.id asc");
 
-        TypedQuery<Artist> query = entityManager.createQuery(jpql.toString(), Artist.class)
-                .setParameter("userStatus", UserStatus.ACTIVE)
-                .setParameter("seed", ArtistRandomOrder.normalizeSeed(seed))
-                .setParameter("multiplier", ArtistRandomOrder.MULTIPLIER)
-                .setParameter("prime", ArtistRandomOrder.PRIME)
+        TypedQuery<Artist> query = entityManager.createQuery(jpql.toString(), Artist.class);
+        applyOrderParameters(query, orderSpec);
+        query.setParameter("userStatus", UserStatus.ACTIVE)
                 .setMaxResults(limit);
 
         if (cursorArtistId != null) {
@@ -58,5 +64,12 @@ public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
         }
 
         return query.getResultList();
+    }
+
+    private void applyOrderParameters(TypedQuery<Artist> query, OrderSpec orderSpec) {
+        query.setParameter("orderModulus", ArtistRandomOrder.ORDER_MODULUS);
+        query.setParameter("quadratic", orderSpec.quadratic());
+        query.setParameter("linear", orderSpec.linear());
+        query.setParameter("offset", orderSpec.offset());
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryImpl.java
@@ -1,0 +1,62 @@
+package app.dearobjet.backend.domain.user.repository;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.artist.support.ArtistRandomOrder;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ArtistRepositoryImpl implements ArtistRepositoryCustom {
+
+    private static final String ORDER_EXPRESSION =
+            "MOD((a.id * :multiplier) + :seed, :prime)";
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public List<Artist> findRandomArtists(long seed, Long cursorArtistId, int limit) {
+        StringBuilder jpql = new StringBuilder("""
+                select a
+                from Artist a
+                join fetch a.user u
+                where u.userStatus = :userStatus
+                """);
+
+        if (cursorArtistId != null) {
+            jpql.append("""
+                     and (
+                        """).append(ORDER_EXPRESSION).append("""
+                         > :cursorOrderKey
+                         or (
+                            """).append(ORDER_EXPRESSION).append("""
+                             = :cursorOrderKey
+                             and a.id > :cursorArtistId
+                         )
+                     )
+                    """);
+        }
+
+        jpql.append(" order by ")
+                .append(ORDER_EXPRESSION)
+                .append(" asc, a.id asc");
+
+        TypedQuery<Artist> query = entityManager.createQuery(jpql.toString(), Artist.class)
+                .setParameter("userStatus", UserStatus.ACTIVE)
+                .setParameter("seed", ArtistRandomOrder.normalizeSeed(seed))
+                .setParameter("multiplier", ArtistRandomOrder.MULTIPLIER)
+                .setParameter("prime", ArtistRandomOrder.PRIME)
+                .setMaxResults(limit);
+
+        if (cursorArtistId != null) {
+            query.setParameter("cursorArtistId", cursorArtistId);
+            query.setParameter("cursorOrderKey", ArtistRandomOrder.calculateOrderKey(seed, cursorArtistId));
+        }
+
+        return query.getResultList();
+    }
+}

--- a/src/test/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryImplTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/user/repository/ArtistRepositoryImplTest.java
@@ -1,0 +1,126 @@
+package app.dearobjet.backend.domain.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.artist.support.ArtistRandomOrder;
+import app.dearobjet.backend.domain.user.entity.BusinessProfile;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.BusinessCategory;
+import app.dearobjet.backend.domain.user.enums.BusinessType;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.global.common.config.JpaConfig;
+import jakarta.persistence.EntityManager;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+class ArtistRepositoryImplTest {
+
+    private static final BusinessType DEFAULT_BUSINESS_TYPE = BusinessType.WHOLESALE_RETAIL;
+    private static final BusinessCategory DEFAULT_BUSINESS_CATEGORY = BusinessCategory.CRAFT_RETAIL;
+
+    @Autowired
+    private ArtistRepository artistRepository;
+
+    @Autowired
+    private BusinessProfileRepository businessProfileRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("seed 기반 정렬 키와 커서 페이징을 일관되게 반환한다")
+    void givenSeedAndCursor_whenFindRandomArtists_thenReturnDeterministicPages() {
+        List<Artist> activeArtists = IntStream.rangeClosed(1, 5)
+                .mapToObj(index -> createArtist(index, UserStatus.ACTIVE))
+                .toList();
+        Artist inactiveArtist = createArtist(99, UserStatus.INACTIVE);
+        flushAndClear();
+
+        long seed = 123_456L;
+        List<Long> expectedOrder = activeArtists.stream()
+                .map(Artist::getId)
+                .sorted(Comparator
+                        .comparingLong((Long artistId) -> ArtistRandomOrder.calculateOrderKey(seed, artistId))
+                        .thenComparingLong(Long::longValue))
+                .toList();
+
+        List<Artist> firstPage = artistRepository.findRandomArtists(seed, null, 3);
+        List<Artist> secondPage = artistRepository.findRandomArtists(seed, firstPage.get(2).getId(), 3);
+
+        assertThat(firstPage).extracting(Artist::getId)
+                .containsExactlyElementsOf(expectedOrder.subList(0, 3));
+        assertThat(secondPage).extracting(Artist::getId)
+                .containsExactlyElementsOf(expectedOrder.subList(3, expectedOrder.size()));
+        assertThat(firstPage).extracting(Artist::getId).doesNotContain(inactiveArtist.getId());
+        assertThat(secondPage).extracting(Artist::getId).doesNotContain(inactiveArtist.getId());
+    }
+
+    @Test
+    @DisplayName("seed가 바뀌면 작가 노출 순서가 달라진다")
+    void givenDifferentSeeds_whenFindRandomArtists_thenReturnDifferentOrders() {
+        IntStream.rangeClosed(1, 8)
+                .forEach(index -> createArtist(index, UserStatus.ACTIVE));
+        flushAndClear();
+
+        List<Long> firstOrder = artistRepository.findRandomArtists(0L, null, 8).stream()
+                .map(Artist::getId)
+                .toList();
+        List<Long> secondOrder = artistRepository.findRandomArtists(1L, null, 8).stream()
+                .map(Artist::getId)
+                .toList();
+
+        assertThat(firstOrder).hasSize(8);
+        assertThat(secondOrder).hasSize(8);
+        assertThat(firstOrder).isNotEqualTo(secondOrder);
+    }
+
+    private Artist createArtist(int index, UserStatus userStatus) {
+        User user = userRepository.save(User.builder()
+                .email("artist" + index + "@test.com")
+                .name("Artist " + index)
+                .phoneNumber("0101000" + String.format("%04d", index))
+                .profileUrl("https://image.test/artist-" + index + ".png")
+                .role(Role.ARTIST)
+                .userStatus(userStatus)
+                .build());
+
+        BusinessProfile businessProfile = businessProfileRepository.save(BusinessProfile.builder()
+                .user(user)
+                .businessType(DEFAULT_BUSINESS_TYPE)
+                .businessNumber("ART-" + index)
+                .businessName("Artist Studio " + index)
+                .ownerName(user.getName())
+                .businessAddress("서울시 성수동 테스트로 " + index)
+                .businessLicenseUrl("https://image.test/license-" + index + ".png")
+                .businessCategory(DEFAULT_BUSINESS_CATEGORY)
+                .specialty(Specialty.values()[(index - 1) % Specialty.values().length])
+                .reviewDataAgreement(Boolean.TRUE)
+                .build());
+
+        return artistRepository.save(Artist.builder()
+                .user(user)
+                .businessProfile(businessProfile)
+                .build());
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR번호} [{이슈번호}]

## **⚡ Content**

- CURSOR 기반 랜덤 무한 스크롤 구현

## **📆 TBD**

- 랜덤을 위한 공식 개선

## **🌟 Point**

- 최초 요청 시 서버가 랜덤 `seed`를 생성해 응답합니다.
- 같은 `seed`를 사용하면 중복 없이 동일한 랜덤 순서로 작가를 조회할 수 있습니다.
- `cursor`를 전달하면 다음 페이지를 조회할 수 있습니다.
- 다음 페이지 존재 여부는 `hasNext`로 판단하며, 다음 요청에는 `nextCursor`에 있는 값을 cursor에 넣어 사용합니다.

## ❓ Question

- 없음.