### PR TITLE
feat: 작가 출고관리 입점 매장 목록 조회 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
@@ -1,0 +1,38 @@
+package app.dearobjet.backend.domain.artist.controller;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
+import app.dearobjet.backend.domain.artist.service.ArtistShipmentService;
+import app.dearobjet.backend.global.api.ApiResponse;
+import app.dearobjet.backend.global.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/artist/shipments")
+public class ArtistShipmentController {
+
+    private final ArtistShipmentService artistShipmentService;
+
+    @GetMapping("/shops")
+    public ApiResponse<ArtistShipmentShopListResponse> getShipmentShops(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(artistShipmentService.getShipmentShops(resolveUserId(userDetails, userId)));
+    }
+
+    private Long resolveUserId(CustomUserDetails userDetails, Long userId) {
+        if (userDetails != null) {
+            return userDetails.getUserId();
+        }
+        if (userId != null) {
+            return userId;
+        }
+        throw new IllegalArgumentException("인증 정보가 없으면 userId 쿼리 파라미터가 필요합니다.");
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentInboundStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentInboundStatus.java
@@ -1,0 +1,27 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public enum ArtistShipmentInboundStatus {
+
+    CONFIRMED("확인"),
+    UNCONFIRMED("미확인"),
+    HOLD("보류");
+
+    private final String label;
+
+    public static ArtistShipmentInboundStatus from(LocalDateTime recentStockedAt, Boolean inboundConfirmed) {
+        if (recentStockedAt == null) {
+            return HOLD;
+        }
+        if (Boolean.TRUE.equals(inboundConfirmed)) {
+            return CONFIRMED;
+        }
+        return UNCONFIRMED;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentShopItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentShopItemResponse.java
@@ -1,0 +1,41 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistShipmentShopItemResponse {
+
+    private final Long contractId;
+    private final Long shopId;
+    private final String shopName;
+    private final Specialty specialty;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final String inboundStatusCode;
+    private final String inboundStatusLabel;
+
+    public static ArtistShipmentShopItemResponse from(ArtistShipmentShopRow row) {
+        ArtistShipmentInboundStatus inboundStatus = ArtistShipmentInboundStatus.from(
+                row.getRecentStockedAt(),
+                row.getInboundConfirmed()
+        );
+
+        return new ArtistShipmentShopItemResponse(
+                row.getContractId(),
+                row.getShopId(),
+                row.getShopName(),
+                row.getSpecialty(),
+                row.getContractStartDate(),
+                row.getContractEndDate(),
+                inboundStatus.name(),
+                inboundStatus.getLabel()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentShopListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentShopListResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistShipmentShopListResponse {
+
+    private final List<ArtistShipmentShopItemResponse> items;
+
+    public static ArtistShipmentShopListResponse from(List<ArtistShipmentShopRow> rows) {
+        return new ArtistShipmentShopListResponse(
+                rows.stream()
+                        .map(ArtistShipmentShopItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
@@ -1,0 +1,42 @@
+package app.dearobjet.backend.domain.artist.service;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.contract.ContractRepository;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistShipmentService {
+
+    private final ArtistRepository artistRepository;
+    private final ContractRepository contractRepository;
+
+    @Transactional(readOnly = true)
+    public ArtistShipmentShopListResponse getShipmentShops(Long userId) {
+        Artist artist = getArtistByUserId(userId);
+
+        return ArtistShipmentShopListResponse.from(
+                contractRepository.findShipmentShopRowsByArtistId(
+                        artist.getId(),
+                        ContractStatus.APPROVED,
+                        ContractProductListingStatus.ACTIVE
+                )
+        );
+    }
+
+    private Artist getArtistByUserId(Long userId) {
+        return artistRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "작가 정보를 찾을 수 없습니다."
+                ));
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract;
 
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
@@ -65,6 +66,40 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             """)
     List<ContractInventoryRow> findInventoryRowsByShopId(
             @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("listingStatus") ContractProductListingStatus listingStatus
+    );
+
+    @Query("""
+            select c.shopArtistContractsId as contractId,
+                   s.shopId as shopId,
+                   bp.businessName as shopName,
+                   bp.specialty as specialty,
+                   c.contractStartDate as contractStartDate,
+                   c.contractEndDate as contractEndDate,
+                   max(cp.recentStockedAt) as recentStockedAt,
+                   c.recentInboundConfirmed as inboundConfirmed
+            from ShopArtistContract c
+            join c.shop s
+            join s.businessProfile bp
+            left join ContractProduct cp
+                on cp.shopArtistContract = c
+               and cp.listingStatus = :listingStatus
+            where c.artist.id = :artistId
+              and c.contractStatus = :contractStatus
+            group by c.shopArtistContractsId,
+                     s.shopId,
+                     bp.businessName,
+                     bp.specialty,
+                     c.contractStartDate,
+                     c.contractEndDate,
+                     c.recentInboundConfirmed
+            order by case when max(cp.recentStockedAt) is null then 1 else 0 end,
+                     max(cp.recentStockedAt) desc,
+                     c.shopArtistContractsId desc
+            """)
+    List<ArtistShipmentShopRow> findShipmentShopRowsByArtistId(
+            @Param("artistId") Long artistId,
             @Param("contractStatus") ContractStatus contractStatus,
             @Param("listingStatus") ContractProductListingStatus listingStatus
     );

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentShopRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentShopRow.java
@@ -1,0 +1,17 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.user.enums.Specialty;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public interface ArtistShipmentShopRow {
+    Long getContractId();
+    Long getShopId();
+    String getShopName();
+    Specialty getSpecialty();
+    LocalDate getContractStartDate();
+    LocalDate getContractEndDate();
+    LocalDateTime getRecentStockedAt();
+    Boolean getInboundConfirmed();
+}

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
@@ -1,0 +1,141 @@
+package app.dearobjet.backend.domain.artist;
+
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.artist.service.ArtistShipmentService;
+import app.dearobjet.backend.domain.contract.ContractRepository;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
+import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("ArtistShipmentService 출고관리 테스트")
+@ExtendWith(MockitoExtension.class)
+class ArtistShipmentServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long ARTIST_ID = 10L;
+    private static final Long CONTRACT_ID = 50L;
+    private static final Long SHOP_ID = 100L;
+    private static final LocalDate CONTRACT_START_DATE = LocalDate.of(2026, 5, 1);
+    private static final LocalDate CONTRACT_END_DATE = LocalDate.of(2026, 12, 31);
+    private static final LocalDateTime RECENT_STOCKED_AT = LocalDateTime.of(2026, 5, 3, 10, 0);
+
+    @InjectMocks
+    private ArtistShipmentService artistShipmentService;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @Mock
+    private ContractRepository contractRepository;
+
+    @Test
+    @DisplayName("출고관리 입점 매장 목록에서 입고확인 상태를 함께 반환한다")
+    void givenArtist_whenGetShipmentShops_thenReturnInboundStatuses() {
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findShipmentShopRowsByArtistId(
+                ARTIST_ID,
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE
+        )).willReturn(List.of(
+                shipmentShopRow(CONTRACT_ID, SHOP_ID, "확인 소품샵", RECENT_STOCKED_AT, true),
+                shipmentShopRow(CONTRACT_ID + 1, SHOP_ID + 1, "미확인 소품샵", RECENT_STOCKED_AT, false),
+                shipmentShopRow(CONTRACT_ID + 2, SHOP_ID + 2, "보류 소품샵", null, false)
+        ));
+
+        ArtistShipmentShopListResponse response = artistShipmentService.getShipmentShops(USER_ID);
+
+        assertThat(response.getItems()).hasSize(3);
+        assertThat(response.getItems()).extracting("inboundStatusCode")
+                .containsExactly("CONFIRMED", "UNCONFIRMED", "HOLD");
+        assertThat(response.getItems()).extracting("inboundStatusLabel")
+                .containsExactly("확인", "미확인", "보류");
+        assertThat(response.getItems().get(0).getSpecialty()).isEqualTo(Specialty.LIVING_GOODS);
+        assertThat(response.getItems().get(0).getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
+        assertThat(response.getItems().get(0).getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
+    }
+
+    @Test
+    @DisplayName("작가 정보가 없으면 출고관리 목록을 조회할 수 없다")
+    void givenMissingArtist_whenGetShipmentShops_thenThrowNotFound() {
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> artistShipmentService.getShipmentShops(USER_ID))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("작가 정보를 찾을 수 없습니다.");
+    }
+
+    private Artist artist() {
+        return Artist.builder()
+                .id(ARTIST_ID)
+                .build();
+    }
+
+    private ArtistShipmentShopRow shipmentShopRow(
+            Long contractId,
+            Long shopId,
+            String shopName,
+            LocalDateTime recentStockedAt,
+            Boolean inboundConfirmed
+    ) {
+        return new ArtistShipmentShopRow() {
+            @Override
+            public Long getContractId() {
+                return contractId;
+            }
+
+            @Override
+            public Long getShopId() {
+                return shopId;
+            }
+
+            @Override
+            public String getShopName() {
+                return shopName;
+            }
+
+            @Override
+            public Specialty getSpecialty() {
+                return Specialty.LIVING_GOODS;
+            }
+
+            @Override
+            public LocalDate getContractStartDate() {
+                return CONTRACT_START_DATE;
+            }
+
+            @Override
+            public LocalDate getContractEndDate() {
+                return CONTRACT_END_DATE;
+            }
+
+            @Override
+            public LocalDateTime getRecentStockedAt() {
+                return recentStockedAt;
+            }
+
+            @Override
+            public Boolean getInboundConfirmed() {
+                return inboundConfirmed;
+            }
+        };
+    }
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -3,6 +3,7 @@ package app.dearobjet.backend.domain.contract;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
@@ -153,6 +154,135 @@ class ContractProductRepositoryTest {
         assertThat(plateRow.getTotalQuantity()).isEqualTo((long) PLATE_INBOUND_QUANTITY);
         assertThat(plateRow.getStockQuantity()).isEqualTo(PLATE_INBOUND_QUANTITY - PLATE_SALE_QUANTITY);
         assertThat(plateRow.getRecentStockedAt()).isEqualTo(PLATE_INBOUND_AT);
+    }
+
+    @Test
+    @DisplayName("출고관리 입점 매장 목록은 승인 계약 소품샵만 반환한다")
+    void givenArtistContracts_whenQueryShipmentShops_thenReturnApprovedShopsOnly() {
+        Artist artist = createArtist(
+                createUser("shipment-artist@test.com", "출고관리 작가", Role.ARTIST, "01097000001", null),
+                "출고관리 작가",
+                Specialty.CERAMIC
+        );
+        Shop approvedShop = createShop(
+                createUser("shipment-approved-shop@test.com", "승인 소품샵", Role.SHOP, "01097000002", null),
+                "승인 소품샵",
+                Specialty.HANDMADE_CRAFT
+        );
+        Shop pendingShop = createShop(
+                createUser("shipment-pending-shop@test.com", "대기 소품샵", Role.SHOP, "01097000003", null),
+                "대기 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop endedShop = createShop(
+                createUser("shipment-ended-shop@test.com", "만료 소품샵", Role.SHOP, "01097000004", null),
+                "만료 소품샵",
+                Specialty.STATIONERY_PAPER
+        );
+        ShopArtistContract approvedContract = createContract(
+                artist,
+                approvedShop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+        createContract(artist, pendingShop, ContractStatus.PENDING, ContractRequestType.NONE, null, null);
+        createContract(artist, endedShop, ContractStatus.ENDED, ContractRequestType.NONE, null, null);
+        flushAndClear();
+
+        List<ArtistShipmentShopRow> rows = contractRepository.findShipmentShopRowsByArtistId(
+                artist.getId(),
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getContractId()).isEqualTo(approvedContract.getShopArtistContractsId());
+        assertThat(rows.get(0).getShopName()).isEqualTo("승인 소품샵");
+        assertThat(rows.get(0).getSpecialty()).isEqualTo(Specialty.HANDMADE_CRAFT);
+        assertThat(rows.get(0).getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
+        assertThat(rows.get(0).getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
+        assertThat(rows.get(0).getRecentStockedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("출고관리 입점 매장 목록은 최근 입고일 기준으로 정렬한다")
+    void givenShipmentShopsWithInbound_whenQueryShipmentShops_thenSortByRecentInbound() {
+        Artist artist = createArtist(
+                createUser("shipment-sort-artist@test.com", "출고정렬 작가", Role.ARTIST, "01098000001", null),
+                "출고정렬 작가",
+                Specialty.CERAMIC
+        );
+        Shop recentShop = createShop(
+                createUser("shipment-sort-recent@test.com", "최근 입고 소품샵", Role.SHOP, "01098000002", null),
+                "최근 입고 소품샵",
+                Specialty.CERAMIC
+        );
+        Shop oldShop = createShop(
+                createUser("shipment-sort-old@test.com", "이전 입고 소품샵", Role.SHOP, "01098000003", null),
+                "이전 입고 소품샵",
+                Specialty.HANDMADE_CRAFT
+        );
+        Shop holdShop = createShop(
+                createUser("shipment-sort-hold@test.com", "보류 소품샵", Role.SHOP, "01098000004", null),
+                "보류 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        ShopArtistContract recentContract = createContract(artist, recentShop);
+        ShopArtistContract oldContract = createContract(artist, oldShop);
+        ShopArtistContract holdContract = createContract(artist, holdShop);
+        Product recentProduct = createProduct(
+                artist,
+                "최근 입고 상품",
+                CUP_PRICE,
+                "https://image.test/products/recent.png"
+        );
+        Product oldProduct = createProduct(
+                artist,
+                "이전 입고 상품",
+                PLATE_PRICE,
+                "https://image.test/products/old.png"
+        );
+        ContractProduct recentInventory = createContractProduct(
+                recentContract,
+                recentProduct,
+                CUP_SELLING_PRICE,
+                CUP_MARGIN_AMOUNT,
+                CUP_UNIT_SETTLEMENT_AMOUNT
+        );
+        ContractProduct oldInventory = createContractProduct(
+                oldContract,
+                oldProduct,
+                PLATE_SELLING_PRICE,
+                new BigDecimal("1800.00"),
+                new BigDecimal("7200.00")
+        );
+        ContractProductStockMovement recentInbound =
+                recentInventory.applyInbound(CUP_INBOUND_QUANTITY, CUP_INBOUND_AT, ACTOR_USER_ID, "최근 입고");
+        ContractProductStockMovement oldInbound =
+                oldInventory.applyInbound(PLATE_INBOUND_QUANTITY, PLATE_INBOUND_AT, ACTOR_USER_ID, "이전 입고");
+        contractProductRepository.save(recentInventory);
+        contractProductRepository.save(oldInventory);
+        saveMovement(recentInbound);
+        saveMovement(oldInbound);
+        flushAndClear();
+
+        List<ArtistShipmentShopRow> rows = contractRepository.findShipmentShopRowsByArtistId(
+                artist.getId(),
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE
+        );
+
+        assertThat(rows).extracting("contractId")
+                .containsExactly(
+                        recentContract.getShopArtistContractsId(),
+                        oldContract.getShopArtistContractsId(),
+                        holdContract.getShopArtistContractsId()
+                );
+        assertThat(rows.get(0).getRecentStockedAt()).isEqualTo(CUP_INBOUND_AT);
+        assertThat(rows.get(1).getRecentStockedAt()).isEqualTo(PLATE_INBOUND_AT);
+        assertThat(rows.get(2).getRecentStockedAt()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 변경 내용
  - 작가 출고관리 페이지에서 계약완료 소품샵 목록을 조회하는 API를 추가
  - 응답에 소품샵명, 매장분류, 최초계약일, 계약종료일, 입고확인 상태를 포함
  - 입고확인 상태는 최근 입고 여부와 소품샵 입고확인 승인 여부를 기준으로 확인/미확인/보류 응답

  ## 테스트
  - ArtistShipmentService 단위 테스트 추가
  - ContractRepository 출고관리 목록 조회 테스트 추가
  - 승인 계약만 노출, 최근 입고일 정렬, 입고확인 상태 계산 검증