### PR TITLE
feat: 작가 상품 메모 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistProductController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistProductController.java
@@ -2,7 +2,9 @@ package app.dearobjet.backend.domain.artist.controller;
 
 import app.dearobjet.backend.domain.artist.dto.ArtistProductItemResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.ArtistProductMemoResponse;
 import app.dearobjet.backend.domain.artist.dto.CreateArtistProductRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductMemoRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
@@ -62,6 +64,40 @@ public class ArtistProductController {
             @Valid @RequestBody UpdateArtistProductStockRequest request
     ) {
         return ApiResponse.of(artistProductService.updateStocks(resolveUserId(userDetails, userId), request));
+    }
+
+    @GetMapping("/{productId}/memo")
+    public ApiResponse<ArtistProductMemoResponse> getProductMemo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long productId
+    ) {
+        return ApiResponse.of(
+                artistProductService.getProductMemo(resolveUserId(userDetails, userId), productId)
+        );
+    }
+
+    @PatchMapping("/{productId}/memo")
+    public ApiResponse<ArtistProductMemoResponse> updateProductMemo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long productId,
+            @Valid @RequestBody UpdateArtistProductMemoRequest request
+    ) {
+        return ApiResponse.of(
+                artistProductService.updateProductMemo(resolveUserId(userDetails, userId), productId, request)
+        );
+    }
+
+    @DeleteMapping("/{productId}/memo")
+    public ApiResponse<ArtistProductMemoResponse> deleteProductMemo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long productId
+    ) {
+        return ApiResponse.of(
+                artistProductService.deleteProductMemo(resolveUserId(userDetails, userId), productId)
+        );
     }
 
     @PutMapping(value = "/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistProductMemoResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistProductMemoResponse.java
@@ -1,0 +1,21 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.shop.entity.Product;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistProductMemoResponse {
+
+    private final Long productId;
+    private final String memo;
+
+    public static ArtistProductMemoResponse from(Product product) {
+        return new ArtistProductMemoResponse(
+                product.getProductsId(),
+                product.getMemo() == null ? "" : product.getMemo()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductMemoRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/UpdateArtistProductMemoRequest.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateArtistProductMemoRequest {
+
+    @NotNull(message = "상품 메모는 필수입니다.")
+    @Size(max = 1000, message = "상품 메모는 1000자 이하여야 합니다.")
+    private String memo;
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistProductService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistProductService.java
@@ -2,7 +2,9 @@ package app.dearobjet.backend.domain.artist.service;
 
 import app.dearobjet.backend.domain.artist.dto.ArtistProductItemResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.ArtistProductMemoResponse;
 import app.dearobjet.backend.domain.artist.dto.CreateArtistProductRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductMemoRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
@@ -138,6 +140,36 @@ public class ArtistProductService {
         productRepository.flush();
 
         return UpdateArtistProductStockResponse.from(updatedProducts);
+    }
+
+    @Transactional(readOnly = true)
+    public ArtistProductMemoResponse getProductMemo(Long userId, Long productId) {
+        Artist artist = getArtistByUserId(userId);
+        Product product = getOwnedActiveProduct(productId, artist.getId());
+
+        return ArtistProductMemoResponse.from(product);
+    }
+
+    @Transactional
+    public ArtistProductMemoResponse updateProductMemo(
+            Long userId,
+            Long productId,
+            UpdateArtistProductMemoRequest request
+    ) {
+        Artist artist = getArtistByUserId(userId);
+        Product product = getOwnedActiveProduct(productId, artist.getId());
+        product.updateMemo(request.getMemo());
+
+        return ArtistProductMemoResponse.from(product);
+    }
+
+    @Transactional
+    public ArtistProductMemoResponse deleteProductMemo(Long userId, Long productId) {
+        Artist artist = getArtistByUserId(userId);
+        Product product = getOwnedActiveProduct(productId, artist.getId());
+        product.updateMemo("");
+
+        return ArtistProductMemoResponse.from(product);
     }
 
     @Transactional

--- a/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
@@ -53,6 +53,10 @@ public class Product extends BaseTimeEntity {
     @Column(name = "stock_quantity", nullable = false)
     private Integer stockQuantity = MIN_STOCK_QUANTITY;
 
+    @Builder.Default
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo = "";
+
     @Version
     @Column(name = "version")
     private Long version;
@@ -102,6 +106,14 @@ public class Product extends BaseTimeEntity {
         validateVersion(expectedVersion);
 
         this.stockQuantity = stockQuantity;
+    }
+
+    public void updateMemo(String memo) {
+        if (memo == null || memo.isBlank()) {
+            this.memo = "";
+            return;
+        }
+        this.memo = memo.trim();
     }
 
     public void deactivate() {

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistProductServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistProductServiceTest.java
@@ -1,7 +1,9 @@
 package app.dearobjet.backend.domain.artist;
 
 import app.dearobjet.backend.domain.artist.dto.ArtistProductListResponse;
+import app.dearobjet.backend.domain.artist.dto.ArtistProductMemoResponse;
 import app.dearobjet.backend.domain.artist.dto.CreateArtistProductRequest;
+import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductMemoRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockRequest;
 import app.dearobjet.backend.domain.artist.dto.UpdateArtistProductStockResponse;
@@ -54,6 +56,8 @@ class ArtistProductServiceTest {
     private static final BigDecimal UPDATED_PRICE = new BigDecimal("15000.00");
     private static final String PRODUCT_IMAGE_URL = "https://image.test/products/new.png";
     private static final String UPDATED_PRODUCT_IMAGE_URL = "https://image.test/products/updated.png";
+    private static final String PRODUCT_MEMO = "행사 진열용 메모";
+    private static final String UPDATED_PRODUCT_MEMO = "재입고 시 우선 확인";
 
     @InjectMocks
     private ArtistProductService artistProductService;
@@ -268,6 +272,122 @@ class ArtistProductServiceTest {
     }
 
     @Test
+    @DisplayName("상품 메모가 있으면 저장된 메모를 조회한다")
+    void givenProductMemo_whenGetProductMemo_thenReturnMemo() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        product.updateMemo(PRODUCT_MEMO);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+
+        ArtistProductMemoResponse response = artistProductService.getProductMemo(USER_ID, CUP_PRODUCT_ID);
+
+        assertThat(response.getProductId()).isEqualTo(CUP_PRODUCT_ID);
+        assertThat(response.getMemo()).isEqualTo(PRODUCT_MEMO);
+    }
+
+    @Test
+    @DisplayName("상품 메모가 없으면 빈 문자열을 조회한다")
+    void givenProductWithoutMemo_whenGetProductMemo_thenReturnEmptyMemo() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+
+        ArtistProductMemoResponse response = artistProductService.getProductMemo(USER_ID, CUP_PRODUCT_ID);
+
+        assertThat(response.getMemo()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("상품 메모를 저장하거나 수정한다")
+    void givenMemoRequest_whenUpdateProductMemo_thenReturnUpdatedMemo() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        UpdateArtistProductMemoRequest request = memoRequest(UPDATED_PRODUCT_MEMO);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+
+        ArtistProductMemoResponse response = artistProductService.updateProductMemo(USER_ID, CUP_PRODUCT_ID, request);
+
+        assertThat(response.getMemo()).isEqualTo(UPDATED_PRODUCT_MEMO);
+        assertThat(product.getMemo()).isEqualTo(UPDATED_PRODUCT_MEMO);
+    }
+
+    @Test
+    @DisplayName("공백만 있는 상품 메모는 삭제와 동일하게 빈 문자열로 저장한다")
+    void givenBlankMemoRequest_whenUpdateProductMemo_thenSaveEmptyMemo() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        product.updateMemo(PRODUCT_MEMO);
+        UpdateArtistProductMemoRequest request = memoRequest("   ");
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+
+        ArtistProductMemoResponse response = artistProductService.updateProductMemo(USER_ID, CUP_PRODUCT_ID, request);
+
+        assertThat(response.getMemo()).isEmpty();
+        assertThat(product.getMemo()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("상품 메모를 삭제한다")
+    void givenProductMemo_whenDeleteProductMemo_thenReturnEmptyMemo() {
+        Artist artist = artist();
+        Product product = product(CUP_PRODUCT_ID, "도자기 컵", CUP_STOCK_QUANTITY, VERSION);
+        product.updateMemo(PRODUCT_MEMO);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.of(product));
+
+        ArtistProductMemoResponse response = artistProductService.deleteProductMemo(USER_ID, CUP_PRODUCT_ID);
+
+        assertThat(response.getMemo()).isEmpty();
+        assertThat(product.getMemo()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 작가 상품의 메모는 조회할 수 없다")
+    void givenNotOwnedProduct_whenGetProductMemo_thenThrowNotFound() {
+        Artist artist = artist();
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(productRepository.findByProductsIdAndArtistIdAndStatus(
+                CUP_PRODUCT_ID,
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> artistProductService.getProductMemo(USER_ID, CUP_PRODUCT_ID))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("상품을 찾을 수 없습니다.");
+    }
+
+    @Test
     @DisplayName("작가 상품 삭제는 비활성화로 처리한다")
     void givenOwnedProduct_whenDeleteProduct_thenDeactivate() {
         Artist artist = artist();
@@ -339,6 +459,12 @@ class ArtistProductServiceTest {
     private UpdateArtistProductStockRequest stockRequest(UpdateArtistProductStockRequest.Item... items) {
         UpdateArtistProductStockRequest request = new UpdateArtistProductStockRequest();
         ReflectionTestUtils.setField(request, "items", List.of(items));
+        return request;
+    }
+
+    private UpdateArtistProductMemoRequest memoRequest(String memo) {
+        UpdateArtistProductMemoRequest request = new UpdateArtistProductMemoRequest();
+        ReflectionTestUtils.setField(request, "memo", memo);
         return request;
     }
 

--- a/src/test/java/app/dearobjet/backend/domain/artist/ProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ProductRepositoryTest.java
@@ -103,6 +103,19 @@ class ProductRepositoryTest {
                 .containsExactly(activeProduct.getProductsId());
     }
 
+    @Test
+    @DisplayName("상품 메모를 저장하고 조회한다")
+    void givenProductMemo_whenSaveAndFind_thenReturnMemo() {
+        Artist artist = createArtist("artist-a@test.com", "Postman 도자기 작가");
+        Product product = createProduct(artist, "활성 컵", ProductStatus.ACTIVE);
+        product.updateMemo("매장 전면 진열");
+        productRepository.flush();
+
+        Product foundProduct = productRepository.findById(product.getProductsId()).orElseThrow();
+
+        assertThat(foundProduct.getMemo()).isEqualTo("매장 전면 진열");
+    }
+
     private Artist createArtist(String email, String businessName) {
         User user = userRepository.save(User.builder()
                 .email(email)


### PR DESCRIPTION
## 요약
  - 작가 상품에 `memo` 필드를 추가
  - 상품 메모 조회, 저장/수정, 삭제 API를 추가
  - 메모가 없거나 삭제된 경우 빈 문자열로 응답하도록 처리

  ## 주요 변경
  - `GET /api/v1/artist/products/{productId}/memo`
  - `PATCH /api/v1/artist/products/{productId}/memo`
  - `DELETE /api/v1/artist/products/{productId}/memo`
  - 메모 길이 1000자 제한 추가
  - 작가 본인 소유의 활성 상품만 메모 접근 가능

  ## 테스트
  - `ArtistProductServiceTest`에 메모 조회/수정/삭제/권한 검증 케이스 추가
  - `ProductRepositoryTest`에 메모 저장/조회 케이스 추가

  ## 검증
  - `./gradlew test --tests "app.dearobjet.backend.domain.artist.ArtistProductServiceTest" --tests "app.dearobjet.backend.domain.artist.ProductRepositoryTest"`
