### PR TITLE
feat: 작가 출고관리 최근 입고 품목 조회 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
@@ -39,6 +39,17 @@ public class ArtistShipmentController {
         );
     }
 
+    @GetMapping("/shops/{shopId}/recent-products")
+    public ApiResponse<ArtistShipmentProductListResponse> getRecentShipmentProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long shopId
+    ) {
+        return ApiResponse.of(
+                artistShipmentService.getRecentShipmentProducts(resolveUserId(userDetails, userId), shopId)
+        );
+    }
+
     private Long resolveUserId(CustomUserDetails userDetails, Long userId) {
         if (userDetails != null) {
             return userDetails.getUserId();

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
@@ -66,6 +66,23 @@ public class ArtistShipmentService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public ArtistShipmentProductListResponse getRecentShipmentProducts(Long userId, Long shopId) {
+        Artist artist = getArtistByUserId(userId);
+        ShopArtistContract recentContract = getRecentShipmentProductContract(artist.getId(), shopId);
+        List<ShopArtistContract> contracts = List.of(recentContract);
+
+        return ArtistShipmentProductListResponse.from(
+                shopId,
+                contracts,
+                contractProductRepository.findShipmentProductRowsByContractIds(
+                        List.of(recentContract.getShopArtistContractsId()),
+                        artist.getId(),
+                        ContractProductStockMovementType.INBOUND
+                )
+        );
+    }
+
     private Artist getArtistByUserId(Long userId) {
         return artistRepository.findByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException(
@@ -87,5 +104,9 @@ public class ArtistShipmentService {
             );
         }
         return contracts;
+    }
+
+    private ShopArtistContract getRecentShipmentProductContract(Long artistId, Long shopId) {
+        return getShipmentProductContracts(artistId, shopId).get(0);
     }
 }

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
@@ -160,6 +160,55 @@ class ArtistShipmentServiceTest {
                 .hasMessage("계약서 정보를 찾을 수 없습니다.");
     }
 
+    @Test
+    @DisplayName("최근 입고 내역은 소품샵의 최신 계약 품목 상세만 반환한다")
+    void givenShipmentContracts_whenGetRecentShipmentProducts_thenReturnLatestContractProductsOnly() {
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findShipmentProductContractsByArtistIdAndShopId(
+                ARTIST_ID,
+                SHOP_ID,
+                List.of(ContractStatus.APPROVED, ContractStatus.ENDED, ContractStatus.TERMINATED)
+        )).willReturn(List.of(
+                contract(CONTRACT_ID + 2, ContractStatus.APPROVED),
+                contract(CONTRACT_ID + 1, ContractStatus.TERMINATED),
+                contract(CONTRACT_ID, ContractStatus.ENDED)
+        ));
+        given(contractProductRepository.findShipmentProductRowsByContractIds(
+                List.of(CONTRACT_ID + 2),
+                ARTIST_ID,
+                ContractProductStockMovementType.INBOUND
+        )).willReturn(List.of(
+                shipmentProductRow(CONTRACT_ID + 2, CONTRACT_PRODUCT_ID + 2, "최근 계약 컵", 5L)
+        ));
+
+        ArtistShipmentProductListResponse response =
+                artistShipmentService.getRecentShipmentProducts(USER_ID, SHOP_ID);
+
+        assertThat(response.getShopId()).isEqualTo(SHOP_ID);
+        assertThat(response.getContracts()).hasSize(1);
+        assertThat(response.getContracts().get(0).getContractId()).isEqualTo(CONTRACT_ID + 2);
+        assertThat(response.getContracts().get(0).getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+        assertThat(response.getContracts().get(0).getItems()).hasSize(1);
+        assertThat(response.getContracts().get(0).getItems().get(0).getProductName()).isEqualTo("최근 계약 컵");
+        assertThat(response.getContracts().get(0).getItems().get(0).getTotalShipmentQuantity()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("최근 입고 내역 조회 시 계약 이력이 없으면 조회할 수 없다")
+    void givenNoShipmentContract_whenGetRecentShipmentProducts_thenThrowNotFound() {
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findShipmentProductContractsByArtistIdAndShopId(
+                ARTIST_ID,
+                SHOP_ID,
+                List.of(ContractStatus.APPROVED, ContractStatus.ENDED, ContractStatus.TERMINATED)
+        ))
+                .willReturn(List.of());
+
+        assertThatThrownBy(() -> artistShipmentService.getRecentShipmentProducts(USER_ID, SHOP_ID))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("계약서 정보를 찾을 수 없습니다.");
+    }
+
     private Artist artist() {
         return Artist.builder()
                 .id(ARTIST_ID)


### PR DESCRIPTION
## 작업 내용
  - 작가 출고관리 페이지에서 특정 소품샵의 최근 계약 품목 상세 조회 API 추가
  - 응답 형태는 전체 출고 이력 조회 API와 동일하게 계약 단위 `contracts` 구조 유지
  - 최근 계약 1건 기준으로 상품이미지, 상품명, 판매가, 출고수량, 수수료, 개당 정산금액 반환
  - `PENDING`, `REJECTED` 계약은 조회 대상에서 제외

  ## 테스트
  - ArtistShipmentService 단위 테스트 추가/수정
  - 최근 품목 조회 시 최신 계약 1건만 반환되는지 검증
  - 계약이 없을 때 예외가 발생하는지 검증