### PR TITLE
fix: 작가 출고관리 매장 목록 및 계약별 출고 이력 조회 구현

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
@@ -28,14 +28,14 @@ public class ArtistShipmentController {
         return ApiResponse.of(artistShipmentService.getShipmentShops(resolveUserId(userDetails, userId)));
     }
 
-    @GetMapping("/shops/{contractId}/products")
+    @GetMapping("/shops/{shopId}/products")
     public ApiResponse<ArtistShipmentProductListResponse> getShipmentProducts(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(required = false) Long userId,
-            @PathVariable Long contractId
+            @PathVariable Long shopId
     ) {
         return ApiResponse.of(
-                artistShipmentService.getShipmentProducts(resolveUserId(userDetails, userId), contractId)
+                artistShipmentService.getShipmentProducts(resolveUserId(userDetails, userId), shopId)
         );
     }
 

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductContractResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductContractResponse.java
@@ -1,0 +1,37 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistShipmentProductContractResponse {
+
+    private final Long contractId;
+    private final ContractStatus contractStatus;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final List<ArtistShipmentProductItemResponse> items;
+
+    public static ArtistShipmentProductContractResponse from(
+            ShopArtistContract contract,
+            List<ArtistShipmentProductRow> rows
+    ) {
+        return new ArtistShipmentProductContractResponse(
+                contract.getShopArtistContractsId(),
+                contract.getContractStatus(),
+                contract.getContractStartDate(),
+                contract.getContractEndDate(),
+                rows.stream()
+                        .map(ArtistShipmentProductItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentProductListResponse.java
@@ -1,24 +1,41 @@
 package app.dearobjet.backend.domain.artist.dto;
 
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ArtistShipmentProductListResponse {
 
-    private final Long contractId;
-    private final List<ArtistShipmentProductItemResponse> items;
+    private final Long shopId;
+    private final List<ArtistShipmentProductContractResponse> contracts;
 
-    public static ArtistShipmentProductListResponse from(Long contractId, List<ArtistShipmentProductRow> rows) {
+    public static ArtistShipmentProductListResponse from(
+            Long shopId,
+            List<ShopArtistContract> contracts,
+            List<ArtistShipmentProductRow> rows
+    ) {
+        Map<Long, List<ArtistShipmentProductRow>> rowsByContractId = rows.stream()
+                .collect(Collectors.groupingBy(ArtistShipmentProductRow::getContractId));
+
         return new ArtistShipmentProductListResponse(
-                contractId,
-                rows.stream()
-                        .map(ArtistShipmentProductItemResponse::from)
+                shopId,
+                contracts.stream()
+                        .map(contract -> ArtistShipmentProductContractResponse.from(
+                                contract,
+                                rowsByContractId.getOrDefault(
+                                        contract.getShopArtistContractsId(),
+                                        Collections.emptyList()
+                                )
+                        ))
                         .toList()
         );
     }

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
@@ -16,9 +16,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ArtistShipmentService {
+
+    private static final List<ContractStatus> SHIPMENT_PRODUCT_CONTRACT_STATUSES = List.of(
+            ContractStatus.APPROVED,
+            ContractStatus.ENDED,
+            ContractStatus.TERMINATED
+    );
 
     private final ArtistRepository artistRepository;
     private final ContractRepository contractRepository;
@@ -32,23 +41,26 @@ public class ArtistShipmentService {
                 contractRepository.findShipmentShopRowsByArtistId(
                         artist.getId(),
                         ContractStatus.APPROVED,
-                        ContractProductListingStatus.ACTIVE
+                        ContractProductListingStatus.ACTIVE,
+                        LocalDate.now()
                 )
         );
     }
 
     @Transactional(readOnly = true)
-    public ArtistShipmentProductListResponse getShipmentProducts(Long userId, Long contractId) {
+    public ArtistShipmentProductListResponse getShipmentProducts(Long userId, Long shopId) {
         Artist artist = getArtistByUserId(userId);
-        ShopArtistContract contract = getApprovedContractByArtist(contractId, artist.getId());
+        List<ShopArtistContract> contracts = getShipmentProductContracts(artist.getId(), shopId);
+        List<Long> contractIds = contracts.stream()
+                .map(ShopArtistContract::getShopArtistContractsId)
+                .toList();
 
         return ArtistShipmentProductListResponse.from(
-                contract.getShopArtistContractsId(),
-                contractProductRepository.findShipmentProductRowsByContractId(
-                        contractId,
+                shopId,
+                contracts,
+                contractProductRepository.findShipmentProductRowsByContractIds(
+                        contractIds,
                         artist.getId(),
-                        ContractStatus.APPROVED,
-                        ContractProductListingStatus.ACTIVE,
                         ContractProductStockMovementType.INBOUND
                 )
         );
@@ -62,18 +74,18 @@ public class ArtistShipmentService {
                 ));
     }
 
-    private ShopArtistContract getApprovedContractByArtist(Long contractId, Long artistId) {
-        ShopArtistContract contract = contractRepository.findContractByIdAndArtistId(contractId, artistId)
-                .orElseThrow(() -> new EntityNotFoundException(
-                        ErrorCode.ENTITY_NOT_FOUND,
-                        "계약서 정보를 찾을 수 없습니다."
-                ));
-        if (contract.getContractStatus() != ContractStatus.APPROVED) {
+    private List<ShopArtistContract> getShipmentProductContracts(Long artistId, Long shopId) {
+        List<ShopArtistContract> contracts = contractRepository.findShipmentProductContractsByArtistIdAndShopId(
+                        artistId,
+                        shopId,
+                        SHIPMENT_PRODUCT_CONTRACT_STATUSES
+                );
+        if (contracts.isEmpty()) {
             throw new EntityNotFoundException(
                     ErrorCode.ENTITY_NOT_FOUND,
                     "계약서 정보를 찾을 수 없습니다."
             );
         }
-        return contract;
+        return contracts;
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -87,6 +87,22 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
                and cp.listingStatus = :listingStatus
             where c.artist.id = :artistId
               and c.contractStatus = :contractStatus
+              and (
+                  c.contractEndDate is null
+                  or c.contractEndDate >= :today
+              )
+              and not exists (
+                  select 1
+                  from ShopArtistContract c2
+                  where c2.artist = c.artist
+                    and c2.shop = c.shop
+                    and c2.contractStatus = :contractStatus
+                    and (
+                        c2.contractEndDate is null
+                        or c2.contractEndDate >= :today
+                    )
+                    and c2.shopArtistContractsId > c.shopArtistContractsId
+              )
             group by c.shopArtistContractsId,
                      s.shopId,
                      bp.businessName,
@@ -101,7 +117,38 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
     List<ArtistShipmentShopRow> findShipmentShopRowsByArtistId(
             @Param("artistId") Long artistId,
             @Param("contractStatus") ContractStatus contractStatus,
-            @Param("listingStatus") ContractProductListingStatus listingStatus
+            @Param("listingStatus") ContractProductListingStatus listingStatus,
+            @Param("today") java.time.LocalDate today
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
+            join fetch c.shop s
+            join fetch s.businessProfile
+            where c.artist.id = :artistId
+              and s.shopId = :shopId
+              and c.contractStatus = :contractStatus
+            order by c.shopArtistContractsId desc
+            """)
+    List<ShopArtistContract> findApprovedContractsByArtistIdAndShopId(
+            @Param("artistId") Long artistId,
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
+            where c.artist.id = :artistId
+              and c.shop.shopId = :shopId
+              and c.contractStatus in :contractStatuses
+            order by c.shopArtistContractsId desc
+            """)
+    List<ShopArtistContract> findShipmentProductContractsByArtistIdAndShopId(
+            @Param("artistId") Long artistId,
+            @Param("shopId") Long shopId,
+            @Param("contractStatuses") List<ContractStatus> contractStatuses
     );
 
     @Query("""
@@ -262,14 +309,25 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
                   from ShopArtistContract c
                   where c.shop.shopId = :shopId
                     and c.artist = a
-                    and c.contractStatus in :excludedStatuses
+                    and (
+                        c.contractStatus = :pendingStatus
+                        or (
+                            c.contractStatus = :approvedStatus
+                            and (
+                                c.contractEndDate is null
+                                or c.contractEndDate >= :today
+                            )
+                        )
+                    )
               )
             """)
     List<ArtistSuggestionRow> findArtistSuggestionRows(
             @Param("shopId") Long shopId,
             @Param("artistRole") Role artistRole,
             @Param("activeStatus") UserStatus activeStatus,
-            @Param("excludedStatuses") List<ContractStatus> excludedStatuses
+            @Param("pendingStatus") ContractStatus pendingStatus,
+            @Param("approvedStatus") ContractStatus approvedStatus,
+            @Param("today") java.time.LocalDate today
     );
 
     @Query("""
@@ -296,7 +354,16 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
                   from ShopArtistContract c
                   where c.shop.shopId = :shopId
                     and c.artist = a
-                    and c.contractStatus in :excludedStatuses
+                    and (
+                        c.contractStatus = :pendingStatus
+                        or (
+                            c.contractStatus = :approvedStatus
+                            and (
+                                c.contractEndDate is null
+                                or c.contractEndDate >= :today
+                            )
+                        )
+                    )
               )
             order by bp.businessName asc, a.id desc
             """)
@@ -304,7 +371,9 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             @Param("shopId") Long shopId,
             @Param("artistRole") Role artistRole,
             @Param("activeStatus") UserStatus activeStatus,
-            @Param("excludedStatuses") List<ContractStatus> excludedStatuses,
+            @Param("pendingStatus") ContractStatus pendingStatus,
+            @Param("approvedStatus") ContractStatus approvedStatus,
+            @Param("today") java.time.LocalDate today,
             @Param("keyword") String keyword,
             Pageable pageable
     );

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -61,12 +61,6 @@ public class ContractService {
             ContractStatus.ENDED
     );
 
-    private static final List<ContractStatus> ARTIST_SUGGESTION_EXCLUDED_STATUSES = List.of(
-            ContractStatus.PENDING,
-            ContractStatus.APPROVED,
-            ContractStatus.ENDED
-    );
-
     private static final List<ContractStatus> MANAGED_SHOP_CONTRACT_STATUSES = List.of(
             ContractStatus.PENDING,
             ContractStatus.APPROVED,
@@ -114,7 +108,9 @@ public class ContractService {
                 shop.getShopId(),
                 Role.ARTIST,
                 UserStatus.ACTIVE,
-                ARTIST_SUGGESTION_EXCLUDED_STATUSES
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                LocalDate.now()
         ));
 
         Collections.shuffle(rows);
@@ -138,7 +134,9 @@ public class ContractService {
                         shop.getShopId(),
                         Role.ARTIST,
                         UserStatus.ACTIVE,
-                        ARTIST_SUGGESTION_EXCLUDED_STATUSES,
+                        ContractStatus.PENDING,
+                        ContractStatus.APPROVED,
+                        LocalDate.now(),
                         "%" + normalizedKeyword + "%",
                         PageRequest.of(0, ARTIST_ACCOUNT_SEARCH_LIMIT)
                 )

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentProductRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ArtistShipmentProductRow.java
@@ -5,6 +5,7 @@ import app.dearobjet.backend.domain.contract.enums.CommissionType;
 import java.math.BigDecimal;
 
 public interface ArtistShipmentProductRow {
+    Long getContractId();
     Long getContractProductId();
     String getProductImageUrl();
     String getProductName();

--- a/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
@@ -40,7 +40,8 @@ public interface ContractProductRepository extends JpaRepository<ContractProduct
               and sac.shop.shopId = :shopId
               and sac.contractStatus = :contractStatus
               and cp.listingStatus = :listingStatus
-            group by cp.contractProductsId,
+            group by sac.shopArtistContractsId,
+                     cp.contractProductsId,
                      p.productUrl,
                      p.productName,
                      cp.sellingPrice,
@@ -62,7 +63,8 @@ public interface ContractProductRepository extends JpaRepository<ContractProduct
     );
 
     @Query("""
-            select cp.contractProductsId as contractProductId,
+            select sac.shopArtistContractsId as contractId,
+                   cp.contractProductsId as contractProductId,
                    p.productUrl as productImageUrl,
                    p.productName as productName,
                    coalesce(sum(m.quantityDelta), 0) as totalShipmentQuantity,
@@ -95,6 +97,41 @@ public interface ContractProductRepository extends JpaRepository<ContractProduct
             @Param("artistId") Long artistId,
             @Param("contractStatus") ContractStatus contractStatus,
             @Param("listingStatus") ContractProductListingStatus listingStatus,
+            @Param("inboundType") ContractProductStockMovementType inboundType
+    );
+
+    @Query("""
+            select sac.shopArtistContractsId as contractId,
+                   cp.contractProductsId as contractProductId,
+                   p.productUrl as productImageUrl,
+                   p.productName as productName,
+                   coalesce(sum(m.quantityDelta), 0) as totalShipmentQuantity,
+                   cp.sellingPrice as sellingPrice,
+                   sac.commissionType as commissionType,
+                   sac.commissionValue as commissionValue,
+                   cp.unitSettlementAmount as unitSettlementAmount
+            from ContractProduct cp
+            join cp.shopArtistContract sac
+            join cp.product p
+            left join ContractProductStockMovement m
+                on m.contractProduct = cp
+               and m.movementType = :inboundType
+            where sac.shopArtistContractsId in :contractIds
+              and sac.artist.id = :artistId
+            group by sac.shopArtistContractsId,
+                     cp.contractProductsId,
+                     p.productUrl,
+                     p.productName,
+                     cp.sellingPrice,
+                     sac.commissionType,
+                     sac.commissionValue,
+                     cp.unitSettlementAmount,
+                     cp.recentStockedAt
+            order by sac.shopArtistContractsId desc, cp.recentStockedAt desc, cp.contractProductsId desc
+            """)
+    List<ArtistShipmentProductRow> findShipmentProductRowsByContractIds(
+            @Param("contractIds") List<Long> contractIds,
+            @Param("artistId") Long artistId,
             @Param("inboundType") ContractProductStockMovementType inboundType
     );
 

--- a/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
@@ -44,7 +44,7 @@ public class User extends BaseTimeEntity {
     private String profileUrl;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "user_status", nullable = false)
+    @Column(name = "user_status", nullable = false, length = 20)
     private UserStatus userStatus;
 
     @Column(name = "social_id")

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @DisplayName("ArtistShipmentService 출고관리 테스트")
@@ -66,9 +68,10 @@ class ArtistShipmentServiceTest {
     void givenArtist_whenGetShipmentShops_thenReturnInboundStatuses() {
         given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
         given(contractRepository.findShipmentShopRowsByArtistId(
-                ARTIST_ID,
-                ContractStatus.APPROVED,
-                ContractProductListingStatus.ACTIVE
+                eq(ARTIST_ID),
+                eq(ContractStatus.APPROVED),
+                eq(ContractProductListingStatus.ACTIVE),
+                any(LocalDate.class)
         )).willReturn(List.of(
                 shipmentShopRow(CONTRACT_ID, SHOP_ID, "확인 소품샵", RECENT_STOCKED_AT, true),
                 shipmentShopRow(CONTRACT_ID + 1, SHOP_ID + 1, "미확인 소품샵", RECENT_STOCKED_AT, false),
@@ -98,40 +101,61 @@ class ArtistShipmentServiceTest {
     }
 
     @Test
-    @DisplayName("출고리스트는 승인 계약의 출고상품 요약을 반환한다")
-    void givenApprovedContract_whenGetShipmentProducts_thenReturnShipmentProducts() {
+    @DisplayName("출고리스트는 소품샵의 계약 이력별 출고상품 상세를 반환한다")
+    void givenShipmentContracts_whenGetShipmentProducts_thenReturnProductsGroupedByContract() {
         given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
-        given(contractRepository.findContractByIdAndArtistId(CONTRACT_ID, ARTIST_ID))
-                .willReturn(Optional.of(contract(ContractStatus.APPROVED)));
-        given(contractProductRepository.findShipmentProductRowsByContractId(
-                CONTRACT_ID,
+        given(contractRepository.findShipmentProductContractsByArtistIdAndShopId(
                 ARTIST_ID,
-                ContractStatus.APPROVED,
-                ContractProductListingStatus.ACTIVE,
+                SHOP_ID,
+                List.of(ContractStatus.APPROVED, ContractStatus.ENDED, ContractStatus.TERMINATED)
+        )).willReturn(List.of(
+                contract(CONTRACT_ID + 1, ContractStatus.ENDED),
+                contract(CONTRACT_ID, ContractStatus.APPROVED)
+        ));
+        given(contractProductRepository.findShipmentProductRowsByContractIds(
+                List.of(CONTRACT_ID + 1, CONTRACT_ID),
+                ARTIST_ID,
                 ContractProductStockMovementType.INBOUND
-        )).willReturn(List.of(shipmentProductRow(CONTRACT_PRODUCT_ID, "세라믹 컵", 10L)));
+        )).willReturn(List.of(
+                shipmentProductRow(CONTRACT_ID + 1, CONTRACT_PRODUCT_ID + 1, "과거 계약 접시", 3L),
+                shipmentProductRow(CONTRACT_ID, CONTRACT_PRODUCT_ID, "세라믹 컵", 10L)
+        ));
 
-        ArtistShipmentProductListResponse response = artistShipmentService.getShipmentProducts(USER_ID, CONTRACT_ID);
+        ArtistShipmentProductListResponse response = artistShipmentService.getShipmentProducts(USER_ID, SHOP_ID);
 
-        assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
-        assertThat(response.getItems()).hasSize(1);
-        assertThat(response.getItems().get(0).getContractProductId()).isEqualTo(CONTRACT_PRODUCT_ID);
-        assertThat(response.getItems().get(0).getProductName()).isEqualTo("세라믹 컵");
-        assertThat(response.getItems().get(0).getTotalShipmentQuantity()).isEqualTo(10L);
-        assertThat(response.getItems().get(0).getSellingPrice()).isEqualByComparingTo(SELLING_PRICE);
-        assertThat(response.getItems().get(0).getCommissionType()).isEqualTo(CommissionType.RATE);
-        assertThat(response.getItems().get(0).getCommissionValue()).isEqualByComparingTo(COMMISSION_VALUE);
-        assertThat(response.getItems().get(0).getUnitSettlementAmount()).isEqualByComparingTo(UNIT_SETTLEMENT_AMOUNT);
+        assertThat(response.getShopId()).isEqualTo(SHOP_ID);
+        assertThat(response.getContracts()).hasSize(2);
+        assertThat(response.getContracts()).extracting("contractId")
+                .containsExactly(CONTRACT_ID + 1, CONTRACT_ID);
+        assertThat(response.getContracts().get(0).getContractStatus()).isEqualTo(ContractStatus.ENDED);
+        assertThat(response.getContracts().get(0).getItems()).hasSize(1);
+        assertThat(response.getContracts().get(0).getItems().get(0).getContractProductId())
+                .isEqualTo(CONTRACT_PRODUCT_ID + 1);
+        assertThat(response.getContracts().get(0).getItems().get(0).getProductName())
+                .isEqualTo("과거 계약 접시");
+        assertThat(response.getContracts().get(1).getItems().get(0).getProductName()).isEqualTo("세라믹 컵");
+        assertThat(response.getContracts().get(1).getItems().get(0).getTotalShipmentQuantity()).isEqualTo(10L);
+        assertThat(response.getContracts().get(1).getItems().get(0).getSellingPrice())
+                .isEqualByComparingTo(SELLING_PRICE);
+        assertThat(response.getContracts().get(1).getItems().get(0).getCommissionType()).isEqualTo(CommissionType.RATE);
+        assertThat(response.getContracts().get(1).getItems().get(0).getCommissionValue())
+                .isEqualByComparingTo(COMMISSION_VALUE);
+        assertThat(response.getContracts().get(1).getItems().get(0).getUnitSettlementAmount())
+                .isEqualByComparingTo(UNIT_SETTLEMENT_AMOUNT);
     }
 
     @Test
-    @DisplayName("승인 계약이 아니면 출고리스트를 조회할 수 없다")
-    void givenNotApprovedContract_whenGetShipmentProducts_thenThrowNotFound() {
+    @DisplayName("계약 이력이 없는 소품샵이면 출고리스트를 조회할 수 없다")
+    void givenNoShipmentContract_whenGetShipmentProducts_thenThrowNotFound() {
         given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
-        given(contractRepository.findContractByIdAndArtistId(CONTRACT_ID, ARTIST_ID))
-                .willReturn(Optional.of(contract(ContractStatus.PENDING)));
+        given(contractRepository.findShipmentProductContractsByArtistIdAndShopId(
+                ARTIST_ID,
+                SHOP_ID,
+                List.of(ContractStatus.APPROVED, ContractStatus.ENDED, ContractStatus.TERMINATED)
+        ))
+                .willReturn(List.of());
 
-        assertThatThrownBy(() -> artistShipmentService.getShipmentProducts(USER_ID, CONTRACT_ID))
+        assertThatThrownBy(() -> artistShipmentService.getShipmentProducts(USER_ID, SHOP_ID))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("계약서 정보를 찾을 수 없습니다.");
     }
@@ -143,18 +167,30 @@ class ArtistShipmentServiceTest {
     }
 
     private ShopArtistContract contract(ContractStatus contractStatus) {
+        return contract(CONTRACT_ID, contractStatus);
+    }
+
+    private ShopArtistContract contract(Long contractId, ContractStatus contractStatus) {
         return ShopArtistContract.builder()
-                .shopArtistContractsId(CONTRACT_ID)
+                .shopArtistContractsId(contractId)
                 .contractStatus(contractStatus)
+                .contractStartDate(CONTRACT_START_DATE)
+                .contractEndDate(CONTRACT_END_DATE)
                 .build();
     }
 
     private ArtistShipmentProductRow shipmentProductRow(
+            Long contractId,
             Long contractProductId,
             String productName,
             Long totalShipmentQuantity
     ) {
         return new ArtistShipmentProductRow() {
+            @Override
+            public Long getContractId() {
+                return contractId;
+            }
+
             @Override
             public Long getContractProductId() {
                 return contractProductId;

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -70,6 +70,7 @@ class ContractProductRepositoryTest {
     private static final BigDecimal CUP_UNIT_SETTLEMENT_AMOUNT = new BigDecimal("9600.00");
     private static final LocalDate CONTRACT_START_DATE = LocalDate.of(2026, 5, 1);
     private static final LocalDate CONTRACT_END_DATE = LocalDate.of(2026, 12, 31);
+    private static final LocalDate QUERY_TODAY = LocalDate.of(2026, 5, 8);
     private static final LocalDateTime CUP_INBOUND_AT = LocalDateTime.of(2026, 4, 28, 10, 0);
     private static final LocalDateTime CUP_SALE_AT = LocalDateTime.of(2026, 4, 28, 12, 0);
     private static final LocalDateTime PLATE_INBOUND_AT = LocalDateTime.of(2026, 4, 27, 14, 30);
@@ -245,6 +246,133 @@ class ContractProductRepositoryTest {
     }
 
     @Test
+    @DisplayName("출고리스트는 소품샵의 계약 이력을 계약별 품목 상세로 조회한다")
+    void givenShopContractHistory_whenQueryShipmentProducts_thenReturnRowsByContract() {
+        Artist artist = createArtist(
+                createUser("shipment-history-artist@test.com", "출고이력 작가", Role.ARTIST, "01097300001", null),
+                "출고이력 작가",
+                Specialty.CERAMIC
+        );
+        Shop shop = createShop(
+                createUser("shipment-history-shop@test.com", "출고이력 소품샵", Role.SHOP, "01097300002", null),
+                "출고이력 소품샵",
+                Specialty.HANDMADE_CRAFT
+        );
+        Shop otherShop = createShop(
+                createUser("shipment-history-other-shop@test.com", "출고이력 다른샵", Role.SHOP, "01097300003", null),
+                "출고이력 다른샵",
+                Specialty.LIVING_GOODS
+        );
+        ShopArtistContract approvedContract = createContract(
+                artist,
+                shop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+        ShopArtistContract endedContract = createContract(
+                artist,
+                shop,
+                ContractStatus.ENDED,
+                ContractRequestType.NONE,
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 2, 1)
+        );
+        ShopArtistContract terminatedContract = createContract(
+                artist,
+                shop,
+                ContractStatus.TERMINATED,
+                ContractRequestType.NONE,
+                LocalDate.of(2026, 2, 2),
+                LocalDate.of(2026, 3, 1)
+        );
+        createContract(artist, shop, ContractStatus.PENDING, ContractRequestType.NONE, null, null);
+        createContract(artist, shop, ContractStatus.REJECTED, ContractRequestType.NONE, null, null);
+        createContract(artist, otherShop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+
+        Product approvedProduct = createProduct(
+                artist,
+                "현재 계약 컵",
+                CUP_PRICE,
+                "https://image.test/products/current-cup.png"
+        );
+        Product endedProduct = createProduct(
+                artist,
+                "만료 계약 접시",
+                PLATE_PRICE,
+                "https://image.test/products/ended-plate.png"
+        );
+        Product terminatedProduct = createProduct(
+                artist,
+                "해지 계약 화병",
+                PLATE_PRICE,
+                "https://image.test/products/terminated-vase.png"
+        );
+        ContractProduct approvedInventory = createContractProduct(
+                approvedContract,
+                approvedProduct,
+                CUP_SELLING_PRICE,
+                CUP_MARGIN_AMOUNT,
+                CUP_UNIT_SETTLEMENT_AMOUNT
+        );
+        ContractProduct endedInventory = ContractProduct.builder()
+                .shopArtistContract(endedContract)
+                .product(endedProduct)
+                .listingStatus(ContractProductListingStatus.ENDED)
+                .sellingPrice(PLATE_SELLING_PRICE)
+                .unitSettlementAmount(new BigDecimal("7200.00"))
+                .build();
+        ContractProduct terminatedInventory = createContractProduct(
+                terminatedContract,
+                terminatedProduct,
+                PLATE_SELLING_PRICE,
+                new BigDecimal("1800.00"),
+                new BigDecimal("7200.00")
+        );
+
+        ContractProductStockMovement approvedInbound =
+                approvedInventory.applyInbound(CUP_INBOUND_QUANTITY, CUP_INBOUND_AT, ACTOR_USER_ID, "현재 계약 입고");
+        ContractProductStockMovement terminatedInbound =
+                terminatedInventory.applyInbound(PLATE_INBOUND_QUANTITY, PLATE_INBOUND_AT, ACTOR_USER_ID, "해지 계약 입고");
+        contractProductRepository.save(approvedInventory);
+        contractProductRepository.save(endedInventory);
+        contractProductRepository.save(terminatedInventory);
+        saveMovement(approvedInbound);
+        saveMovement(terminatedInbound);
+        flushAndClear();
+
+        List<ShopArtistContract> contracts = contractRepository.findShipmentProductContractsByArtistIdAndShopId(
+                artist.getId(),
+                shop.getShopId(),
+                List.of(ContractStatus.APPROVED, ContractStatus.ENDED, ContractStatus.TERMINATED)
+        );
+        List<ArtistShipmentProductRow> rows = contractProductRepository.findShipmentProductRowsByContractIds(
+                contracts.stream()
+                        .map(ShopArtistContract::getShopArtistContractsId)
+                        .toList(),
+                artist.getId(),
+                ContractProductStockMovementType.INBOUND
+        );
+
+        assertThat(contracts).extracting(ShopArtistContract::getContractStatus)
+                .containsExactly(ContractStatus.TERMINATED, ContractStatus.ENDED, ContractStatus.APPROVED);
+        assertThat(rows).extracting("productName")
+                .containsExactly("해지 계약 화병", "만료 계약 접시", "현재 계약 컵");
+        assertThat(findShipmentProductRow(rows, "현재 계약 컵").getContractId())
+                .isEqualTo(approvedContract.getShopArtistContractsId());
+        assertThat(findShipmentProductRow(rows, "현재 계약 컵").getTotalShipmentQuantity())
+                .isEqualTo(CUP_INBOUND_QUANTITY);
+        assertThat(findShipmentProductRow(rows, "만료 계약 접시").getContractId())
+                .isEqualTo(endedContract.getShopArtistContractsId());
+        assertThat(findShipmentProductRow(rows, "만료 계약 접시").getTotalShipmentQuantity()).isZero();
+        assertThat(findShipmentProductRow(rows, "해지 계약 화병").getContractId())
+                .isEqualTo(terminatedContract.getShopArtistContractsId());
+        assertThat(findShipmentProductRow(rows, "해지 계약 화병").getTotalShipmentQuantity())
+                .isEqualTo(PLATE_INBOUND_QUANTITY);
+    }
+
+    @Test
     @DisplayName("출고관리 입점 매장 목록은 승인 계약 소품샵만 반환한다")
     void givenArtistContracts_whenQueryShipmentShops_thenReturnApprovedShopsOnly() {
         Artist artist = createArtist(
@@ -282,7 +410,8 @@ class ContractProductRepositoryTest {
         List<ArtistShipmentShopRow> rows = contractRepository.findShipmentShopRowsByArtistId(
                 artist.getId(),
                 ContractStatus.APPROVED,
-                ContractProductListingStatus.ACTIVE
+                ContractProductListingStatus.ACTIVE,
+                QUERY_TODAY
         );
 
         assertThat(rows).hasSize(1);
@@ -292,6 +421,81 @@ class ContractProductRepositoryTest {
         assertThat(rows.get(0).getContractStartDate()).isEqualTo(CONTRACT_START_DATE);
         assertThat(rows.get(0).getContractEndDate()).isEqualTo(CONTRACT_END_DATE);
         assertThat(rows.get(0).getRecentStockedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("출고관리 입점 매장 목록은 같은 소품샵을 중복 반환하지 않는다")
+    void givenDuplicatedApprovedShopContracts_whenQueryShipmentShops_thenReturnLatestShopOnly() {
+        Artist artist = createArtist(
+                createUser("shipment-dedup-artist@test.com", "출고중복 작가", Role.ARTIST, "01097100001", null),
+                "출고중복 작가",
+                Specialty.CERAMIC
+        );
+        Shop shop = createShop(
+                createUser("shipment-dedup-shop@test.com", "중복 소품샵", Role.SHOP, "01097100002", null),
+                "중복 소품샵",
+                Specialty.HANDMADE_CRAFT
+        );
+        ShopArtistContract oldContract = createContract(
+                artist,
+                shop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 6, 30)
+        );
+        ShopArtistContract latestContract = createContract(
+                artist,
+                shop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+        flushAndClear();
+
+        List<ArtistShipmentShopRow> rows = contractRepository.findShipmentShopRowsByArtistId(
+                artist.getId(),
+                ContractStatus.APPROVED,
+                ContractProductListingStatus.ACTIVE,
+                QUERY_TODAY
+        );
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getShopId()).isEqualTo(shop.getShopId());
+        assertThat(rows.get(0).getContractId()).isEqualTo(latestContract.getShopArtistContractsId());
+        assertThat(rows.get(0).getContractId()).isNotEqualTo(oldContract.getShopArtistContractsId());
+    }
+
+    @Test
+    @DisplayName("작가 출고리스트 조회용 계약은 소품샵 기준 최신 승인 계약을 반환한다")
+    void givenApprovedShopContract_whenFindByArtistAndShop_thenReturnLatestContract() {
+        Artist artist = createArtist(
+                createUser("shipment-shop-contract-artist@test.com", "소품샵계약 작가", Role.ARTIST, "01097200001", null),
+                "소품샵계약 작가",
+                Specialty.CERAMIC
+        );
+        Shop shop = createShop(
+                createUser("shipment-shop-contract-shop@test.com", "소품샵계약 매장", Role.SHOP, "01097200002", null),
+                "소품샵계약 매장",
+                Specialty.HANDMADE_CRAFT
+        );
+        ShopArtistContract oldContract = createContract(artist, shop);
+        ShopArtistContract latestContract = createContract(artist, shop);
+        createContract(artist, shop, ContractStatus.PENDING, ContractRequestType.NONE, null, null);
+        flushAndClear();
+
+        List<ShopArtistContract> contracts = contractRepository.findApprovedContractsByArtistIdAndShopId(
+                artist.getId(),
+                shop.getShopId(),
+                ContractStatus.APPROVED
+        );
+
+        assertThat(contracts).extracting(ShopArtistContract::getShopArtistContractsId)
+                .containsExactly(
+                        latestContract.getShopArtistContractsId(),
+                        oldContract.getShopArtistContractsId()
+                );
     }
 
     @Test
@@ -359,7 +563,8 @@ class ContractProductRepositoryTest {
         List<ArtistShipmentShopRow> rows = contractRepository.findShipmentShopRowsByArtistId(
                 artist.getId(),
                 ContractStatus.APPROVED,
-                ContractProductListingStatus.ACTIVE
+                ContractProductListingStatus.ACTIVE,
+                QUERY_TODAY
         );
 
         assertThat(rows).extracting("contractId")
@@ -557,8 +762,13 @@ class ContractProductRepositoryTest {
                 Specialty.CERAMIC
         );
         Artist endedArtist = createArtist(
-                createUser("suggestion-ended@test.com", "만료 제외 작가", Role.ARTIST, "01093000009", null),
-                "만료 제외 작가",
+                createUser("suggestion-ended@test.com", "만료 가능 작가", Role.ARTIST, "01093000009", null),
+                "만료 가능 작가",
+                Specialty.CERAMIC
+        );
+        Artist expiredApprovedArtist = createArtist(
+                createUser("suggestion-expired-approved@test.com", "종료일 경과 작가", Role.ARTIST, "01093000010", null),
+                "종료일 경과 작가",
                 Specialty.CERAMIC
         );
 
@@ -568,13 +778,23 @@ class ContractProductRepositoryTest {
         createContract(pendingArtist, shop, ContractStatus.PENDING, ContractRequestType.EXTENSION, null, null);
         createContract(approvedArtist, shop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
         createContract(endedArtist, shop, ContractStatus.ENDED, ContractRequestType.NONE, null, null);
+        createContract(
+                expiredApprovedArtist,
+                shop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                QUERY_TODAY.minusMonths(2),
+                QUERY_TODAY.minusDays(1)
+        );
         flushAndClear();
 
         var rows = contractRepository.findArtistSuggestionRows(
                 shop.getShopId(),
                 Role.ARTIST,
                 UserStatus.ACTIVE,
-                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                QUERY_TODAY
         );
 
         assertThat(rows).extracting("artistName")
@@ -582,12 +802,13 @@ class ContractProductRepositoryTest {
                         "추천 가능 작가",
                         "거절 이력 작가",
                         "해지 이력 작가",
-                        "다른샵 계약 작가"
+                        "다른샵 계약 작가",
+                        "만료 가능 작가",
+                        "종료일 경과 작가"
                 )
                 .doesNotContain(
                         "대기 제외 작가",
-                        "계약 제외 작가",
-                        "만료 제외 작가"
+                        "계약 제외 작가"
                 );
         assertThat(findSuggestionRow(rows, "추천 가능 작가").getArtistId())
                 .isEqualTo(eligibleArtist.getId());
@@ -641,7 +862,9 @@ class ContractProductRepositoryTest {
                 shop.getShopId(),
                 Role.ARTIST,
                 UserStatus.ACTIVE,
-                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                QUERY_TODAY,
                 "%postman%",
                 PageRequest.of(0, 10)
         );
@@ -717,8 +940,13 @@ class ContractProductRepositoryTest {
                 Specialty.CERAMIC
         );
         Artist endedArtist = createArtist(
-                createUser("account-ended@test.com", "검색 만료 제외 작가", Role.ARTIST, "01095000009", null),
-                "계약 검색 만료 제외 작가",
+                createUser("account-ended@test.com", "검색 만료 가능 작가", Role.ARTIST, "01095000009", null),
+                "계약 검색 만료 가능 작가",
+                Specialty.CERAMIC
+        );
+        Artist expiredApprovedArtist = createArtist(
+                createUser("account-expired-approved@test.com", "검색 종료일 경과 작가", Role.ARTIST, "01095000010", null),
+                "계약 검색 종료일 경과 작가",
                 Specialty.CERAMIC
         );
 
@@ -728,13 +956,23 @@ class ContractProductRepositoryTest {
         createContract(pendingArtist, shop, ContractStatus.PENDING, ContractRequestType.EXTENSION, null, null);
         createContract(approvedArtist, shop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
         createContract(endedArtist, shop, ContractStatus.ENDED, ContractRequestType.NONE, null, null);
+        createContract(
+                expiredApprovedArtist,
+                shop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                QUERY_TODAY.minusMonths(2),
+                QUERY_TODAY.minusDays(1)
+        );
         flushAndClear();
 
         var rows = contractRepository.searchArtistAccountRows(
                 shop.getShopId(),
                 Role.ARTIST,
                 UserStatus.ACTIVE,
-                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                QUERY_TODAY,
                 "%계약 검색%",
                 PageRequest.of(0, 10)
         );
@@ -744,12 +982,13 @@ class ContractProductRepositoryTest {
                         "계약 검색 가능 작가",
                         "계약 검색 거절 이력 작가",
                         "계약 검색 해지 이력 작가",
-                        "계약 검색 다른샵 계약 작가"
+                        "계약 검색 다른샵 계약 작가",
+                        "계약 검색 만료 가능 작가",
+                        "계약 검색 종료일 경과 작가"
                 )
                 .doesNotContain(
                         "계약 검색 대기 제외 작가",
-                        "계약 검색 승인 제외 작가",
-                        "계약 검색 만료 제외 작가"
+                        "계약 검색 승인 제외 작가"
                 );
         assertThat(findAccountSearchRow(rows, "계약 검색 가능 작가").getArtistId())
                 .isEqualTo(eligibleArtist.getId());

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -57,6 +57,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -127,10 +129,12 @@ class ContractServiceTest {
 
         given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
         given(contractRepository.findArtistSuggestionRows(
-                SHOP_ID,
-                Role.ARTIST,
-                UserStatus.ACTIVE,
-                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+                eq(SHOP_ID),
+                eq(Role.ARTIST),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
         )).willReturn(rows);
 
         ArtistSuggestionListResponse response = contractService.getArtistSuggestions(USER_ID);
@@ -152,10 +156,12 @@ class ContractServiceTest {
 
         given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
         given(contractRepository.findArtistSuggestionRows(
-                SHOP_ID,
-                Role.ARTIST,
-                UserStatus.ACTIVE,
-                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+                eq(SHOP_ID),
+                eq(Role.ARTIST),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
         )).willReturn(List.of(artistSuggestionRow(ARTIST_ID, USER_ID + 100, "Postman 추천 작가")));
 
         ArtistSuggestionListResponse response = contractService.getArtistSuggestions(USER_ID);
@@ -175,12 +181,14 @@ class ContractServiceTest {
 
         given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
         given(contractRepository.searchArtistAccountRows(
-                SHOP_ID,
-                Role.ARTIST,
-                UserStatus.ACTIVE,
-                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED),
-                "%postman%",
-                org.springframework.data.domain.PageRequest.of(0, 10)
+                eq(SHOP_ID),
+                eq(Role.ARTIST),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class),
+                eq("%postman%"),
+                eq(org.springframework.data.domain.PageRequest.of(0, 10))
         )).willReturn(List.of(artistAccountSearchRow(ARTIST_ID, USER_ID + 100, "Postman 검색 작가")));
 
         ArtistAccountSearchResponse response = contractService.searchArtistAccounts(USER_ID, " Postman ");


### PR DESCRIPTION
## 작업 내용
  - 작가 출고관리 입점 매장 목록 조회 API 구현/수정
  - 같은 작가-소품샵의 유지 중인 계약 1건만 목록에 노출
  - 계약 가능 작가 검색/추천 기준 수정
    - PENDING, 유지 중인 APPROVED 제외
    - 계약 종료일 지난 APPROVED, ENDED, TERMINATED, REJECTED 허용
  - 특정 소품샵 출고리스트 조회 API를 계약별 그룹 응답으로 변경
  - 출고 품목별 상품이미지, 상품명, 판매가, 출고수량, 수수료, 개당 정산금액 반환

  ## 테스트
  - ArtistShipmentServiceTest
  - ContractProductRepositoryTest
  - ContractServiceTest
