### PR TITLE
feat: 작가 상품 등록 및 수정 API 구현

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistProductController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistProductController.java
@@ -1,6 +1,9 @@
 package app.dearobjet.backend.domain.artist.controller;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistProductItemResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistProductRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
 import app.dearobjet.backend.domain.artist.service.ArtistProductService;
@@ -8,15 +11,20 @@ import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +32,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class ArtistProductController {
 
     private final ArtistProductService artistProductService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ArtistProductItemResponse> createProduct(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @Valid @RequestPart("request") CreateArtistProductRequest request,
+            @RequestPart("productImage") MultipartFile productImage
+    ) {
+        return ApiResponse.of(
+                artistProductService.createProduct(resolveUserId(userDetails, userId), request, productImage)
+        );
+    }
 
     @GetMapping
     public ApiResponse<ArtistProductListResponse> getProducts(
@@ -42,6 +62,24 @@ public class ArtistProductController {
             @Valid @RequestBody UpdateArtistProductStockRequest request
     ) {
         return ApiResponse.of(artistProductService.updateStocks(resolveUserId(userDetails, userId), request));
+    }
+
+    @PutMapping(value = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ArtistProductItemResponse> updateProduct(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long productId,
+            @Valid @RequestPart("request") UpdateArtistProductRequest request,
+            @RequestPart(value = "productImage", required = false) MultipartFile productImage
+    ) {
+        return ApiResponse.of(
+                artistProductService.updateProduct(
+                        resolveUserId(userDetails, userId),
+                        productId,
+                        request,
+                        productImage
+                )
+        );
     }
 
     @DeleteMapping("/{productId}")

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistProductRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistProductRequest.java
@@ -1,0 +1,25 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateArtistProductRequest {
+
+    @NotBlank(message = "상품명은 필수입니다.")
+    private String productName;
+
+    @NotNull(message = "판매가는 필수입니다.")
+    @DecimalMin(value = "0.0", message = "판매가는 0 이상이어야 합니다.")
+    private BigDecimal price;
+
+    @NotNull(message = "총재고는 필수입니다.")
+    @Min(value = 0, message = "총재고는 0 이상이어야 합니다.")
+    private Integer stockQuantity;
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductRequest.java
@@ -1,0 +1,25 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateArtistProductRequest {
+
+    @NotBlank(message = "상품명은 필수입니다.")
+    private String productName;
+
+    @NotNull(message = "판매가는 필수입니다.")
+    @DecimalMin(value = "0.0", message = "판매가는 0 이상이어야 합니다.")
+    private BigDecimal price;
+
+    @NotNull(message = "총재고는 필수입니다.")
+    @Min(value = 0, message = "총재고는 0 이상이어야 합니다.")
+    private Integer stockQuantity;
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistProductService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistProductService.java
@@ -1,6 +1,9 @@
 package app.dearobjet.backend.domain.artist.service;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistProductItemResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistProductRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
 import app.dearobjet.backend.domain.artist.entity.Artist;
@@ -11,6 +14,7 @@ import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
 import app.dearobjet.backend.global.exception.InvalidInputException;
+import app.dearobjet.backend.global.s3.service.S3FileUploadService;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +26,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +38,56 @@ public class ArtistProductService {
 
     private final ArtistRepository artistRepository;
     private final ProductRepository productRepository;
+    private final S3FileUploadService s3FileUploadService;
+
+    @Transactional
+    public ArtistProductItemResponse createProduct(
+            Long userId,
+            CreateArtistProductRequest request,
+            MultipartFile productImage
+    ) {
+        Artist artist = getArtistByUserId(userId);
+        String productImageUrl = s3FileUploadService.uploadProductImage(productImage, userId);
+
+        Product product = Product.create(
+                artist,
+                request.getProductName(),
+                request.getPrice(),
+                request.getStockQuantity(),
+                productImageUrl
+        );
+
+        return ArtistProductItemResponse.from(productRepository.save(product));
+    }
+
+    @Transactional
+    public ArtistProductItemResponse updateProduct(
+            Long userId,
+            Long productId,
+            UpdateArtistProductRequest request,
+            MultipartFile productImage
+    ) {
+        Artist artist = getArtistByUserId(userId);
+        Product product = getOwnedActiveProduct(productId, artist.getId());
+
+        if (hasImageFile(productImage)) {
+            String productImageUrl = s3FileUploadService.uploadProductImage(productImage, userId);
+            product.updateProductInfo(
+                    request.getProductName(),
+                    request.getPrice(),
+                    request.getStockQuantity(),
+                    productImageUrl
+            );
+            return ArtistProductItemResponse.from(product);
+        }
+
+        product.updateProductInfoKeepingImage(
+                request.getProductName(),
+                request.getPrice(),
+                request.getStockQuantity()
+        );
+        return ArtistProductItemResponse.from(product);
+    }
 
     @Transactional(readOnly = true)
     public ArtistProductListResponse getProducts(Long userId, int page, int size) {
@@ -88,17 +143,21 @@ public class ArtistProductService {
     @Transactional
     public void deleteProduct(Long userId, Long productId) {
         Artist artist = getArtistByUserId(userId);
-        Product product = productRepository.findByProductsIdAndArtistIdAndStatus(
+        Product product = getOwnedActiveProduct(productId, artist.getId());
+
+        product.deactivate();
+    }
+
+    private Product getOwnedActiveProduct(Long productId, Long artistId) {
+        return productRepository.findByProductsIdAndArtistIdAndStatus(
                         productId,
-                        artist.getId(),
+                        artistId,
                         ProductStatus.ACTIVE
                 )
                 .orElseThrow(() -> new EntityNotFoundException(
                         ErrorCode.ENTITY_NOT_FOUND,
                         "상품을 찾을 수 없습니다."
                 ));
-
-        product.deactivate();
     }
 
     private Product updateStock(
@@ -134,5 +193,9 @@ public class ArtistProductService {
         if (new HashSet<>(productIds).size() != productIds.size()) {
             throw new InvalidInputException(ErrorCode.INVALID_INPUT, "중복된 상품 ID가 포함되어 있습니다.");
         }
+    }
+
+    private boolean hasImageFile(MultipartFile productImage) {
+        return productImage != null && !productImage.isEmpty();
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 public class Product extends BaseTimeEntity {
 
     private static final int MIN_STOCK_QUANTITY = 0;
+    private static final BigDecimal MIN_PRICE = BigDecimal.ZERO;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -56,6 +57,46 @@ public class Product extends BaseTimeEntity {
     @Column(name = "version")
     private Long version;
 
+    public static Product create(
+            Artist artist,
+            String productName,
+            BigDecimal price,
+            int stockQuantity,
+            String productUrl
+    ) {
+        Product product = Product.builder()
+                .artist(artist)
+                .status(ProductStatus.ACTIVE)
+                .build();
+        product.updateProductInfo(productName, price, stockQuantity, productUrl);
+        return product;
+    }
+
+    public void updateProductInfo(
+            String productName,
+            BigDecimal price,
+            int stockQuantity,
+            String productUrl
+    ) {
+        validateProductName(productName);
+        validatePrice(price);
+        validateStockQuantity(stockQuantity);
+        validateProductUrl(productUrl);
+
+        this.productName = productName.trim();
+        this.price = price;
+        this.stockQuantity = stockQuantity;
+        this.productUrl = productUrl;
+    }
+
+    public void updateProductInfoKeepingImage(
+            String productName,
+            BigDecimal price,
+            int stockQuantity
+    ) {
+        updateProductInfo(productName, price, stockQuantity, this.productUrl);
+    }
+
     public void updateStockQuantity(int stockQuantity, Long expectedVersion) {
         validateStockQuantity(stockQuantity);
         validateVersion(expectedVersion);
@@ -70,6 +111,24 @@ public class Product extends BaseTimeEntity {
     private void validateStockQuantity(int stockQuantity) {
         if (stockQuantity < MIN_STOCK_QUANTITY) {
             throw new InvalidInputException(ErrorCode.INVALID_INPUT, "재고 수량은 0 이상이어야 합니다.");
+        }
+    }
+
+    private void validateProductName(String productName) {
+        if (productName == null || productName.isBlank()) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "상품명은 필수입니다.");
+        }
+    }
+
+    private void validatePrice(BigDecimal price) {
+        if (price == null || price.compareTo(MIN_PRICE) < 0) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "판매가는 0 이상이어야 합니다.");
+        }
+    }
+
+    private void validateProductUrl(String productUrl) {
+        if (productUrl == null || productUrl.isBlank()) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "상품 이미지는 필수입니다.");
         }
     }
 

--- a/src/main/java/app/dearobjet/backend/global/s3/service/S3FileUploadService.java
+++ b/src/main/java/app/dearobjet/backend/global/s3/service/S3FileUploadService.java
@@ -97,6 +97,34 @@ public class S3FileUploadService {
         }
     }
 
+    public String uploadProductImage(MultipartFile file, Long userId) {
+        validateImageFile(file, "상품 이미지 파일", MAX_IMAGE_FILE_SIZE_BYTES);
+
+        String key = buildProductImageKey(userId, file.getOriginalFilename());
+        String contentType = file.getContentType();
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+            return buildPublicUrl(key);
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "파일 읽기에 실패했습니다.");
+        } catch (S3Exception e) {
+            String detailMessage = e.awsErrorDetails() == null
+                    ? e.getMessage()
+                    : e.awsErrorDetails().errorCode() + ": " + e.awsErrorDetails().errorMessage();
+            throw new BusinessException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "S3 업로드에 실패했습니다. " + detailMessage
+            );
+        }
+    }
+
     public String uploadProfileImage(MultipartFile file, Long userId) {
         validateImageFile(file, "프로필 이미지 파일", MAX_IMAGE_FILE_SIZE_BYTES);
 
@@ -203,6 +231,11 @@ public class S3FileUploadService {
     private String buildClassImageKey(Long userId, String originalFilename) {
         String extension = extractExtension(originalFilename);
         return "class-image/" + userId + "/" + UUID.randomUUID() + extension;
+    }
+
+    private String buildProductImageKey(Long userId, String originalFilename) {
+        String extension = extractExtension(originalFilename);
+        return "product-image/" + userId + "/" + UUID.randomUUID() + extension;
     }
 
     private String buildProfileImageKey(Long userId, String originalFilename) {

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistProductServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistProductServiceTest.java
@@ -1,6 +1,8 @@
 package app.dearobjet.backend.domain.artist;
 
 import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistProductRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
 import app.dearobjet.backend.domain.artist.entity.Artist;
@@ -12,6 +14,7 @@ import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.global.exception.BusinessException;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.InvalidInputException;
+import app.dearobjet.backend.global.s3.service.S3FileUploadService;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
@@ -23,10 +26,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -44,6 +50,10 @@ class ArtistProductServiceTest {
     private static final int CUP_STOCK_QUANTITY = 5;
     private static final int UPDATED_CUP_STOCK_QUANTITY = 12;
     private static final int UPDATED_PLATE_STOCK_QUANTITY = 3;
+    private static final BigDecimal DEFAULT_PRICE = new BigDecimal("10000.00");
+    private static final BigDecimal UPDATED_PRICE = new BigDecimal("15000.00");
+    private static final String PRODUCT_IMAGE_URL = "https://image.test/products/new.png";
+    private static final String UPDATED_PRODUCT_IMAGE_URL = "https://image.test/products/updated.png";
 
     @InjectMocks
     private ArtistProductService artistProductService;
@@ -53,6 +63,96 @@ class ArtistProductServiceTest {
 
     @Mock
     private ProductRepository productRepository;
+
+    @Mock
+    private S3FileUploadService s3FileUploadService;
+
+    @Test
+    @DisplayName("상품 이미지와 함께 작가 상품을 등록한다")
+    void givenProductRequestAndImage_whenCreateProduct_thenSaveActiveProduct() {
+        Artist artist = artist();
+        CreateArtistProductRequest request = createProductRequest("도자기 컵", DEFAULT_PRICE, CUP_STOCK_QUANTITY);
+        MultipartFile productImage = productImage();
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(s3FileUploadService.uploadProductImage(productImage, USER_ID)).willReturn(PRODUCT_IMAGE_URL);
+        given(productRepository.save(any(Product.class))).willAnswer(invocation -> {
+            Product savedProduct = invocation.getArgument(0);
+            ReflectionTestUtils.setField(savedProduct, "productsId", CUP_PRODUCT_ID);
+            ReflectionTestUtils.setField(savedProduct, "version", VERSION);
+            return savedProduct;
+        });
+
+        var response = artistProductService.createProduct(USER_ID, request, productImage);
+
+        assertThat(response.getProductId()).isEqualTo(CUP_PRODUCT_ID);
+        assertThat(response.getProductName()).isEqualTo("도자기 컵");
+        assertThat(response.getPrice()).isEqualByComparingTo(DEFAULT_PRICE);
+        assertThat(response.getStockQuantity()).isEqualTo(CUP_STOCK_QUANTITY);
+        assertThat(response.getImageUrl()).isEqualTo(PRODUCT_IMAGE_URL);
+    }
+
+    @Test
+    @DisplayName("상품 수정 시 이미지가 없으면 기존 이미지를 유지한다")
+    void givenUpdateRequestWithoutImage_whenUpdateProduct_thenKeepImage() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        UpdateArtistProductRequest request = updateProductRequest("수정 컵", UPDATED_PRICE, UPDATED_CUP_STOCK_QUANTITY);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+
+        var response = artistProductService.updateProduct(USER_ID, CUP_PRODUCT_ID, request, null);
+
+        assertThat(response.getProductName()).isEqualTo("수정 컵");
+        assertThat(response.getPrice()).isEqualByComparingTo(UPDATED_PRICE);
+        assertThat(response.getStockQuantity()).isEqualTo(UPDATED_CUP_STOCK_QUANTITY);
+        assertThat(response.getImageUrl()).isEqualTo("https://image.test/products/" + CUP_PRODUCT_ID + ".png");
+    }
+
+    @Test
+    @DisplayName("상품 수정 시 새 이미지가 있으면 이미지 URL을 교체한다")
+    void givenUpdateRequestWithImage_whenUpdateProduct_thenReplaceImage() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        UpdateArtistProductRequest request = updateProductRequest("수정 컵", UPDATED_PRICE, UPDATED_CUP_STOCK_QUANTITY);
+        MultipartFile productImage = productImage();
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+        given(s3FileUploadService.uploadProductImage(productImage, USER_ID)).willReturn(UPDATED_PRODUCT_IMAGE_URL);
+
+        var response = artistProductService.updateProduct(USER_ID, CUP_PRODUCT_ID, request, productImage);
+
+        assertThat(response.getImageUrl()).isEqualTo(UPDATED_PRODUCT_IMAGE_URL);
+        assertThat(product.getProductUrl()).isEqualTo(UPDATED_PRODUCT_IMAGE_URL);
+    }
+
+    @Test
+    @DisplayName("다른 작가 상품은 수정할 수 없다")
+    void givenNotOwnedProduct_whenUpdateProduct_thenThrowNotFound() {
+        Artist artist = artist();
+        UpdateArtistProductRequest request = updateProductRequest("수정 컵", UPDATED_PRICE, UPDATED_CUP_STOCK_QUANTITY);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> artistProductService.updateProduct(USER_ID, CUP_PRODUCT_ID, request, null))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("상품을 찾을 수 없습니다.");
+    }
 
     @Test
     @DisplayName("작가의 활성 상품 목록을 조회한다")
@@ -212,6 +312,30 @@ class ArtistProductServiceTest {
                 .build();
     }
 
+    private CreateArtistProductRequest createProductRequest(
+            String productName,
+            BigDecimal price,
+            int stockQuantity
+    ) {
+        CreateArtistProductRequest request = new CreateArtistProductRequest();
+        ReflectionTestUtils.setField(request, "productName", productName);
+        ReflectionTestUtils.setField(request, "price", price);
+        ReflectionTestUtils.setField(request, "stockQuantity", stockQuantity);
+        return request;
+    }
+
+    private UpdateArtistProductRequest updateProductRequest(
+            String productName,
+            BigDecimal price,
+            int stockQuantity
+    ) {
+        UpdateArtistProductRequest request = new UpdateArtistProductRequest();
+        ReflectionTestUtils.setField(request, "productName", productName);
+        ReflectionTestUtils.setField(request, "price", price);
+        ReflectionTestUtils.setField(request, "stockQuantity", stockQuantity);
+        return request;
+    }
+
     private UpdateArtistProductStockRequest stockRequest(UpdateArtistProductStockRequest.Item... items) {
         UpdateArtistProductStockRequest request = new UpdateArtistProductStockRequest();
         ReflectionTestUtils.setField(request, "items", List.of(items));
@@ -228,5 +352,14 @@ class ArtistProductServiceTest {
         ReflectionTestUtils.setField(item, "stockQuantity", stockQuantity);
         ReflectionTestUtils.setField(item, "version", version);
         return item;
+    }
+
+    private MultipartFile productImage() {
+        return new MockMultipartFile(
+                "productImage",
+                "product.png",
+                "image/png",
+                "image".getBytes()
+        );
     }
 }


### PR DESCRIPTION
## Summary
  - 작가 상품 등록 API 추가
  - 작가 상품 수정 API 추가
  - 상품 이미지 S3 업로드 기능 추가
  - 상품명, 판매가, 총재고, 상품 이미지 검증 로직 추가
  - 수정 시 이미지 미첨부이면 기존 이미지 유지

##  주요 API

  POST /api/v1/artist/products
  PUT /api/v1/artist/products/{productId}

##  비고

  - 요청 형식은 multipart/form-data
  - 등록 시 productImage 필수
  - 수정 시 productImage 선택