### PR TITLE
feat: 작가 입점처 리스트 및 계약 상태변경 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -12,6 +12,9 @@ import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.security.CustomUserDetails;
@@ -50,6 +53,14 @@ public class ContractController {
         return ApiResponse.of(contractService.getManagedArtists(resolveUserId(userDetails, userId)));
     }
 
+    @GetMapping("/shops")
+    public ApiResponse<ManagedShopContractListResponse> getManagedShops(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(contractService.getManagedShops(resolveUserId(userDetails, userId)));
+    }
+
     @GetMapping("/artists/suggestions")
     public ApiResponse<ArtistSuggestionListResponse> getArtistSuggestions(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -75,6 +86,62 @@ public class ContractController {
     ) {
         return ApiResponse.of(
                 contractService.getManagedArtistContract(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
+
+    @GetMapping("/shops/{contractId}")
+    public ApiResponse<ManagedShopContractDetailResponse> getManagedShopContract(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.getManagedShopContract(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
+
+    @PatchMapping("/shops/{contractId}/extension-request")
+    public ApiResponse<ManagedShopContractActionResultResponse> requestManagedShopContractExtension(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.requestManagedShopContractExtension(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
+
+    @PatchMapping("/shops/{contractId}/release-request")
+    public ApiResponse<ManagedShopContractActionResultResponse> requestManagedShopContractRelease(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.requestManagedShopContractRelease(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
+
+    @PatchMapping("/shops/{contractId}/release-cancellation")
+    public ApiResponse<ManagedShopContractActionResultResponse> cancelManagedShopContractRelease(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.cancelManagedShopContractRelease(
                         resolveUserId(userDetails, userId),
                         contractId
                 )

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -4,6 +4,7 @@ import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchR
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
@@ -16,6 +17,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
 
 public interface ContractRepository extends JpaRepository<ShopArtistContract, Long> {
 
@@ -126,6 +128,85 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             @Param("contractId") Long contractId,
             @Param("shopId") Long shopId,
             @Param("contractStatuses") List<ContractStatus> contractStatuses
+    );
+
+    @Query("""
+            select c.shopArtistContractsId as contractId,
+                   s.shopId as shopId,
+                   bp.businessName as shopName,
+                   c.contractStartDate as contractStartDate,
+                   c.contractEndDate as contractEndDate,
+                   c.contractStatus as contractStatus,
+                   c.contractRequestType as contractRequestType,
+                   c.terminatedAt as terminatedAt
+            from ShopArtistContract c
+            join c.shop s
+            join s.businessProfile bp
+            where c.artist.id = :artistId
+              and (
+                  c.contractStatus in :contractStatuses
+                  or (
+                      c.contractStatus = :terminatedStatus
+                      and (c.terminatedAt is null or c.terminatedAt > :terminatedVisibleAfter)
+                  )
+              )
+            order by case
+                        when c.contractStatus = :pendingStatus then 0
+                        when c.contractStatus = :approvedStatus then 1
+                        when c.contractStatus = :endedStatus then 2
+                        when c.contractStatus = :terminatedStatus then 3
+                        else 4
+                     end,
+                     c.shopArtistContractsId desc
+            """)
+    List<ManagedShopContractRow> findManagedShopRowsByArtistId(
+            @Param("artistId") Long artistId,
+            @Param("contractStatuses") List<ContractStatus> contractStatuses,
+            @Param("terminatedStatus") ContractStatus terminatedStatus,
+            @Param("terminatedVisibleAfter") LocalDateTime terminatedVisibleAfter,
+            @Param("pendingStatus") ContractStatus pendingStatus,
+            @Param("approvedStatus") ContractStatus approvedStatus,
+            @Param("endedStatus") ContractStatus endedStatus
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
+            join fetch c.artist a
+            join fetch a.businessProfile
+            join fetch c.shop s
+            join fetch s.businessProfile
+            where c.shopArtistContractsId = :contractId
+              and c.artist.id = :artistId
+              and (
+                  c.contractStatus in :contractStatuses
+                  or (
+                      c.contractStatus = :terminatedStatus
+                      and (c.terminatedAt is null or c.terminatedAt > :terminatedVisibleAfter)
+                  )
+              )
+            """)
+    Optional<ShopArtistContract> findManagedShopContractByIdAndArtistId(
+            @Param("contractId") Long contractId,
+            @Param("artistId") Long artistId,
+            @Param("contractStatuses") List<ContractStatus> contractStatuses,
+            @Param("terminatedStatus") ContractStatus terminatedStatus,
+            @Param("terminatedVisibleAfter") LocalDateTime terminatedVisibleAfter
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
+            join fetch c.artist a
+            join fetch a.businessProfile
+            join fetch c.shop s
+            join fetch s.businessProfile
+            where c.shopArtistContractsId = :contractId
+              and c.artist.id = :artistId
+            """)
+    Optional<ShopArtistContract> findContractByIdAndArtistId(
+            @Param("contractId") Long contractId,
+            @Param("artistId") Long artistId
     );
 
     @Query("""

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -12,6 +12,9 @@ import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
@@ -23,9 +26,11 @@ import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
 import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
 import app.dearobjet.backend.domain.shop.entity.Shop;
+import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
@@ -62,10 +67,17 @@ public class ContractService {
             ContractStatus.ENDED
     );
 
+    private static final List<ContractStatus> MANAGED_SHOP_CONTRACT_STATUSES = List.of(
+            ContractStatus.PENDING,
+            ContractStatus.APPROVED,
+            ContractStatus.ENDED
+    );
+
     private final ContractRepository contractRepository;
     private final ContractProductRepository contractProductRepository;
     private final ContractProductStockMovementRepository contractProductStockMovementRepository;
     private final ShopRepository shopRepository;
+    private final ArtistRepository artistRepository;
 
     @Transactional(readOnly = true)
     public ContractApplicationCountResponse getPendingApplicationCount(Long userId) {
@@ -150,6 +162,96 @@ public class ContractService {
         return ManagedArtistContractDetailResponse.from(contract);
     }
 
+    @Transactional(readOnly = true)
+    public ManagedShopContractListResponse getManagedShops(Long userId) {
+        Artist artist = getArtistByUserId(userId);
+        LocalDate today = LocalDate.now();
+
+        return ManagedShopContractListResponse.from(
+                contractRepository.findManagedShopRowsByArtistId(
+                        artist.getId(),
+                        MANAGED_SHOP_CONTRACT_STATUSES,
+                        ContractStatus.TERMINATED,
+                        LocalDateTime.now().minusDays(TERMINATION_GRACE_PERIOD_DAYS),
+                        ContractStatus.PENDING,
+                        ContractStatus.APPROVED,
+                        ContractStatus.ENDED
+                ),
+                today
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ManagedShopContractDetailResponse getManagedShopContract(Long userId, Long contractId) {
+        Artist artist = getArtistByUserId(userId);
+
+        ShopArtistContract contract = contractRepository.findManagedShopContractByIdAndArtistId(
+                        contractId,
+                        artist.getId(),
+                        MANAGED_SHOP_CONTRACT_STATUSES,
+                        ContractStatus.TERMINATED,
+                        LocalDateTime.now().minusDays(TERMINATION_GRACE_PERIOD_DAYS)
+                )
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "계약서 정보를 찾을 수 없습니다."
+                ));
+
+        return ManagedShopContractDetailResponse.from(contract);
+    }
+
+    @Transactional
+    public ManagedShopContractActionResultResponse requestManagedShopContractExtension(
+            Long userId,
+            Long contractId
+    ) {
+        ShopArtistContract contract = getArtistOwnedContract(userId, contractId);
+        if (!isArtistRenewable(contract, LocalDate.now())) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "계약연장 신청이 가능한 계약이 아닙니다."
+            );
+        }
+
+        contract.requestExtension();
+        return ManagedShopContractActionResultResponse.from(contract);
+    }
+
+    @Transactional
+    public ManagedShopContractActionResultResponse requestManagedShopContractRelease(
+            Long userId,
+            Long contractId
+    ) {
+        ShopArtistContract contract = getArtistOwnedContract(userId, contractId);
+        if (!isArtistRenewable(contract, LocalDate.now())) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "해제신청이 가능한 계약이 아닙니다."
+            );
+        }
+
+        contract.requestRelease();
+        return ManagedShopContractActionResultResponse.from(contract);
+    }
+
+    @Transactional
+    public ManagedShopContractActionResultResponse cancelManagedShopContractRelease(
+            Long userId,
+            Long contractId
+    ) {
+        ShopArtistContract contract = getArtistOwnedContract(userId, contractId);
+        if (contract.getContractStatus() != ContractStatus.PENDING
+                || contract.getContractRequestType() != ContractRequestType.RELEASE) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "해제취소가 가능한 계약이 아닙니다."
+            );
+        }
+
+        contract.cancelReleaseRequest();
+        return ManagedShopContractActionResultResponse.from(contract);
+    }
+
     @Transactional
     public ContractTerminationResponse terminateManagedArtistContract(Long userId, Long contractId) {
         Shop shop = getShopByUserId(userId);
@@ -171,7 +273,7 @@ public class ContractService {
             );
         }
 
-        contract.terminate();
+        contract.terminate(LocalDateTime.now());
         return ContractTerminationResponse.from(contract);
     }
 
@@ -259,6 +361,21 @@ public class ContractService {
                 .orElseThrow(() -> new IllegalArgumentException("Shop not found for user: " + userId));
     }
 
+    private Artist getArtistByUserId(Long userId) {
+        return artistRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Artist not found for user: " + userId));
+    }
+
+    private ShopArtistContract getArtistOwnedContract(Long userId, Long contractId) {
+        Artist artist = getArtistByUserId(userId);
+
+        return contractRepository.findContractByIdAndArtistId(contractId, artist.getId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "계약서 정보를 찾을 수 없습니다."
+                ));
+    }
+
     private ShopArtistContract getApprovedContract(Long contractId, Long shopId) {
         return contractRepository.findApprovedByIdAndShopId(contractId, shopId, ContractStatus.APPROVED)
                 .orElseThrow(() -> new EntityNotFoundException(
@@ -280,6 +397,18 @@ public class ContractService {
 
         LocalDate endDate = contract.getContractEndDate();
         return endDate != null && !today.isBefore(endDate.plusDays(TERMINATION_GRACE_PERIOD_DAYS));
+    }
+
+    private boolean isArtistRenewable(ShopArtistContract contract, LocalDate today) {
+        if (contract.getContractStatus() == ContractStatus.ENDED) {
+            return true;
+        }
+        if (contract.getContractStatus() != ContractStatus.APPROVED) {
+            return false;
+        }
+
+        LocalDate endDate = contract.getContractEndDate();
+        return endDate != null && today != null && today.isAfter(endDate);
     }
 
     private String normalizeSearchKeyword(String keyword) {

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractActionResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractActionResponse.java
@@ -1,0 +1,18 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedShopContractActionResponse {
+
+    private final String code;
+    private final String label;
+    private final Boolean enabled;
+
+    public static ManagedShopContractActionResponse of(String code, String label, boolean enabled) {
+        return new ManagedShopContractActionResponse(code, label, enabled);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractActionResultResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractActionResultResponse.java
@@ -1,0 +1,25 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedShopContractActionResultResponse {
+
+    private final Long contractId;
+    private final ContractStatus contractStatus;
+    private final ContractRequestType contractRequestType;
+
+    public static ManagedShopContractActionResultResponse from(ShopArtistContract contract) {
+        return new ManagedShopContractActionResultResponse(
+                contract.getShopArtistContractsId(),
+                contract.getContractStatus(),
+                contract.getContractRequestType()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractDetailResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractDetailResponse.java
@@ -1,0 +1,47 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedShopContractDetailResponse {
+
+    private final Long contractId;
+    private final Long shopId;
+    private final String shopName;
+    private final Long artistId;
+    private final String artistName;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final ContractStatus contractStatus;
+    private final ContractRequestType contractRequestType;
+    private final CommissionType commissionType;
+    private final BigDecimal commissionValue;
+    private final String memo;
+
+    public static ManagedShopContractDetailResponse from(ShopArtistContract contract) {
+        return new ManagedShopContractDetailResponse(
+                contract.getShopArtistContractsId(),
+                contract.getShop().getShopId(),
+                contract.getShop().getBusinessName(),
+                contract.getArtist().getId(),
+                contract.getArtist().getBusinessProfile().getBusinessName(),
+                contract.getContractStartDate(),
+                contract.getContractEndDate(),
+                contract.getContractStatus(),
+                contract.getContractRequestType(),
+                contract.getCommissionType(),
+                contract.getCommissionValue(),
+                contract.getMemo() == null ? "" : contract.getMemo()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractItemResponse.java
@@ -1,0 +1,103 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedShopContractItemResponse {
+
+    private final Long contractId;
+    private final Long shopId;
+    private final String shopName;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final String statusCode;
+    private final String statusLabel;
+    private final Boolean statusDisabled;
+    private final List<ManagedShopContractActionResponse> actions;
+    private final Boolean detailAvailable;
+
+    public static ManagedShopContractItemResponse from(ManagedShopContractRow row, LocalDate today) {
+        Display display = Display.from(row, today);
+
+        return new ManagedShopContractItemResponse(
+                row.getContractId(),
+                row.getShopId(),
+                row.getShopName(),
+                row.getContractStartDate(),
+                row.getContractEndDate(),
+                display.statusCode(),
+                display.statusLabel(),
+                display.statusDisabled(),
+                display.actions(),
+                true
+        );
+    }
+
+    private record Display(
+            String statusCode,
+            String statusLabel,
+            Boolean statusDisabled,
+            List<ManagedShopContractActionResponse> actions
+    ) {
+        private static Display from(ManagedShopContractRow row, LocalDate today) {
+            if (row.getContractStatus() == ContractStatus.TERMINATED) {
+                return new Display("EXPIRED", "계약만료", false, List.of());
+            }
+            if (row.getContractStatus() == ContractStatus.PENDING
+                    && row.getContractRequestType() == ContractRequestType.RELEASE) {
+                return new Display(
+                        "EXTENSION_AVAILABLE",
+                        "계약 연장",
+                        true,
+                        List.of(ManagedShopContractActionResponse.of("RELEASE_CANCEL", "해제취소", true))
+                );
+            }
+            if (row.getContractStatus() == ContractStatus.PENDING) {
+                return new Display(
+                        "PENDING",
+                        "계약 대기",
+                        false,
+                        List.of(ManagedShopContractActionResponse.of("WAITING_APPROVAL", "계약승인", false))
+                );
+            }
+            if (row.getContractStatus() == ContractStatus.ENDED || isExpired(row, today)) {
+                return new Display(
+                        "EXTENSION_AVAILABLE",
+                        "계약 연장",
+                        false,
+                        List.of(
+                                ManagedShopContractActionResponse.of("EXTENSION_REQUEST", "계약연장", true),
+                                ManagedShopContractActionResponse.of("RELEASE_REQUEST", "해제신청", true)
+                        )
+                );
+            }
+            if (row.getContractStatus() == ContractStatus.APPROVED) {
+                return new Display(
+                        "COMPLETED",
+                        "계약 완료",
+                        false,
+                        List.of(ManagedShopContractActionResponse.of("CONTRACT_APPROVED", "계약승인", false))
+                );
+            }
+
+            return new Display("UNAVAILABLE", "표시 불가", true, List.of());
+        }
+
+        private static boolean isExpired(ManagedShopContractRow row, LocalDate today) {
+            LocalDate endDate = row.getContractEndDate();
+            return row.getContractStatus() == ContractStatus.APPROVED
+                    && endDate != null
+                    && today != null
+                    && today.isAfter(endDate);
+        }
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractListResponse.java
@@ -1,0 +1,24 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ManagedShopContractListResponse {
+
+    private final List<ManagedShopContractItemResponse> items;
+
+    public static ManagedShopContractListResponse from(List<ManagedShopContractRow> rows, LocalDate today) {
+        return new ManagedShopContractListResponse(
+                rows.stream()
+                        .map(row -> ManagedShopContractItemResponse.from(row, today))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedShopContractRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedShopContractRow.java
@@ -1,0 +1,18 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface ManagedShopContractRow {
+    Long getContractId();
+    Long getShopId();
+    String getShopName();
+    LocalDate getContractStartDate();
+    LocalDate getContractEndDate();
+    ContractStatus getContractStatus();
+    ContractRequestType getContractRequestType();
+    LocalDateTime getTerminatedAt();
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
@@ -76,6 +76,9 @@ public class ShopArtistContract extends BaseTimeEntity {
     @Column(name = "recent_inbound_confirmed_by_user_id")
     private Long recentInboundConfirmedByUserId;
 
+    @Column(name = "terminated_at")
+    private LocalDateTime terminatedAt;
+
     public void updateMemo(String memo) {
         this.memo = memo == null ? "" : memo;
     }
@@ -86,8 +89,28 @@ public class ShopArtistContract extends BaseTimeEntity {
         this.recentInboundConfirmedByUserId = null;
     }
 
-    public void terminate() {
+    public void terminate(LocalDateTime terminatedAt) {
         this.contractStatus = ContractStatus.TERMINATED;
+        this.contractRequestType = ContractRequestType.NONE;
+        this.terminatedAt = terminatedAt;
+    }
+
+    public void terminate() {
+        terminate(LocalDateTime.now());
+    }
+
+    public void requestExtension() {
+        this.contractStatus = ContractStatus.PENDING;
+        this.contractRequestType = ContractRequestType.EXTENSION;
+    }
+
+    public void requestRelease() {
+        this.contractStatus = ContractStatus.PENDING;
+        this.contractRequestType = ContractRequestType.RELEASE;
+    }
+
+    public void cancelReleaseRequest() {
+        this.contractStatus = ContractStatus.ENDED;
         this.contractRequestType = ContractRequestType.NONE;
     }
 

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -5,6 +5,7 @@ import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchR
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
@@ -536,6 +537,134 @@ class ContractProductRepositoryTest {
                 .isEqualTo(eligibleArtist.getId());
     }
 
+    @Test
+    @DisplayName("입점처 목록은 작가 소유 계약과 해지 후 14일 이내 계약만 반환한다")
+    void givenArtistContracts_whenQueryManagedShops_thenReturnOwnedVisibleContractsOnly() {
+        LocalDateTime now = LocalDateTime.of(2026, 5, 7, 10, 0);
+        User artistUser = createUser(
+                "managed-shop-list-artist@test.com",
+                "입점처 목록 작가",
+                Role.ARTIST,
+                "01096000001",
+                null
+        );
+        User otherArtistUser = createUser(
+                "managed-shop-list-other-artist@test.com",
+                "다른 입점처 목록 작가",
+                Role.ARTIST,
+                "01096000002",
+                null
+        );
+        Artist artist = createArtist(artistUser, "입점처 목록 작가", Specialty.CERAMIC);
+        Artist otherArtist = createArtist(otherArtistUser, "다른 입점처 목록 작가", Specialty.HANDMADE_CRAFT);
+
+        Shop pendingShop = createShop(
+                createUser("managed-shop-list-pending@test.com", "대기 소품샵", Role.SHOP, "01096000003", null),
+                "대기 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop approvedShop = createShop(
+                createUser("managed-shop-list-approved@test.com", "완료 소품샵", Role.SHOP, "01096000004", null),
+                "완료 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop endedShop = createShop(
+                createUser("managed-shop-list-ended@test.com", "연장 소품샵", Role.SHOP, "01096000005", null),
+                "연장 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop terminatedRecentShop = createShop(
+                createUser("managed-shop-list-terminated-recent@test.com", "최근 만료 소품샵", Role.SHOP, "01096000006", null),
+                "최근 만료 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop terminatedOldShop = createShop(
+                createUser("managed-shop-list-terminated-old@test.com", "오래된 만료 소품샵", Role.SHOP, "01096000007", null),
+                "오래된 만료 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop rejectedShop = createShop(
+                createUser("managed-shop-list-rejected@test.com", "거절 소품샵", Role.SHOP, "01096000008", null),
+                "거절 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop otherArtistShop = createShop(
+                createUser("managed-shop-list-other-owner@test.com", "타 작가 소품샵", Role.SHOP, "01096000009", null),
+                "타 작가 소품샵",
+                Specialty.LIVING_GOODS
+        );
+
+        ShopArtistContract pendingContract = createContract(
+                artist,
+                pendingShop,
+                ContractStatus.PENDING,
+                ContractRequestType.EXTENSION,
+                null,
+                null
+        );
+        ShopArtistContract approvedContract = createContract(
+                artist,
+                approvedShop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+        ShopArtistContract endedContract = createContract(
+                artist,
+                endedShop,
+                ContractStatus.ENDED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE.minusYears(1),
+                CONTRACT_END_DATE.minusYears(1)
+        );
+        ShopArtistContract terminatedRecentContract = createContract(
+                artist,
+                terminatedRecentShop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE.minusYears(1),
+                CONTRACT_END_DATE.minusYears(1)
+        );
+        terminatedRecentContract.terminate(now.minusDays(13));
+        ShopArtistContract terminatedOldContract = createContract(
+                artist,
+                terminatedOldShop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE.minusYears(1),
+                CONTRACT_END_DATE.minusYears(1)
+        );
+        terminatedOldContract.terminate(now.minusDays(15));
+        createContract(artist, rejectedShop, ContractStatus.REJECTED, ContractRequestType.NONE, null, null);
+        createContract(otherArtist, otherArtistShop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+        flushAndClear();
+
+        List<ManagedShopContractRow> rows = contractRepository.findManagedShopRowsByArtistId(
+                artist.getId(),
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                ContractStatus.TERMINATED,
+                now.minusDays(14),
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                ContractStatus.ENDED
+        );
+
+        assertThat(rows).extracting("contractId")
+                .contains(
+                        pendingContract.getShopArtistContractsId(),
+                        approvedContract.getShopArtistContractsId(),
+                        endedContract.getShopArtistContractsId(),
+                        terminatedRecentContract.getShopArtistContractsId()
+                )
+                .doesNotContain(terminatedOldContract.getShopArtistContractsId());
+        assertThat(rows).extracting("shopName")
+                .contains("대기 소품샵", "완료 소품샵", "연장 소품샵", "최근 만료 소품샵")
+                .doesNotContain("오래된 만료 소품샵", "거절 소품샵", "타 작가 소품샵");
+        assertThat(findManagedShopRow(rows, "최근 만료 소품샵").getTerminatedAt())
+                .isEqualTo(now.minusDays(13));
+    }
+
     private InventoryFixture createInventoryFixture() {
         User shopUser = createUser(
                 "postman-shop@test.com",
@@ -782,6 +911,13 @@ class ContractProductRepositoryTest {
     private ArtistAccountSearchRow findAccountSearchRow(List<ArtistAccountSearchRow> rows, String artistName) {
         return rows.stream()
                 .filter(row -> artistName.equals(row.getArtistName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private ManagedShopContractRow findManagedShopRow(List<ManagedShopContractRow> rows, String shopName) {
+        return rows.stream()
+                .filter(row -> shopName.equals(row.getShopName()))
                 .findFirst()
                 .orElseThrow();
     }

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -10,11 +10,15 @@ import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
+import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
@@ -32,6 +36,7 @@ import app.dearobjet.backend.domain.user.entity.User;
 import app.dearobjet.backend.domain.user.enums.Specialty;
 import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.InvalidInputException;
@@ -83,6 +88,9 @@ class ContractServiceTest {
 
     @Mock
     private ShopRepository shopRepository;
+
+    @Mock
+    private ArtistRepository artistRepository;
 
     @Test
     @DisplayName("재고관리 목록에서 계약 작가를 조회한다")
@@ -235,6 +243,146 @@ class ContractServiceTest {
         assertThat(response.getItems().get(3).getContractStatusLabel()).isEqualTo("계약 만료");
         assertThat(response.getItems().get(3).getNextAction().getCode()).isEqualTo("TERMINATE_CONTRACT");
         assertThat(response.getItems().get(3).getDetailAvailable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("입점처 목록에서 계약 완료, 계약 대기, 계약 연장, 계약만료 상태를 조회한다")
+    void givenArtistContracts_whenGetManagedShops_thenReturnShopRowsWithActions() {
+        Artist artist = artistWithId(ARTIST_ID);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(contractRepository.findManagedShopRowsByArtistId(
+                org.mockito.ArgumentMatchers.eq(ARTIST_ID),
+                org.mockito.ArgumentMatchers.eq(List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)),
+                org.mockito.ArgumentMatchers.eq(ContractStatus.TERMINATED),
+                org.mockito.ArgumentMatchers.any(LocalDateTime.class),
+                org.mockito.ArgumentMatchers.eq(ContractStatus.PENDING),
+                org.mockito.ArgumentMatchers.eq(ContractStatus.APPROVED),
+                org.mockito.ArgumentMatchers.eq(ContractStatus.ENDED)
+        )).willReturn(List.of(
+                managedShopRow(1L, ContractStatus.APPROVED, ContractRequestType.NONE, "계약 완료 소품샵"),
+                managedShopRow(2L, ContractStatus.PENDING, ContractRequestType.EXTENSION, "계약 대기 소품샵"),
+                managedShopRow(
+                        3L,
+                        ContractStatus.APPROVED,
+                        ContractRequestType.NONE,
+                        "계약 연장 소품샵",
+                        LocalDate.now().minusDays(1),
+                        null
+                ),
+                managedShopRow(4L, ContractStatus.PENDING, ContractRequestType.RELEASE, "해제 신청 소품샵"),
+                managedShopRow(5L, ContractStatus.TERMINATED, ContractRequestType.NONE, "계약만료 소품샵")
+        ));
+
+        ManagedShopContractListResponse response = contractService.getManagedShops(USER_ID);
+
+        assertThat(response.getItems()).hasSize(5);
+        assertThat(response.getItems().get(0).getStatusLabel()).isEqualTo("계약 완료");
+        assertThat(response.getItems().get(0).getActions().get(0).getLabel()).isEqualTo("계약승인");
+        assertThat(response.getItems().get(0).getActions().get(0).getEnabled()).isFalse();
+        assertThat(response.getItems().get(1).getStatusLabel()).isEqualTo("계약 대기");
+        assertThat(response.getItems().get(2).getStatusLabel()).isEqualTo("계약 연장");
+        assertThat(response.getItems().get(2).getActions()).extracting("code")
+                .containsExactly("EXTENSION_REQUEST", "RELEASE_REQUEST");
+        assertThat(response.getItems().get(3).getStatusLabel()).isEqualTo("계약 연장");
+        assertThat(response.getItems().get(3).getStatusDisabled()).isTrue();
+        assertThat(response.getItems().get(3).getActions().get(0).getLabel()).isEqualTo("해제취소");
+        assertThat(response.getItems().get(4).getStatusLabel()).isEqualTo("계약만료");
+    }
+
+    @Test
+    @DisplayName("입점처 계약서 상세를 조회한다")
+    void givenArtistOwnedContract_whenGetManagedShopContract_thenReturnDetail() {
+        Artist artist = artistWithId(ARTIST_ID);
+        ShopArtistContract contract = contractWithArtistAndShop(CONTRACT_ID, ContractStatus.APPROVED);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(contractRepository.findManagedShopContractByIdAndArtistId(
+                org.mockito.ArgumentMatchers.eq(CONTRACT_ID),
+                org.mockito.ArgumentMatchers.eq(ARTIST_ID),
+                org.mockito.ArgumentMatchers.eq(List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)),
+                org.mockito.ArgumentMatchers.eq(ContractStatus.TERMINATED),
+                org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+        )).willReturn(Optional.of(contract));
+
+        ManagedShopContractDetailResponse response = contractService.getManagedShopContract(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getShopId()).isEqualTo(SHOP_ID);
+        assertThat(response.getShopName()).isEqualTo("Postman 테스트 소품샵");
+        assertThat(response.getArtistId()).isEqualTo(ARTIST_ID);
+        assertThat(response.getArtistName()).isEqualTo("Postman 도자기 작가");
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("작가가 계약연장을 신청한다")
+    void givenRenewableContract_whenRequestManagedShopContractExtension_thenChangeToPendingExtension() {
+        ShopArtistContract contract = contractWithArtistAndShop(
+                CONTRACT_ID,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE.minusYears(1),
+                LocalDate.now().minusDays(1)
+        );
+        givenArtistOwnedContract(contract);
+
+        ManagedShopContractActionResultResponse response =
+                contractService.requestManagedShopContractExtension(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.PENDING);
+        assertThat(response.getContractRequestType()).isEqualTo(ContractRequestType.EXTENSION);
+        assertThat(contract.getContractStatus()).isEqualTo(ContractStatus.PENDING);
+        assertThat(contract.getContractRequestType()).isEqualTo(ContractRequestType.EXTENSION);
+    }
+
+    @Test
+    @DisplayName("작가가 해제신청을 한다")
+    void givenRenewableContract_whenRequestManagedShopContractRelease_thenChangeToPendingRelease() {
+        ShopArtistContract contract = contractWithArtistAndShop(
+                CONTRACT_ID,
+                ContractStatus.ENDED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE.minusYears(1),
+                CONTRACT_END_DATE.minusYears(1)
+        );
+        givenArtistOwnedContract(contract);
+
+        ManagedShopContractActionResultResponse response =
+                contractService.requestManagedShopContractRelease(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.PENDING);
+        assertThat(response.getContractRequestType()).isEqualTo(ContractRequestType.RELEASE);
+    }
+
+    @Test
+    @DisplayName("작가가 해제신청을 취소한다")
+    void givenReleaseRequestedContract_whenCancelManagedShopContractRelease_thenReturnEnded() {
+        ShopArtistContract contract = contractWithArtistAndShop(
+                CONTRACT_ID,
+                ContractStatus.PENDING,
+                ContractRequestType.RELEASE,
+                CONTRACT_START_DATE.minusYears(1),
+                CONTRACT_END_DATE.minusYears(1)
+        );
+        givenArtistOwnedContract(contract);
+
+        ManagedShopContractActionResultResponse response =
+                contractService.cancelManagedShopContractRelease(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.ENDED);
+        assertThat(response.getContractRequestType()).isEqualTo(ContractRequestType.NONE);
+    }
+
+    @Test
+    @DisplayName("계약 완료 상태에서는 작가가 해제신청할 수 없다")
+    void givenActiveApprovedContract_whenRequestManagedShopContractRelease_thenThrowException() {
+        ShopArtistContract contract = contractWithArtistAndShop(CONTRACT_ID, ContractStatus.APPROVED);
+        givenArtistOwnedContract(contract);
+
+        assertThatThrownBy(() -> contractService.requestManagedShopContractRelease(USER_ID, CONTRACT_ID))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessageContaining("해제신청이 가능한 계약이 아닙니다.");
     }
 
     @Test
@@ -592,6 +740,86 @@ class ContractServiceTest {
                 return requestType;
             }
         };
+    }
+
+    private ManagedShopContractRow managedShopRow(
+            Long contractId,
+            ContractStatus contractStatus,
+            ContractRequestType requestType,
+            String shopName
+    ) {
+        return managedShopRow(contractId, contractStatus, requestType, shopName, CONTRACT_END_DATE, null);
+    }
+
+    private ManagedShopContractRow managedShopRow(
+            Long contractId,
+            ContractStatus contractStatus,
+            ContractRequestType requestType,
+            String shopName,
+            LocalDate contractEndDate,
+            LocalDateTime terminatedAt
+    ) {
+        return new ManagedShopContractRow() {
+            @Override
+            public Long getContractId() {
+                return contractId;
+            }
+
+            @Override
+            public Long getShopId() {
+                return SHOP_ID + contractId;
+            }
+
+            @Override
+            public String getShopName() {
+                return shopName;
+            }
+
+            @Override
+            public LocalDate getContractStartDate() {
+                return CONTRACT_START_DATE;
+            }
+
+            @Override
+            public LocalDate getContractEndDate() {
+                return contractEndDate;
+            }
+
+            @Override
+            public ContractStatus getContractStatus() {
+                return contractStatus;
+            }
+
+            @Override
+            public ContractRequestType getContractRequestType() {
+                return requestType;
+            }
+
+            @Override
+            public LocalDateTime getTerminatedAt() {
+                return terminatedAt;
+            }
+        };
+    }
+
+    private Artist artistWithId(Long artistId) {
+        User artistUser = User.builder()
+                .id(USER_ID)
+                .build();
+        BusinessProfile businessProfile = BusinessProfile.builder()
+                .businessName("Postman 도자기 작가")
+                .build();
+        return Artist.builder()
+                .id(artistId)
+                .user(artistUser)
+                .businessProfile(businessProfile)
+                .build();
+    }
+
+    private void givenArtistOwnedContract(ShopArtistContract contract) {
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artistWithId(ARTIST_ID)));
+        given(contractRepository.findContractByIdAndArtistId(CONTRACT_ID, ARTIST_ID))
+                .willReturn(Optional.of(contract));
     }
 
     private Shop shopWithId(Long shopId) {


### PR DESCRIPTION
## 요약
  - 작가 기준 입점처 리스트/계약서 상세 조회 API를 추가했습니다.
  - 작가가 계약연장 신청, 해제신청, 해제취소를 수행할 수 있는 API를 추가했습니다.
  - 해지 완료 계약은 14일 동안 계약만료로 표시 후 리스트에서 제외되도록 처리했습니다.

  ## 변경 사항
  - `GET /api/v1/contracts/shops`
  - `GET /api/v1/contracts/shops/{contractId}`
  - `PATCH /api/v1/contracts/shops/{contractId}/extension-request`
  - `PATCH /api/v1/contracts/shops/{contractId}/release-request`
  - `PATCH /api/v1/contracts/shops/{contractId}/release-cancellation`
  - `ShopArtistContract.terminatedAt` 추가
  - 작가 화면 전용 상태/액션 응답 DTO 추가

  ## 테스트
  - `ContractServiceTest`
  - `ContractProductRepositoryTest`
  - 실행:
    `./gradlew test --tests
  "app.dearobjet.backend.domain.contract.ContractServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`