### PR TITLE
feat: 작가 품목 및 재고관리 API 구현

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistProductController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistProductController.java
@@ -1,0 +1,66 @@
+package app.dearobjet.backend.domain.artist.controller;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
+import app.dearobjet.backend.domain.artist.service.ArtistProductService;
+import app.dearobjet.backend.global.api.ApiResponse;
+import app.dearobjet.backend.global.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/artist/products")
+public class ArtistProductController {
+
+    private final ArtistProductService artistProductService;
+
+    @GetMapping
+    public ApiResponse<ArtistProductListResponse> getProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponse.of(artistProductService.getProducts(resolveUserId(userDetails, userId), page, size));
+    }
+
+    @PatchMapping("/stocks")
+    public ApiResponse<UpdateArtistProductStockResponse> updateStocks(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @Valid @RequestBody UpdateArtistProductStockRequest request
+    ) {
+        return ApiResponse.of(artistProductService.updateStocks(resolveUserId(userDetails, userId), request));
+    }
+
+    @DeleteMapping("/{productId}")
+    public ApiResponse<Void> deleteProduct(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long productId
+    ) {
+        artistProductService.deleteProduct(resolveUserId(userDetails, userId), productId);
+        return ApiResponse.of(null);
+    }
+
+    private Long resolveUserId(CustomUserDetails userDetails, Long userId) {
+        if (userDetails != null) {
+            return userDetails.getUserId();
+        }
+        if (userId != null) {
+            return userId;
+        }
+        throw new IllegalArgumentException("인증 정보가 없으면 userId 쿼리 파라미터가 필요합니다.");
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistProductItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistProductItemResponse.java
@@ -1,0 +1,33 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.shop.entity.Product;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistProductItemResponse {
+
+    private final Long productId;
+    private final String imageUrl;
+    private final String productName;
+    private final BigDecimal price;
+    private final Integer stockQuantity;
+    private final LocalDateTime registeredAt;
+    private final Long version;
+
+    public static ArtistProductItemResponse from(Product product) {
+        return new ArtistProductItemResponse(
+                product.getProductsId(),
+                product.getProductUrl(),
+                product.getProductName(),
+                product.getPrice(),
+                product.getStockQuantity(),
+                product.getCreatedAt(),
+                product.getVersion()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistProductListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistProductListResponse.java
@@ -1,0 +1,27 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.shop.entity.Product;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistProductListResponse {
+
+    private final List<ArtistProductItemResponse> items;
+    private final int page;
+    private final int totalPages;
+
+    public static ArtistProductListResponse from(Page<Product> productPage, int page) {
+        return new ArtistProductListResponse(
+                productPage.getContent().stream()
+                        .map(ArtistProductItemResponse::from)
+                        .toList(),
+                page,
+                productPage.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductStockRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductStockRequest.java
@@ -1,0 +1,32 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateArtistProductStockRequest {
+
+    @NotEmpty(message = "재고를 변경할 상품은 1개 이상이어야 합니다.")
+    private List<@Valid Item> items;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Item {
+
+        @NotNull(message = "상품 ID는 필수입니다.")
+        private Long productId;
+
+        @NotNull(message = "재고 수량은 필수입니다.")
+        @Min(value = 0, message = "재고 수량은 0 이상이어야 합니다.")
+        private Integer stockQuantity;
+
+        @NotNull(message = "상품 버전은 필수입니다.")
+        private Long version;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductStockResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductStockResponse.java
@@ -1,0 +1,22 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.shop.entity.Product;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateArtistProductStockResponse {
+
+    private final List<ArtistProductItemResponse> items;
+
+    public static UpdateArtistProductStockResponse from(List<Product> products) {
+        return new UpdateArtistProductStockResponse(
+                products.stream()
+                        .map(ArtistProductItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistProductService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistProductService.java
@@ -1,0 +1,138 @@
+package app.dearobjet.backend.domain.artist.service;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.shop.entity.Product;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
+import app.dearobjet.backend.domain.shop.repository.ProductRepository;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistProductService {
+
+    private static final int FIRST_PAGE = 1;
+    private static final int FIRST_PAGE_INDEX = 0;
+    private static final int MIN_PAGE_SIZE = 1;
+
+    private final ArtistRepository artistRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public ArtistProductListResponse getProducts(Long userId, int page, int size) {
+        validatePageSize(size);
+        Artist artist = getArtistByUserId(userId);
+        PageRequest pageRequest = PageRequest.of(
+                toPageIndex(page),
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "productsId"))
+        );
+
+        Page<Product> productPage = productRepository.findByArtistIdAndStatus(
+                artist.getId(),
+                ProductStatus.ACTIVE,
+                pageRequest
+        );
+
+        return ArtistProductListResponse.from(productPage, page);
+    }
+
+    @Transactional
+    public UpdateArtistProductStockResponse updateStocks(
+            Long userId,
+            UpdateArtistProductStockRequest request
+    ) {
+        Artist artist = getArtistByUserId(userId);
+        validateDuplicateProductIds(request);
+
+        List<Long> productIds = request.getItems().stream()
+                .map(UpdateArtistProductStockRequest.Item::getProductId)
+                .toList();
+        Map<Long, Product> productMap = productRepository.findByProductsIdInAndArtistIdAndStatus(
+                        productIds,
+                        artist.getId(),
+                        ProductStatus.ACTIVE
+                ).stream()
+                .collect(Collectors.toMap(Product::getProductsId, Function.identity()));
+
+        if (productMap.size() != productIds.size()) {
+            throw new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND, "상품을 찾을 수 없습니다.");
+        }
+
+        List<Product> updatedProducts = request.getItems().stream()
+                .map(item -> updateStock(productMap.get(item.getProductId()), item))
+                .toList();
+
+        productRepository.flush();
+
+        return UpdateArtistProductStockResponse.from(updatedProducts);
+    }
+
+    @Transactional
+    public void deleteProduct(Long userId, Long productId) {
+        Artist artist = getArtistByUserId(userId);
+        Product product = productRepository.findByProductsIdAndArtistIdAndStatus(
+                        productId,
+                        artist.getId(),
+                        ProductStatus.ACTIVE
+                )
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "상품을 찾을 수 없습니다."
+                ));
+
+        product.deactivate();
+    }
+
+    private Product updateStock(
+            Product product,
+            UpdateArtistProductStockRequest.Item item
+    ) {
+        product.updateStockQuantity(item.getStockQuantity(), item.getVersion());
+        return product;
+    }
+
+    private Artist getArtistByUserId(Long userId) {
+        return artistRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "작가 정보를 찾을 수 없습니다."
+                ));
+    }
+
+    private int toPageIndex(int page) {
+        return Math.max(page - FIRST_PAGE, FIRST_PAGE_INDEX);
+    }
+
+    private void validatePageSize(int size) {
+        if (size < MIN_PAGE_SIZE) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "페이지 크기는 1 이상이어야 합니다.");
+        }
+    }
+
+    private void validateDuplicateProductIds(UpdateArtistProductStockRequest request) {
+        List<Long> productIds = request.getItems().stream()
+                .map(UpdateArtistProductStockRequest.Item::getProductId)
+                .toList();
+        if (new HashSet<>(productIds).size() != productIds.size()) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "중복된 상품 ID가 포함되어 있습니다.");
+        }
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
@@ -3,10 +3,14 @@ package app.dearobjet.backend.domain.shop.entity;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.shop.enums.ProductStatus;
 import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
  * 작가의 품목 관리 엔티티
@@ -18,6 +22,8 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @Builder
 public class Product extends BaseTimeEntity {
+
+    private static final int MIN_STOCK_QUANTITY = 0;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,4 +47,35 @@ public class Product extends BaseTimeEntity {
 
     @Column(name = "product_url")
     private String productUrl;
+
+    @Builder.Default
+    @Column(name = "stock_quantity", nullable = false)
+    private Integer stockQuantity = MIN_STOCK_QUANTITY;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    public void updateStockQuantity(int stockQuantity, Long expectedVersion) {
+        validateStockQuantity(stockQuantity);
+        validateVersion(expectedVersion);
+
+        this.stockQuantity = stockQuantity;
+    }
+
+    public void deactivate() {
+        this.status = ProductStatus.INACTIVE;
+    }
+
+    private void validateStockQuantity(int stockQuantity) {
+        if (stockQuantity < MIN_STOCK_QUANTITY) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "재고 수량은 0 이상이어야 합니다.");
+        }
+    }
+
+    private void validateVersion(Long expectedVersion) {
+        if (!Objects.equals(this.version, expectedVersion)) {
+            throw new BusinessException(ErrorCode.PRODUCT_STOCK_CONFLICT);
+        }
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/shop/repository/ProductRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/repository/ProductRepository.java
@@ -1,0 +1,27 @@
+package app.dearobjet.backend.domain.shop.repository;
+
+import app.dearobjet.backend.domain.shop.entity.Product;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    Page<Product> findByArtistIdAndStatus(Long artistId, ProductStatus status, Pageable pageable);
+
+    Optional<Product> findByProductsIdAndArtistIdAndStatus(
+            Long productsId,
+            Long artistId,
+            ProductStatus status
+    );
+
+    List<Product> findByProductsIdInAndArtistIdAndStatus(
+            Collection<Long> productsIds,
+            Long artistId,
+            ProductStatus status
+    );
+}

--- a/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
@@ -41,7 +41,10 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A004", "인증이 필요합니다"),
 
     // Notice (N0XX)
-    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "공지사항을 찾을 수 없습니다");
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "공지사항을 찾을 수 없습니다"),
+
+    // Product (P0XX)
+    PRODUCT_STOCK_CONFLICT(HttpStatus.CONFLICT, "P001", "상품 재고가 이미 변경되었습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistProductServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistProductServiceTest.java
@@ -1,0 +1,232 @@
+package app.dearobjet.backend.domain.artist;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.artist.service.ArtistProductService;
+import app.dearobjet.backend.domain.shop.entity.Product;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
+import app.dearobjet.backend.domain.shop.repository.ProductRepository;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.InvalidInputException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("ArtistProductService 품목 및 재고관리 테스트")
+@ExtendWith(MockitoExtension.class)
+class ArtistProductServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long ARTIST_ID = 10L;
+    private static final Long CUP_PRODUCT_ID = 100L;
+    private static final Long PLATE_PRODUCT_ID = 101L;
+    private static final Long VERSION = 0L;
+    private static final int PAGE = 1;
+    private static final int SIZE = 20;
+    private static final int CUP_STOCK_QUANTITY = 5;
+    private static final int UPDATED_CUP_STOCK_QUANTITY = 12;
+    private static final int UPDATED_PLATE_STOCK_QUANTITY = 3;
+
+    @InjectMocks
+    private ArtistProductService artistProductService;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Test
+    @DisplayName("작가의 활성 상품 목록을 조회한다")
+    void givenArtist_whenGetProducts_thenReturnActiveProducts() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByArtistIdAndStatus(
+                ARTIST_ID,
+                ProductStatus.ACTIVE,
+                PageRequest.of(0, SIZE, org.springframework.data.domain.Sort.by(
+                        org.springframework.data.domain.Sort.Direction.DESC,
+                        "createdAt"
+                ).and(org.springframework.data.domain.Sort.by(
+                        org.springframework.data.domain.Sort.Direction.DESC,
+                        "productsId"
+                )))
+        )).willReturn(new PageImpl<>(List.of(product)));
+
+        ArtistProductListResponse response = artistProductService.getProducts(USER_ID, PAGE, SIZE);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getProductId()).isEqualTo(CUP_PRODUCT_ID);
+        assertThat(response.getItems().get(0).getStockQuantity()).isEqualTo(CUP_STOCK_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("체크한 상품들의 재고를 요청 순서대로 일괄 변경한다")
+    void givenStockRequest_whenUpdateStocks_thenUpdateAllProducts() {
+        Artist artist = artist();
+        Product cup = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        Product plate = product(PLATE_PRODUCT_ID, "디저트 접시", 0, VERSION);
+        UpdateArtistProductStockRequest request = stockRequest(
+                stockItem(CUP_PRODUCT_ID, UPDATED_CUP_STOCK_QUANTITY, VERSION),
+                stockItem(PLATE_PRODUCT_ID, UPDATED_PLATE_STOCK_QUANTITY, VERSION)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdInAndArtistIdAndStatus(
+                List.of(CUP_PRODUCT_ID, PLATE_PRODUCT_ID),
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(List.of(plate, cup));
+
+        UpdateArtistProductStockResponse response = artistProductService.updateStocks(USER_ID, request);
+
+        assertThat(cup.getStockQuantity()).isEqualTo(UPDATED_CUP_STOCK_QUANTITY);
+        assertThat(plate.getStockQuantity()).isEqualTo(UPDATED_PLATE_STOCK_QUANTITY);
+        assertThat(response.getItems())
+                .extracting("productId")
+                .containsExactly(CUP_PRODUCT_ID, PLATE_PRODUCT_ID);
+        verify(productRepository).flush();
+    }
+
+    @Test
+    @DisplayName("상품 버전이 다르면 재고 변경을 거부한다")
+    void givenStaleVersion_whenUpdateStocks_thenThrowConflict() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        UpdateArtistProductStockRequest request = stockRequest(
+                stockItem(CUP_PRODUCT_ID, UPDATED_CUP_STOCK_QUANTITY, 99L)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdInAndArtistIdAndStatus(
+                List.of(CUP_PRODUCT_ID),
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(List.of(product));
+
+        assertThatThrownBy(() -> artistProductService.updateStocks(USER_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("상품 재고가 이미 변경되었습니다");
+
+        assertThat(product.getStockQuantity()).isEqualTo(CUP_STOCK_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("다른 작가 상품이 포함되면 재고 변경을 거부한다")
+    void givenNotOwnedProduct_whenUpdateStocks_thenThrowNotFound() {
+        Artist artist = artist();
+        UpdateArtistProductStockRequest request = stockRequest(
+                stockItem(CUP_PRODUCT_ID, UPDATED_CUP_STOCK_QUANTITY, VERSION)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdInAndArtistIdAndStatus(
+                List.of(CUP_PRODUCT_ID),
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(List.of());
+
+        assertThatThrownBy(() -> artistProductService.updateStocks(USER_ID, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("상품을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("중복 상품 ID가 포함되면 재고 변경을 거부한다")
+    void givenDuplicateProductId_whenUpdateStocks_thenThrowInvalidInput() {
+        Artist artist = artist();
+        UpdateArtistProductStockRequest request = stockRequest(
+                stockItem(CUP_PRODUCT_ID, UPDATED_CUP_STOCK_QUANTITY, VERSION),
+                stockItem(CUP_PRODUCT_ID, UPDATED_PLATE_STOCK_QUANTITY, VERSION)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+
+        assertThatThrownBy(() -> artistProductService.updateStocks(USER_ID, request))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessage("중복된 상품 ID가 포함되어 있습니다.");
+    }
+
+    @Test
+    @DisplayName("작가 상품 삭제는 비활성화로 처리한다")
+    void givenOwnedProduct_whenDeleteProduct_thenDeactivate() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+
+        artistProductService.deleteProduct(USER_ID, CUP_PRODUCT_ID);
+
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("페이지 크기가 1보다 작으면 목록 조회를 거부한다")
+    void givenInvalidSize_whenGetProducts_thenThrowInvalidInput() {
+        assertThatThrownBy(() -> artistProductService.getProducts(USER_ID, PAGE, 0))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessage("페이지 크기는 1 이상이어야 합니다.");
+    }
+
+    private Artist artist() {
+        return Artist.builder()
+                .id(ARTIST_ID)
+                .build();
+    }
+
+    private Product product(Long productId, String productName, int stockQuantity, Long version) {
+        return Product.builder()
+                .productsId(productId)
+                .artist(artist())
+                .productName(productName)
+                .price(new BigDecimal("10000.00"))
+                .status(ProductStatus.ACTIVE)
+                .productUrl("https://image.test/products/" + productId + ".png")
+                .stockQuantity(stockQuantity)
+                .version(version)
+                .build();
+    }
+
+    private UpdateArtistProductStockRequest stockRequest(UpdateArtistProductStockRequest.Item... items) {
+        UpdateArtistProductStockRequest request = new UpdateArtistProductStockRequest();
+        ReflectionTestUtils.setField(request, "items", List.of(items));
+        return request;
+    }
+
+    private UpdateArtistProductStockRequest.Item stockItem(
+            Long productId,
+            int stockQuantity,
+            Long version
+    ) {
+        UpdateArtistProductStockRequest.Item item = new UpdateArtistProductStockRequest.Item();
+        ReflectionTestUtils.setField(item, "productId", productId);
+        ReflectionTestUtils.setField(item, "stockQuantity", stockQuantity);
+        ReflectionTestUtils.setField(item, "version", version);
+        return item;
+    }
+}

--- a/src/test/java/app/dearobjet/backend/domain/artist/ProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ProductRepositoryTest.java
@@ -1,0 +1,139 @@
+package app.dearobjet.backend.domain.artist;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.shop.entity.Product;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
+import app.dearobjet.backend.domain.shop.repository.ProductRepository;
+import app.dearobjet.backend.domain.user.entity.BusinessProfile;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.BusinessCategory;
+import app.dearobjet.backend.domain.user.enums.BusinessType;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.domain.user.repository.BusinessProfileRepository;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import app.dearobjet.backend.global.common.config.JpaConfig;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+class ProductRepositoryTest {
+
+    private static final BigDecimal DEFAULT_PRICE = new BigDecimal("10000.00");
+    private static final int FIRST_PAGE_INDEX = 0;
+    private static final int PAGE_SIZE = 10;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ArtistRepository artistRepository;
+
+    @Autowired
+    private BusinessProfileRepository businessProfileRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("작가 상품 목록은 활성 상품만 최신 등록순으로 조회한다")
+    void givenProducts_whenFindByArtist_thenReturnActiveProductsByNewest() {
+        Artist artist = createArtist("artist-a@test.com", "Postman 도자기 작가");
+        Artist otherArtist = createArtist("artist-b@test.com", "Postman 문구 작가");
+        Product oldProduct = createProduct(artist, "오래된 컵", ProductStatus.ACTIVE);
+        Product newestProduct = createProduct(artist, "최신 접시", ProductStatus.ACTIVE);
+        createProduct(artist, "비활성 화병", ProductStatus.INACTIVE);
+        createProduct(otherArtist, "다른 작가 상품", ProductStatus.ACTIVE);
+
+        Page<Product> result = productRepository.findByArtistIdAndStatus(
+                artist.getId(),
+                ProductStatus.ACTIVE,
+                PageRequest.of(
+                        FIRST_PAGE_INDEX,
+                        PAGE_SIZE,
+                        Sort.by(Sort.Direction.DESC, "createdAt")
+                                .and(Sort.by(Sort.Direction.DESC, "productsId"))
+                )
+        );
+
+        assertThat(result.getContent())
+                .extracting(Product::getProductName)
+                .containsExactly("최신 접시", "오래된 컵");
+        assertThat(result.getContent())
+                .extracting(Product::getProductsId)
+                .containsExactly(newestProduct.getProductsId(), oldProduct.getProductsId());
+    }
+
+    @Test
+    @DisplayName("작가 소유 활성 상품만 ID 목록으로 조회한다")
+    void givenProductIds_whenFindByIdsAndArtist_thenReturnOnlyOwnedActiveProducts() {
+        Artist artist = createArtist("artist-a@test.com", "Postman 도자기 작가");
+        Artist otherArtist = createArtist("artist-b@test.com", "Postman 문구 작가");
+        Product activeProduct = createProduct(artist, "활성 컵", ProductStatus.ACTIVE);
+        Product inactiveProduct = createProduct(artist, "비활성 접시", ProductStatus.INACTIVE);
+        Product otherArtistProduct = createProduct(otherArtist, "다른 작가 상품", ProductStatus.ACTIVE);
+
+        List<Product> products = productRepository.findByProductsIdInAndArtistIdAndStatus(
+                List.of(
+                        activeProduct.getProductsId(),
+                        inactiveProduct.getProductsId(),
+                        otherArtistProduct.getProductsId()
+                ),
+                artist.getId(),
+                ProductStatus.ACTIVE
+        );
+
+        assertThat(products)
+                .extracting(Product::getProductsId)
+                .containsExactly(activeProduct.getProductsId());
+    }
+
+    private Artist createArtist(String email, String businessName) {
+        User user = userRepository.save(User.builder()
+                .email(email)
+                .name(businessName)
+                .role(Role.ARTIST)
+                .userStatus(UserStatus.ACTIVE)
+                .build());
+        BusinessProfile businessProfile = businessProfileRepository.save(BusinessProfile.builder()
+                .user(user)
+                .businessType(BusinessType.WHOLESALE_RETAIL)
+                .businessNumber("123-45-" + Math.abs(email.hashCode() % 100000))
+                .businessName(businessName)
+                .ownerName("대표")
+                .businessAddress("서울시 성동구")
+                .businessCategory(BusinessCategory.CRAFT_RETAIL)
+                .specialty(Specialty.CERAMIC)
+                .reviewDataAgreement(true)
+                .build());
+        return artistRepository.save(Artist.builder()
+                .user(user)
+                .businessProfile(businessProfile)
+                .build());
+    }
+
+    private Product createProduct(Artist artist, String productName, ProductStatus status) {
+        return productRepository.save(Product.builder()
+                .artist(artist)
+                .productName(productName)
+                .price(DEFAULT_PRICE)
+                .status(status)
+                .productUrl("https://image.test/products/" + productName + ".png")
+                .build());
+    }
+}


### PR DESCRIPTION
## Summary
  - 작가 보유 상품의 품목/재고 목록 조회 API 추가
  - 체크된 상품들의 재고 수량을 일괄 저장하는 API 추가
  - 상품 삭제를 물리 삭제가 아닌 INACTIVE 상태 변경으로 처리
  - 재고 동시 수정 방지를 위해 Product version 검증 추가

  ## Test
  - ./gradlew test --tests "app.dearobjet.backend.domain.artist.*" --tests "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"