### PR TITLE
feat: 작가 출고리스트 조회 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.domain.artist.controller;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
 import app.dearobjet.backend.domain.artist.service.ArtistShipmentService;
 import app.dearobjet.backend.global.api.ApiResponse;
@@ -7,6 +8,7 @@ import app.dearobjet.backend.global.auth.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +26,17 @@ public class ArtistShipmentController {
             @RequestParam(required = false) Long userId
     ) {
         return ApiResponse.of(artistShipmentService.getShipmentShops(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/shops/{contractId}/products")
+    public ApiResponse<ArtistShipmentProductListResponse> getShipmentProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                artistShipmentService.getShipmentProducts(resolveUserId(userDetails, userId), contractId)
+        );
     }
 
     private Long resolveUserId(CustomUserDetails userDetails, Long userId) {

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductItemResponse.java
@@ -1,0 +1,29 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistShipmentProductItemResponse {
+
+    private final Long contractProductId;
+    private final String productImageUrl;
+    private final String productName;
+    private final Long totalShipmentQuantity;
+    private final BigDecimal sellingPrice;
+
+    public static ArtistShipmentProductItemResponse from(ArtistShipmentProductRow row) {
+        return new ArtistShipmentProductItemResponse(
+                row.getContractProductId(),
+                row.getProductImageUrl(),
+                row.getProductName(),
+                row.getTotalShipmentQuantity(),
+                row.getSellingPrice()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductListResponse.java
@@ -1,0 +1,25 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistShipmentProductListResponse {
+
+    private final Long contractId;
+    private final List<ArtistShipmentProductItemResponse> items;
+
+    public static ArtistShipmentProductListResponse from(Long contractId, List<ArtistShipmentProductRow> rows) {
+        return new ArtistShipmentProductListResponse(
+                contractId,
+                rows.stream()
+                        .map(ArtistShipmentProductItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
@@ -1,10 +1,14 @@
 package app.dearobjet.backend.domain.artist.service;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.ContractRepository;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
 import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
@@ -18,6 +22,7 @@ public class ArtistShipmentService {
 
     private final ArtistRepository artistRepository;
     private final ContractRepository contractRepository;
+    private final ContractProductRepository contractProductRepository;
 
     @Transactional(readOnly = true)
     public ArtistShipmentShopListResponse getShipmentShops(Long userId) {
@@ -32,11 +37,43 @@ public class ArtistShipmentService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public ArtistShipmentProductListResponse getShipmentProducts(Long userId, Long contractId) {
+        Artist artist = getArtistByUserId(userId);
+        ShopArtistContract contract = getApprovedContractByArtist(contractId, artist.getId());
+
+        return ArtistShipmentProductListResponse.from(
+                contract.getShopArtistContractsId(),
+                contractProductRepository.findShipmentProductRowsByContractId(
+                        contractId,
+                        artist.getId(),
+                        ContractStatus.APPROVED,
+                        ContractProductListingStatus.ACTIVE,
+                        ContractProductStockMovementType.INBOUND
+                )
+        );
+    }
+
     private Artist getArtistByUserId(Long userId) {
         return artistRepository.findByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException(
                         ErrorCode.ENTITY_NOT_FOUND,
                         "작가 정보를 찾을 수 없습니다."
                 ));
+    }
+
+    private ShopArtistContract getApprovedContractByArtist(Long contractId, Long artistId) {
+        ShopArtistContract contract = contractRepository.findContractByIdAndArtistId(contractId, artistId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "계약서 정보를 찾을 수 없습니다."
+                ));
+        if (contract.getContractStatus() != ContractStatus.APPROVED) {
+            throw new EntityNotFoundException(
+                    ErrorCode.ENTITY_NOT_FOUND,
+                    "계약서 정보를 찾을 수 없습니다."
+            );
+        }
+        return contract;
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentProductRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentProductRow.java
@@ -1,0 +1,11 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import java.math.BigDecimal;
+
+public interface ArtistShipmentProductRow {
+    Long getContractProductId();
+    String getProductImageUrl();
+    String getProductName();
+    Long getTotalShipmentQuantity();
+    BigDecimal getSellingPrice();
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.domain.contract.repository;
 
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
@@ -55,6 +56,37 @@ public interface ContractProductRepository extends JpaRepository<ContractProduct
     List<ContractInventoryProductRow> findInventoryProductRowsByContractId(
             @Param("contractId") Long contractId,
             @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("listingStatus") ContractProductListingStatus listingStatus,
+            @Param("inboundType") ContractProductStockMovementType inboundType
+    );
+
+    @Query("""
+            select cp.contractProductsId as contractProductId,
+                   p.productUrl as productImageUrl,
+                   p.productName as productName,
+                   coalesce(sum(m.quantityDelta), 0) as totalShipmentQuantity,
+                   cp.sellingPrice as sellingPrice
+            from ContractProduct cp
+            join cp.shopArtistContract sac
+            join cp.product p
+            left join ContractProductStockMovement m
+                on m.contractProduct = cp
+               and m.movementType = :inboundType
+            where sac.shopArtistContractsId = :contractId
+              and sac.artist.id = :artistId
+              and sac.contractStatus = :contractStatus
+              and cp.listingStatus = :listingStatus
+            group by cp.contractProductsId,
+                     p.productUrl,
+                     p.productName,
+                     cp.sellingPrice,
+                     cp.recentStockedAt
+            order by cp.recentStockedAt desc, cp.contractProductsId desc
+            """)
+    List<ArtistShipmentProductRow> findShipmentProductRowsByContractId(
+            @Param("contractId") Long contractId,
+            @Param("artistId") Long artistId,
             @Param("contractStatus") ContractStatus contractStatus,
             @Param("listingStatus") ContractProductListingStatus listingStatus,
             @Param("inboundType") ContractProductStockMovementType inboundType

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
@@ -1,12 +1,17 @@
 package app.dearobjet.backend.domain.artist;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.artist.service.ArtistShipmentService;
 import app.dearobjet.backend.domain.contract.ContractRepository;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
 import app.dearobjet.backend.domain.user.enums.Specialty;
 import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
@@ -17,6 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,7 +39,9 @@ class ArtistShipmentServiceTest {
     private static final Long USER_ID = 1L;
     private static final Long ARTIST_ID = 10L;
     private static final Long CONTRACT_ID = 50L;
+    private static final Long CONTRACT_PRODUCT_ID = 70L;
     private static final Long SHOP_ID = 100L;
+    private static final BigDecimal SELLING_PRICE = new BigDecimal("15000.00");
     private static final LocalDate CONTRACT_START_DATE = LocalDate.of(2026, 5, 1);
     private static final LocalDate CONTRACT_END_DATE = LocalDate.of(2026, 12, 31);
     private static final LocalDateTime RECENT_STOCKED_AT = LocalDateTime.of(2026, 5, 3, 10, 0);
@@ -46,6 +54,9 @@ class ArtistShipmentServiceTest {
 
     @Mock
     private ContractRepository contractRepository;
+
+    @Mock
+    private ContractProductRepository contractProductRepository;
 
     @Test
     @DisplayName("출고관리 입점 매장 목록에서 입고확인 상태를 함께 반환한다")
@@ -83,10 +94,86 @@ class ArtistShipmentServiceTest {
                 .hasMessage("작가 정보를 찾을 수 없습니다.");
     }
 
+    @Test
+    @DisplayName("출고리스트는 승인 계약의 출고상품 요약을 반환한다")
+    void givenApprovedContract_whenGetShipmentProducts_thenReturnShipmentProducts() {
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findContractByIdAndArtistId(CONTRACT_ID, ARTIST_ID))
+                .willReturn(Optional.of(contract(ContractStatus.APPROVED)));
+        given(contractProductRepository.findShipmentProductRowsByContractId(
+                CONTRACT_ID,
+                ARTIST_ID,
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE,
+                ContractProductStockMovementType.INBOUND
+        )).willReturn(List.of(shipmentProductRow(CONTRACT_PRODUCT_ID, "세라믹 컵", 10L)));
+
+        ArtistShipmentProductListResponse response = artistShipmentService.getShipmentProducts(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getContractProductId()).isEqualTo(CONTRACT_PRODUCT_ID);
+        assertThat(response.getItems().get(0).getProductName()).isEqualTo("세라믹 컵");
+        assertThat(response.getItems().get(0).getTotalShipmentQuantity()).isEqualTo(10L);
+        assertThat(response.getItems().get(0).getSellingPrice()).isEqualByComparingTo(SELLING_PRICE);
+    }
+
+    @Test
+    @DisplayName("승인 계약이 아니면 출고리스트를 조회할 수 없다")
+    void givenNotApprovedContract_whenGetShipmentProducts_thenThrowNotFound() {
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findContractByIdAndArtistId(CONTRACT_ID, ARTIST_ID))
+                .willReturn(Optional.of(contract(ContractStatus.PENDING)));
+
+        assertThatThrownBy(() -> artistShipmentService.getShipmentProducts(USER_ID, CONTRACT_ID))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("계약서 정보를 찾을 수 없습니다.");
+    }
+
     private Artist artist() {
         return Artist.builder()
                 .id(ARTIST_ID)
                 .build();
+    }
+
+    private ShopArtistContract contract(ContractStatus contractStatus) {
+        return ShopArtistContract.builder()
+                .shopArtistContractsId(CONTRACT_ID)
+                .contractStatus(contractStatus)
+                .build();
+    }
+
+    private ArtistShipmentProductRow shipmentProductRow(
+            Long contractProductId,
+            String productName,
+            Long totalShipmentQuantity
+    ) {
+        return new ArtistShipmentProductRow() {
+            @Override
+            public Long getContractProductId() {
+                return contractProductId;
+            }
+
+            @Override
+            public String getProductImageUrl() {
+                return "https://image.test/products/cup.png";
+            }
+
+            @Override
+            public String getProductName() {
+                return productName;
+            }
+
+            @Override
+            public Long getTotalShipmentQuantity() {
+                return totalShipmentQuantity;
+            }
+
+            @Override
+            public BigDecimal getSellingPrice() {
+                return SELLING_PRICE;
+            }
+        };
     }
 
     private ArtistShipmentShopRow shipmentShopRow(

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -3,6 +3,7 @@ package app.dearobjet.backend.domain.contract;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
@@ -154,6 +155,89 @@ class ContractProductRepositoryTest {
         assertThat(plateRow.getTotalQuantity()).isEqualTo((long) PLATE_INBOUND_QUANTITY);
         assertThat(plateRow.getStockQuantity()).isEqualTo(PLATE_INBOUND_QUANTITY - PLATE_SALE_QUANTITY);
         assertThat(plateRow.getRecentStockedAt()).isEqualTo(PLATE_INBOUND_AT);
+    }
+
+    @Test
+    @DisplayName("작가 출고리스트는 활성 계약상품의 총 출고수량과 판매가를 반환한다")
+    void givenArtistShipmentProducts_whenQueryByContract_thenReturnShipmentProductRows() {
+        Artist artist = createArtist(
+                createUser("shipment-products-artist@test.com", "출고상품 작가", Role.ARTIST, "01099000001", null),
+                "출고상품 작가",
+                Specialty.CERAMIC
+        );
+        Shop shop = createShop(
+                createUser("shipment-products-shop@test.com", "출고상품 소품샵", Role.SHOP, "01099000002", null),
+                "출고상품 소품샵",
+                Specialty.HANDMADE_CRAFT
+        );
+        ShopArtistContract contract = createContract(artist, shop);
+        Product shippedProduct = createProduct(
+                artist,
+                "출고된 세라믹 컵",
+                CUP_PRICE,
+                "https://image.test/products/shipped-cup.png"
+        );
+        Product pendingProduct = createProduct(
+                artist,
+                "출고 대기 접시",
+                PLATE_PRICE,
+                "https://image.test/products/pending-plate.png"
+        );
+        Product endedProduct = createProduct(
+                artist,
+                "종료된 상품",
+                PLATE_PRICE,
+                "https://image.test/products/ended.png"
+        );
+        ContractProduct shippedInventory = createContractProduct(
+                contract,
+                shippedProduct,
+                CUP_SELLING_PRICE,
+                CUP_MARGIN_AMOUNT,
+                CUP_UNIT_SETTLEMENT_AMOUNT
+        );
+        ContractProduct pendingInventory = createContractProduct(
+                contract,
+                pendingProduct,
+                PLATE_SELLING_PRICE,
+                new BigDecimal("1800.00"),
+                new BigDecimal("7200.00")
+        );
+        ContractProduct endedInventory = ContractProduct.builder()
+                .shopArtistContract(contract)
+                .product(endedProduct)
+                .listingStatus(ContractProductListingStatus.ENDED)
+                .sellingPrice(PLATE_SELLING_PRICE)
+                .build();
+        ContractProductStockMovement firstInbound =
+                shippedInventory.applyInbound(CUP_INBOUND_QUANTITY, CUP_INBOUND_AT, ACTOR_USER_ID, "1차 출고");
+        ContractProductStockMovement secondInbound =
+                shippedInventory.applyInbound(PLATE_INBOUND_QUANTITY, PLATE_INBOUND_AT, ACTOR_USER_ID, "2차 출고");
+
+        contractProductRepository.save(shippedInventory);
+        contractProductRepository.save(pendingInventory);
+        contractProductRepository.save(endedInventory);
+        saveMovement(firstInbound);
+        saveMovement(secondInbound);
+        flushAndClear();
+
+        List<ArtistShipmentProductRow> rows = contractProductRepository.findShipmentProductRowsByContractId(
+                contract.getShopArtistContractsId(),
+                artist.getId(),
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE,
+                ContractProductStockMovementType.INBOUND
+        );
+
+        assertThat(rows).hasSize(2);
+        ArtistShipmentProductRow shippedRow = findShipmentProductRow(rows, "출고된 세라믹 컵");
+        ArtistShipmentProductRow pendingRow = findShipmentProductRow(rows, "출고 대기 접시");
+
+        assertThat(shippedRow.getTotalShipmentQuantity()).isEqualTo(CUP_INBOUND_QUANTITY + PLATE_INBOUND_QUANTITY);
+        assertThat(shippedRow.getProductImageUrl()).isEqualTo("https://image.test/products/shipped-cup.png");
+        assertThat(shippedRow.getSellingPrice()).isEqualByComparingTo(CUP_SELLING_PRICE);
+        assertThat(pendingRow.getTotalShipmentQuantity()).isZero();
+        assertThat(rows).extracting("productName").doesNotContain("종료된 상품");
     }
 
     @Test
@@ -1013,6 +1097,16 @@ class ContractProductRepositoryTest {
 
     private ContractInventoryProductRow findProductRow(
             List<ContractInventoryProductRow> rows,
+            String productName
+    ) {
+        return rows.stream()
+                .filter(row -> productName.equals(row.getProductName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private ArtistShipmentProductRow findShipmentProductRow(
+            List<ArtistShipmentProductRow> rows,
             String productName
     ) {
         return rows.stream()


### PR DESCRIPTION
## 변경 내용
  - 작가 출고관리 페이지에서 입점 매장 행의 열람 버튼 클릭 시 사용할 출고리스트 조회 API를 추가
  - `contractId` 기준으로 작가 본인 소유의 승인 계약만 조회되도록 검증
  - 계약상품별 상품 이미지, 상품명, 총 출고수량, 판매가를 반환
  - 총 출고수량은 `INBOUND` 재고 이동 수량 합계 기준으로 계산

  ## API
  - `GET /api/v1/artist/shipments/shops/{contractId}/products`

  ## 테스트
  - 출고리스트 서비스 단위 테스트 추가
  - Repository 조회 테스트 추가
  - 승인 계약/활성 계약상품 조회, 출고수량 합산, 출고 이력 없는 상품 0 반환, 비활성 계약상품 제외 검증

  검증 명령:

  ./gradlew test --tests "app.dearobjet.backend.domain.artist.ArtistShipmentServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"