### PR TITLE
feat: 작가 출고리스트 정산 정보 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductItemResponse.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.domain.artist.dto;
 
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,6 +17,9 @@ public class ArtistShipmentProductItemResponse {
     private final String productName;
     private final Long totalShipmentQuantity;
     private final BigDecimal sellingPrice;
+    private final CommissionType commissionType;
+    private final BigDecimal commissionValue;
+    private final BigDecimal unitSettlementAmount;
 
     public static ArtistShipmentProductItemResponse from(ArtistShipmentProductRow row) {
         return new ArtistShipmentProductItemResponse(
@@ -23,7 +27,10 @@ public class ArtistShipmentProductItemResponse {
                 row.getProductImageUrl(),
                 row.getProductName(),
                 row.getTotalShipmentQuantity(),
-                row.getSellingPrice()
+                row.getSellingPrice(),
+                row.getCommissionType(),
+                row.getCommissionValue(),
+                row.getUnitSettlementAmount()
         );
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentProductRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentProductRow.java
@@ -1,5 +1,7 @@
 package app.dearobjet.backend.domain.contract.dto.projection;
 
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+
 import java.math.BigDecimal;
 
 public interface ArtistShipmentProductRow {
@@ -8,4 +10,7 @@ public interface ArtistShipmentProductRow {
     String getProductName();
     Long getTotalShipmentQuantity();
     BigDecimal getSellingPrice();
+    CommissionType getCommissionType();
+    BigDecimal getCommissionValue();
+    BigDecimal getUnitSettlementAmount();
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
@@ -66,7 +66,10 @@ public interface ContractProductRepository extends JpaRepository<ContractProduct
                    p.productUrl as productImageUrl,
                    p.productName as productName,
                    coalesce(sum(m.quantityDelta), 0) as totalShipmentQuantity,
-                   cp.sellingPrice as sellingPrice
+                   cp.sellingPrice as sellingPrice,
+                   sac.commissionType as commissionType,
+                   sac.commissionValue as commissionValue,
+                   cp.unitSettlementAmount as unitSettlementAmount
             from ContractProduct cp
             join cp.shopArtistContract sac
             join cp.product p
@@ -81,6 +84,9 @@ public interface ContractProductRepository extends JpaRepository<ContractProduct
                      p.productUrl,
                      p.productName,
                      cp.sellingPrice,
+                     sac.commissionType,
+                     sac.commissionValue,
+                     cp.unitSettlementAmount,
                      cp.recentStockedAt
             order by cp.recentStockedAt desc, cp.contractProductsId desc
             """)

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
@@ -8,6 +8,7 @@ import app.dearobjet.backend.domain.contract.ContractRepository;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
@@ -42,6 +43,8 @@ class ArtistShipmentServiceTest {
     private static final Long CONTRACT_PRODUCT_ID = 70L;
     private static final Long SHOP_ID = 100L;
     private static final BigDecimal SELLING_PRICE = new BigDecimal("15000.00");
+    private static final BigDecimal COMMISSION_VALUE = new BigDecimal("20.0000");
+    private static final BigDecimal UNIT_SETTLEMENT_AMOUNT = new BigDecimal("12000.00");
     private static final LocalDate CONTRACT_START_DATE = LocalDate.of(2026, 5, 1);
     private static final LocalDate CONTRACT_END_DATE = LocalDate.of(2026, 12, 31);
     private static final LocalDateTime RECENT_STOCKED_AT = LocalDateTime.of(2026, 5, 3, 10, 0);
@@ -116,6 +119,9 @@ class ArtistShipmentServiceTest {
         assertThat(response.getItems().get(0).getProductName()).isEqualTo("세라믹 컵");
         assertThat(response.getItems().get(0).getTotalShipmentQuantity()).isEqualTo(10L);
         assertThat(response.getItems().get(0).getSellingPrice()).isEqualByComparingTo(SELLING_PRICE);
+        assertThat(response.getItems().get(0).getCommissionType()).isEqualTo(CommissionType.RATE);
+        assertThat(response.getItems().get(0).getCommissionValue()).isEqualByComparingTo(COMMISSION_VALUE);
+        assertThat(response.getItems().get(0).getUnitSettlementAmount()).isEqualByComparingTo(UNIT_SETTLEMENT_AMOUNT);
     }
 
     @Test
@@ -172,6 +178,21 @@ class ArtistShipmentServiceTest {
             @Override
             public BigDecimal getSellingPrice() {
                 return SELLING_PRICE;
+            }
+
+            @Override
+            public CommissionType getCommissionType() {
+                return CommissionType.RATE;
+            }
+
+            @Override
+            public BigDecimal getCommissionValue() {
+                return COMMISSION_VALUE;
+            }
+
+            @Override
+            public BigDecimal getUnitSettlementAmount() {
+                return UNIT_SETTLEMENT_AMOUNT;
             }
         };
     }

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -236,7 +236,11 @@ class ContractProductRepositoryTest {
         assertThat(shippedRow.getTotalShipmentQuantity()).isEqualTo(CUP_INBOUND_QUANTITY + PLATE_INBOUND_QUANTITY);
         assertThat(shippedRow.getProductImageUrl()).isEqualTo("https://image.test/products/shipped-cup.png");
         assertThat(shippedRow.getSellingPrice()).isEqualByComparingTo(CUP_SELLING_PRICE);
+        assertThat(shippedRow.getCommissionType()).isEqualTo(CommissionType.RATE);
+        assertThat(shippedRow.getCommissionValue()).isEqualByComparingTo(DEFAULT_COMMISSION_VALUE);
+        assertThat(shippedRow.getUnitSettlementAmount()).isEqualByComparingTo(CUP_UNIT_SETTLEMENT_AMOUNT);
         assertThat(pendingRow.getTotalShipmentQuantity()).isZero();
+        assertThat(pendingRow.getUnitSettlementAmount()).isEqualByComparingTo(new BigDecimal("7200.00"));
         assertThat(rows).extracting("productName").doesNotContain("종료된 상품");
     }
 


### PR DESCRIPTION
resolves #67 

## 변경 내용
  - 작가 출고리스트 열람 API 응답에 수수료와 개당 정산금액을 추가
  - 계약상품별로 상품이미지, 상품명, 판매가, 출고수량, 수수료, 개당 정산금액을 확인할 수 있도록 수정
  - 수수료는 계약 단위의 `commissionType`, `commissionValue`를 사용하고, 개당 정산금액은 계약상품의 `unitSettlementAmount`를 사용

  ## API 응답 추가 필드
  - `commissionType`
  - `commissionValue`
  - `unitSettlementAmount`

  ## 테스트
  - 출고리스트 서비스 테스트에 정산 정보 검증 추가
  - Repository 조회 테스트에 수수료/개당 정산금액 검증 추가

  검증 명령:

  ./gradlew test --tests "app.dearobjet.backend.domain.artist.ArtistShipmentServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"