### PR TITLE
feat: 작가 출고관리 품목 조회 및 출고 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/controller/ArtistShipmentController.java
@@ -1,14 +1,20 @@
 package app.dearobjet.backend.domain.artist.controller;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentAvailableProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistShipmentRequest;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistShipmentResponse;
 import app.dearobjet.backend.domain.artist.service.ArtistShipmentService;
 import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,6 +53,38 @@ public class ArtistShipmentController {
     ) {
         return ApiResponse.of(
                 artistShipmentService.getRecentShipmentProducts(resolveUserId(userDetails, userId), shopId)
+        );
+    }
+
+    @GetMapping("/shops/{shopId}/available-products")
+    public ApiResponse<ArtistShipmentAvailableProductListResponse> getAvailableProducts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long shopId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponse.of(
+                artistShipmentService.getAvailableProducts(
+                        resolveUserId(userDetails, userId),
+                        shopId,
+                        keyword,
+                        page,
+                        size
+                )
+        );
+    }
+
+    @PostMapping("/shops/{shopId}/shipments")
+    public ApiResponse<CreateArtistShipmentResponse> createShipment(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long shopId,
+            @Valid @RequestBody CreateArtistShipmentRequest request
+    ) {
+        return ApiResponse.of(
+                artistShipmentService.createShipment(resolveUserId(userDetails, userId), shopId, request)
         );
     }
 

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentAvailableProductItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentAvailableProductItemResponse.java
@@ -1,0 +1,35 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.shop.entity.Product;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistShipmentAvailableProductItemResponse {
+
+    private static final int DEFAULT_SHIPMENT_QUANTITY = 0;
+
+    private final Long productId;
+    private final String productImageUrl;
+    private final String productName;
+    private final BigDecimal sellingPrice;
+    private final Integer shipmentQuantity;
+    private final Integer totalQuantity;
+    private final Long version;
+
+    public static ArtistShipmentAvailableProductItemResponse from(Product product) {
+        return new ArtistShipmentAvailableProductItemResponse(
+                product.getProductsId(),
+                product.getProductUrl(),
+                product.getProductName(),
+                product.getPrice(),
+                DEFAULT_SHIPMENT_QUANTITY,
+                product.getStockQuantity(),
+                product.getVersion()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentAvailableProductListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/ArtistShipmentAvailableProductListResponse.java
@@ -1,0 +1,37 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.shop.entity.Product;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ArtistShipmentAvailableProductListResponse {
+
+    private final Long shopId;
+    private final Long contractId;
+    private final List<ArtistShipmentAvailableProductItemResponse> items;
+    private final int page;
+    private final int totalPages;
+
+    public static ArtistShipmentAvailableProductListResponse from(
+            Long shopId,
+            Long contractId,
+            Page<Product> productPage,
+            int page
+    ) {
+        return new ArtistShipmentAvailableProductListResponse(
+                shopId,
+                contractId,
+                productPage.getContent().stream()
+                        .map(ArtistShipmentAvailableProductItemResponse::from)
+                        .toList(),
+                page,
+                productPage.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistShipmentItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistShipmentItemResponse.java
@@ -1,0 +1,45 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.shop.entity.Product;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateArtistShipmentItemResponse {
+
+    private final Long productId;
+    private final Long contractProductId;
+    private final String productImageUrl;
+    private final String productName;
+    private final BigDecimal sellingPrice;
+    private final Integer shipmentQuantity;
+    private final Integer remainingQuantity;
+    private final CommissionType commissionType;
+    private final BigDecimal commissionValue;
+    private final BigDecimal unitSettlementAmount;
+
+    public static CreateArtistShipmentItemResponse from(
+            Product product,
+            ContractProduct contractProduct,
+            int shipmentQuantity
+    ) {
+        return new CreateArtistShipmentItemResponse(
+                product.getProductsId(),
+                contractProduct.getContractProductsId(),
+                product.getProductUrl(),
+                product.getProductName(),
+                contractProduct.getSellingPrice(),
+                shipmentQuantity,
+                product.getStockQuantity(),
+                contractProduct.getShopArtistContract().getCommissionType(),
+                contractProduct.getShopArtistContract().getCommissionValue(),
+                contractProduct.getUnitSettlementAmount()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistShipmentRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistShipmentRequest.java
@@ -1,0 +1,34 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreateArtistShipmentRequest {
+
+    @Valid
+    @NotEmpty(message = "출고할 상품은 1개 이상이어야 합니다.")
+    private List<Item> items;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Item {
+
+        @NotNull(message = "상품 ID는 필수입니다.")
+        private Long productId;
+
+        @NotNull(message = "출고 수량은 필수입니다.")
+        @Min(value = 1, message = "출고 수량은 1 이상이어야 합니다.")
+        private Integer quantity;
+
+        @NotNull(message = "상품 버전은 필수입니다.")
+        private Long version;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistShipmentResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/dto/CreateArtistShipmentResponse.java
@@ -1,0 +1,24 @@
+package app.dearobjet.backend.domain.artist.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateArtistShipmentResponse {
+
+    private final Long shopId;
+    private final Long contractId;
+    private final List<CreateArtistShipmentItemResponse> items;
+
+    public static CreateArtistShipmentResponse from(
+            Long shopId,
+            Long contractId,
+            List<CreateArtistShipmentItemResponse> items
+    ) {
+        return new CreateArtistShipmentResponse(shopId, contractId, items);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/artist/service/ArtistShipmentService.java
@@ -1,23 +1,45 @@
 package app.dearobjet.backend.domain.artist.service;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentAvailableProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistShipmentItemResponse;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistShipmentRequest;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistShipmentResponse;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.ContractRepository;
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.CommissionType;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
+import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
+import app.dearobjet.backend.domain.shop.entity.Product;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
+import app.dearobjet.backend.domain.shop.repository.ProductRepository;
 import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,10 +50,18 @@ public class ArtistShipmentService {
             ContractStatus.ENDED,
             ContractStatus.TERMINATED
     );
+    private static final int FIRST_PAGE = 1;
+    private static final int FIRST_PAGE_INDEX = 0;
+    private static final int MIN_PAGE_SIZE = 1;
+    private static final BigDecimal PERCENT_DENOMINATOR = new BigDecimal("100");
+    private static final int MONEY_SCALE = 2;
+    private static final String SHIPMENT_INBOUND_MEMO = "작가 출고";
 
     private final ArtistRepository artistRepository;
     private final ContractRepository contractRepository;
     private final ContractProductRepository contractProductRepository;
+    private final ContractProductStockMovementRepository contractProductStockMovementRepository;
+    private final ProductRepository productRepository;
 
     @Transactional(readOnly = true)
     public ArtistShipmentShopListResponse getShipmentShops(Long userId) {
@@ -83,6 +113,71 @@ public class ArtistShipmentService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public ArtistShipmentAvailableProductListResponse getAvailableProducts(
+            Long userId,
+            Long shopId,
+            String keyword,
+            int page,
+            int size
+    ) {
+        validatePageSize(size);
+        Artist artist = getArtistByUserId(userId);
+        ShopArtistContract contract = getCurrentApprovedContract(artist.getId(), shopId);
+        PageRequest pageRequest = PageRequest.of(
+                toPageIndex(page),
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "productsId"))
+        );
+
+        Page<Product> products = productRepository.findShipmentAvailableProducts(
+                artist.getId(),
+                ProductStatus.ACTIVE,
+                normalizeSearchKeyword(keyword),
+                pageRequest
+        );
+
+        return ArtistShipmentAvailableProductListResponse.from(
+                shopId,
+                contract.getShopArtistContractsId(),
+                products,
+                page
+        );
+    }
+
+    @Transactional
+    public CreateArtistShipmentResponse createShipment(
+            Long userId,
+            Long shopId,
+            CreateArtistShipmentRequest request
+    ) {
+        Artist artist = getArtistByUserId(userId);
+        ShopArtistContract contract = getCurrentApprovedContract(artist.getId(), shopId);
+        validateDuplicateProductIds(request);
+
+        List<Long> productIds = request.getItems().stream()
+                .map(CreateArtistShipmentRequest.Item::getProductId)
+                .toList();
+        Map<Long, Product> productMap = getOwnedActiveProductMap(productIds, artist.getId());
+        Map<Long, ContractProduct> contractProductMap = getActiveContractProductMap(
+                contract.getShopArtistContractsId(),
+                productIds
+        );
+
+        List<CreateArtistShipmentItemResponse> items = request.getItems().stream()
+                .map(item -> shipProduct(userId, contract, productMap.get(item.getProductId()), contractProductMap, item))
+                .toList();
+
+        contract.markRecentInboundPending();
+
+        return CreateArtistShipmentResponse.from(
+                shopId,
+                contract.getShopArtistContractsId(),
+                items
+        );
+    }
+
     private Artist getArtistByUserId(Long userId) {
         return artistRepository.findByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException(
@@ -108,5 +203,140 @@ public class ArtistShipmentService {
 
     private ShopArtistContract getRecentShipmentProductContract(Long artistId, Long shopId) {
         return getShipmentProductContracts(artistId, shopId).get(0);
+    }
+
+    private ShopArtistContract getCurrentApprovedContract(Long artistId, Long shopId) {
+        return contractRepository.findCurrentApprovedContractsByArtistIdAndShopId(
+                        artistId,
+                        shopId,
+                        ContractStatus.APPROVED,
+                        LocalDate.now()
+                ).stream()
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "현재 승인된 계약 정보를 찾을 수 없습니다."
+                ));
+    }
+
+    private Map<Long, Product> getOwnedActiveProductMap(List<Long> productIds, Long artistId) {
+        Map<Long, Product> productMap = productRepository.findByProductsIdInAndArtistIdAndStatus(
+                        productIds,
+                        artistId,
+                        ProductStatus.ACTIVE
+                ).stream()
+                .collect(Collectors.toMap(Product::getProductsId, Function.identity()));
+
+        if (productMap.size() != productIds.size()) {
+            throw new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND, "상품을 찾을 수 없습니다.");
+        }
+        return productMap;
+    }
+
+    private Map<Long, ContractProduct> getActiveContractProductMap(Long contractId, List<Long> productIds) {
+        return contractProductRepository.findActiveProductsByContractIdAndProductIds(
+                        contractId,
+                        productIds,
+                        ContractProductListingStatus.ACTIVE
+                ).stream()
+                .collect(Collectors.toMap(
+                        contractProduct -> contractProduct.getProduct().getProductsId(),
+                        Function.identity()
+                ));
+    }
+
+    private CreateArtistShipmentItemResponse shipProduct(
+            Long userId,
+            ShopArtistContract contract,
+            Product product,
+            Map<Long, ContractProduct> contractProductMap,
+            CreateArtistShipmentRequest.Item item
+    ) {
+        int quantity = item.getQuantity();
+        product.decreaseStockQuantity(quantity, item.getVersion());
+
+        ContractProduct contractProduct = contractProductMap.computeIfAbsent(
+                product.getProductsId(),
+                productId -> contractProductRepository.save(createContractProduct(contract, product))
+        );
+        ContractProductStockMovement movement = contractProduct.applyInbound(
+                quantity,
+                LocalDateTime.now(),
+                userId,
+                SHIPMENT_INBOUND_MEMO
+        );
+        contractProductStockMovementRepository.save(movement);
+
+        return CreateArtistShipmentItemResponse.from(product, contractProduct, quantity);
+    }
+
+    private ContractProduct createContractProduct(ShopArtistContract contract, Product product) {
+        SettlementAmounts settlementAmounts = calculateSettlementAmounts(
+                product.getPrice(),
+                contract.getCommissionType(),
+                contract.getCommissionValue()
+        );
+        return ContractProduct.create(
+                contract,
+                product,
+                product.getPrice(),
+                settlementAmounts.marginAmount(),
+                settlementAmounts.unitSettlementAmount()
+        );
+    }
+
+    private SettlementAmounts calculateSettlementAmounts(
+            BigDecimal sellingPrice,
+            CommissionType commissionType,
+            BigDecimal commissionValue
+    ) {
+        if (sellingPrice == null || commissionType == null || commissionValue == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "정산 정보를 계산할 수 없습니다.");
+        }
+
+        BigDecimal marginAmount = switch (commissionType) {
+            case RATE -> sellingPrice
+                    .multiply(commissionValue)
+                    .divide(PERCENT_DENOMINATOR, MONEY_SCALE, RoundingMode.HALF_UP);
+            case FIXED_AMOUNT -> commissionValue.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+        };
+        BigDecimal unitSettlementAmount = sellingPrice.subtract(marginAmount);
+        if (unitSettlementAmount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "개당 정산금액은 0 이상이어야 합니다.");
+        }
+
+        return new SettlementAmounts(marginAmount, unitSettlementAmount);
+    }
+
+    private int toPageIndex(int page) {
+        return Math.max(page - FIRST_PAGE, FIRST_PAGE_INDEX);
+    }
+
+    private void validatePageSize(int size) {
+        if (size < MIN_PAGE_SIZE) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "페이지 크기는 1 이상이어야 합니다.");
+        }
+    }
+
+    private void validateDuplicateProductIds(CreateArtistShipmentRequest request) {
+        List<Long> productIds = request.getItems().stream()
+                .map(CreateArtistShipmentRequest.Item::getProductId)
+                .toList();
+        if (new HashSet<>(productIds).size() != productIds.size()) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "중복된 상품 ID가 포함되어 있습니다.");
+        }
+    }
+
+    private String normalizeSearchKeyword(String keyword) {
+        if (keyword == null) {
+            return "";
+        }
+        return keyword.trim().toLowerCase();
+    }
+
+    private record SettlementAmounts(
+            BigDecimal marginAmount,
+            BigDecimal unitSettlementAmount
+    ) {
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -140,6 +140,27 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
     @Query("""
             select c
             from ShopArtistContract c
+            join fetch c.shop s
+            join fetch s.businessProfile
+            where c.artist.id = :artistId
+              and s.shopId = :shopId
+              and c.contractStatus = :contractStatus
+              and (
+                  c.contractEndDate is null
+                  or c.contractEndDate >= :today
+              )
+            order by c.shopArtistContractsId desc
+            """)
+    List<ShopArtistContract> findCurrentApprovedContractsByArtistIdAndShopId(
+            @Param("artistId") Long artistId,
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("today") java.time.LocalDate today
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
             where c.artist.id = :artistId
               and c.shop.shopId = :shopId
               and c.contractStatus in :contractStatuses

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ContractProduct.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ContractProduct.java
@@ -76,6 +76,25 @@ public class ContractProduct extends BaseTimeEntity {
     @Column(name = "version")
     private Long version;
 
+    public static ContractProduct create(
+            ShopArtistContract shopArtistContract,
+            Product product,
+            BigDecimal sellingPrice,
+            BigDecimal marginAmount,
+            BigDecimal unitSettlementAmount
+    ) {
+        return ContractProduct.builder()
+                .shopArtistContract(shopArtistContract)
+                .product(product)
+                .sellingPrice(sellingPrice)
+                .marginAmount(marginAmount)
+                .unitSettlementAmount(unitSettlementAmount)
+                .listingStatus(ContractProductListingStatus.ACTIVE)
+                .stockQuantity(ZERO_STOCK_QUANTITY)
+                .soldQuantity(ZERO_STOCK_QUANTITY)
+                .build();
+    }
+
     /**
      * 정산 관련 금액은 재고 이력과 분리해서 관리한다.
      */

--- a/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/repository/ContractProductRepository.java
@@ -150,4 +150,18 @@ public interface ContractProductRepository extends JpaRepository<ContractProduct
             @Param("contractStatus") ContractStatus contractStatus,
             @Param("listingStatus") ContractProductListingStatus listingStatus
     );
+
+    @Query("""
+            select cp
+            from ContractProduct cp
+            join fetch cp.product p
+            where cp.shopArtistContract.shopArtistContractsId = :contractId
+              and p.productsId in :productIds
+              and cp.listingStatus = :listingStatus
+            """)
+    List<ContractProduct> findActiveProductsByContractIdAndProductIds(
+            @Param("contractId") Long contractId,
+            @Param("productIds") List<Long> productIds,
+            @Param("listingStatus") ContractProductListingStatus listingStatus
+    );
 }

--- a/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/entity/Product.java
@@ -108,6 +108,18 @@ public class Product extends BaseTimeEntity {
         this.stockQuantity = stockQuantity;
     }
 
+    public void decreaseStockQuantity(int quantity, Long expectedVersion) {
+        validateVersion(expectedVersion);
+        if (quantity < 1) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "차감 수량은 1 이상이어야 합니다.");
+        }
+        if (this.stockQuantity < quantity) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "출고 수량이 보유 재고보다 많습니다.");
+        }
+
+        this.stockQuantity -= quantity;
+    }
+
     public void updateMemo(String memo) {
         if (memo == null || memo.isBlank()) {
             this.memo = "";

--- a/src/main/java/app/dearobjet/backend/domain/shop/repository/ProductRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/shop/repository/ProductRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
@@ -23,5 +25,23 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             Collection<Long> productsIds,
             Long artistId,
             ProductStatus status
+    );
+
+    @Query("""
+            select p
+            from Product p
+            where p.artist.id = :artistId
+              and p.status = :status
+              and p.stockQuantity > 0
+              and (
+                  :keyword = ''
+                  or lower(p.productName) like concat('%', :keyword, '%')
+              )
+            """)
+    Page<Product> findShipmentAvailableProducts(
+            @Param("artistId") Long artistId,
+            @Param("status") ProductStatus status,
+            @Param("keyword") String keyword,
+            Pageable pageable
     );
 }

--- a/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ArtistShipmentServiceTest.java
@@ -1,24 +1,38 @@
 package app.dearobjet.backend.domain.artist;
 
+import app.dearobjet.backend.domain.artist.dto.ArtistShipmentAvailableProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentProductListResponse;
 import app.dearobjet.backend.domain.artist.dto.ArtistShipmentShopListResponse;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistShipmentRequest;
+import app.dearobjet.backend.domain.artist.dto.CreateArtistShipmentResponse;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.artist.service.ArtistShipmentService;
 import app.dearobjet.backend.domain.contract.ContractRepository;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
+import app.dearobjet.backend.domain.contract.entity.ContractProduct;
+import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.CommissionType;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
+import app.dearobjet.backend.domain.contract.repository.ContractProductStockMovementRepository;
+import app.dearobjet.backend.domain.shop.entity.Product;
+import app.dearobjet.backend.domain.shop.enums.ProductStatus;
+import app.dearobjet.backend.domain.shop.repository.ProductRepository;
 import app.dearobjet.backend.domain.user.enums.Specialty;
 import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @DisplayName("ArtistShipmentService 출고관리 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -43,7 +58,10 @@ class ArtistShipmentServiceTest {
     private static final Long ARTIST_ID = 10L;
     private static final Long CONTRACT_ID = 50L;
     private static final Long CONTRACT_PRODUCT_ID = 70L;
+    private static final Long CUP_PRODUCT_ID = 80L;
+    private static final Long PLATE_PRODUCT_ID = 81L;
     private static final Long SHOP_ID = 100L;
+    private static final Long VERSION = 0L;
     private static final BigDecimal SELLING_PRICE = new BigDecimal("15000.00");
     private static final BigDecimal COMMISSION_VALUE = new BigDecimal("20.0000");
     private static final BigDecimal UNIT_SETTLEMENT_AMOUNT = new BigDecimal("12000.00");
@@ -62,6 +80,12 @@ class ArtistShipmentServiceTest {
 
     @Mock
     private ContractProductRepository contractProductRepository;
+
+    @Mock
+    private ContractProductStockMovementRepository contractProductStockMovementRepository;
+
+    @Mock
+    private ProductRepository productRepository;
 
     @Test
     @DisplayName("출고관리 입점 매장 목록에서 입고확인 상태를 함께 반환한다")
@@ -209,6 +233,182 @@ class ArtistShipmentServiceTest {
                 .hasMessage("계약서 정보를 찾을 수 없습니다.");
     }
 
+    @Test
+    @DisplayName("출고 가능 품목은 현재 승인 계약과 작가 보유 재고 상품을 반환한다")
+    void givenCurrentContract_whenGetAvailableProducts_thenReturnArtistProducts() {
+        Product cup = product(CUP_PRODUCT_ID, "세라믹 컵", 10, VERSION);
+        PageRequest pageRequest = PageRequest.of(
+                0,
+                20,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "productsId"))
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findCurrentApprovedContractsByArtistIdAndShopId(
+                eq(ARTIST_ID),
+                eq(SHOP_ID),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
+        )).willReturn(List.of(contract(CONTRACT_ID, ContractStatus.APPROVED)));
+        given(productRepository.findShipmentAvailableProducts(
+                ARTIST_ID,
+                ProductStatus.ACTIVE,
+                "컵",
+                pageRequest
+        )).willReturn(new PageImpl<>(List.of(cup)));
+
+        ArtistShipmentAvailableProductListResponse response =
+                artistShipmentService.getAvailableProducts(USER_ID, SHOP_ID, " 컵 ", 1, 20);
+
+        assertThat(response.getShopId()).isEqualTo(SHOP_ID);
+        assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getProductId()).isEqualTo(CUP_PRODUCT_ID);
+        assertThat(response.getItems().get(0).getShipmentQuantity()).isZero();
+        assertThat(response.getItems().get(0).getTotalQuantity()).isEqualTo(10);
+        assertThat(response.getItems().get(0).getVersion()).isEqualTo(VERSION);
+    }
+
+    @Test
+    @DisplayName("출고 시 기존 입고 품목 재고를 증가시키고 작가 보유 재고를 차감한다")
+    void givenExistingContractProduct_whenCreateShipment_thenIncreaseInventoryAndDecreaseArtistStock() {
+        Product cup = product(CUP_PRODUCT_ID, "세라믹 컵", 10, VERSION);
+        ShopArtistContract contract = contract(CONTRACT_ID, ContractStatus.APPROVED);
+        ContractProduct contractProduct = contractProduct(CONTRACT_PRODUCT_ID, contract, cup, 2);
+        CreateArtistShipmentRequest request = shipmentRequest(
+                shipmentItem(CUP_PRODUCT_ID, 3, VERSION)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findCurrentApprovedContractsByArtistIdAndShopId(
+                eq(ARTIST_ID),
+                eq(SHOP_ID),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
+        )).willReturn(List.of(contract));
+        given(productRepository.findByProductsIdInAndArtistIdAndStatus(
+                List.of(CUP_PRODUCT_ID),
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(List.of(cup));
+        given(contractProductRepository.findActiveProductsByContractIdAndProductIds(
+                CONTRACT_ID,
+                List.of(CUP_PRODUCT_ID),
+                ContractProductListingStatus.ACTIVE
+        )).willReturn(List.of(contractProduct));
+
+        CreateArtistShipmentResponse response = artistShipmentService.createShipment(USER_ID, SHOP_ID, request);
+
+        assertThat(cup.getStockQuantity()).isEqualTo(7);
+        assertThat(contractProduct.getStockQuantity()).isEqualTo(5);
+        assertThat(contract.getRecentInboundConfirmed()).isFalse();
+        assertThat(response.getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getContractProductId()).isEqualTo(CONTRACT_PRODUCT_ID);
+        assertThat(response.getItems().get(0).getShipmentQuantity()).isEqualTo(3);
+        assertThat(response.getItems().get(0).getRemainingQuantity()).isEqualTo(7);
+        verify(contractProductStockMovementRepository).save(any(ContractProductStockMovement.class));
+    }
+
+    @Test
+    @DisplayName("출고 시 신규 품목이면 계약 품목을 생성하고 정산 금액을 계산한다")
+    void givenNewProduct_whenCreateShipment_thenCreateContractProductWithSettlementAmounts() {
+        Product cup = product(CUP_PRODUCT_ID, "세라믹 컵", 10, VERSION);
+        ShopArtistContract contract = contract(CONTRACT_ID, ContractStatus.APPROVED);
+        CreateArtistShipmentRequest request = shipmentRequest(
+                shipmentItem(CUP_PRODUCT_ID, 4, VERSION)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findCurrentApprovedContractsByArtistIdAndShopId(
+                eq(ARTIST_ID),
+                eq(SHOP_ID),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
+        )).willReturn(List.of(contract));
+        given(productRepository.findByProductsIdInAndArtistIdAndStatus(
+                List.of(CUP_PRODUCT_ID),
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(List.of(cup));
+        given(contractProductRepository.findActiveProductsByContractIdAndProductIds(
+                CONTRACT_ID,
+                List.of(CUP_PRODUCT_ID),
+                ContractProductListingStatus.ACTIVE
+        )).willReturn(List.of());
+        given(contractProductRepository.save(any(ContractProduct.class))).willAnswer(invocation -> {
+            ContractProduct saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "contractProductsId", CONTRACT_PRODUCT_ID);
+            return saved;
+        });
+
+        CreateArtistShipmentResponse response = artistShipmentService.createShipment(USER_ID, SHOP_ID, request);
+
+        assertThat(cup.getStockQuantity()).isEqualTo(6);
+        assertThat(response.getItems().get(0).getContractProductId()).isEqualTo(CONTRACT_PRODUCT_ID);
+        assertThat(response.getItems().get(0).getUnitSettlementAmount())
+                .isEqualByComparingTo("12000.00");
+        assertThat(response.getItems().get(0).getCommissionType()).isEqualTo(CommissionType.RATE);
+        assertThat(response.getItems().get(0).getCommissionValue()).isEqualByComparingTo(COMMISSION_VALUE);
+        verify(contractProductRepository).save(any(ContractProduct.class));
+        verify(contractProductStockMovementRepository).save(any(ContractProductStockMovement.class));
+    }
+
+    @Test
+    @DisplayName("출고 수량이 작가 보유 재고보다 많으면 출고할 수 없다")
+    void givenQuantityExceedsStock_whenCreateShipment_thenThrowInvalidInput() {
+        Product cup = product(CUP_PRODUCT_ID, "세라믹 컵", 2, VERSION);
+        ShopArtistContract contract = contract(CONTRACT_ID, ContractStatus.APPROVED);
+        CreateArtistShipmentRequest request = shipmentRequest(
+                shipmentItem(CUP_PRODUCT_ID, 3, VERSION)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findCurrentApprovedContractsByArtistIdAndShopId(
+                eq(ARTIST_ID),
+                eq(SHOP_ID),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
+        )).willReturn(List.of(contract));
+        given(productRepository.findByProductsIdInAndArtistIdAndStatus(
+                List.of(CUP_PRODUCT_ID),
+                ARTIST_ID,
+                ProductStatus.ACTIVE
+        )).willReturn(List.of(cup));
+        given(contractProductRepository.findActiveProductsByContractIdAndProductIds(
+                CONTRACT_ID,
+                List.of(CUP_PRODUCT_ID),
+                ContractProductListingStatus.ACTIVE
+        )).willReturn(List.of());
+
+        assertThatThrownBy(() -> artistShipmentService.createShipment(USER_ID, SHOP_ID, request))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessage("출고 수량이 보유 재고보다 많습니다.");
+    }
+
+    @Test
+    @DisplayName("중복 상품이 포함되면 출고할 수 없다")
+    void givenDuplicateProductIds_whenCreateShipment_thenThrowInvalidInput() {
+        ShopArtistContract contract = contract(CONTRACT_ID, ContractStatus.APPROVED);
+        CreateArtistShipmentRequest request = shipmentRequest(
+                shipmentItem(CUP_PRODUCT_ID, 1, VERSION),
+                shipmentItem(CUP_PRODUCT_ID, 2, VERSION)
+        );
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist()));
+        given(contractRepository.findCurrentApprovedContractsByArtistIdAndShopId(
+                eq(ARTIST_ID),
+                eq(SHOP_ID),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
+        )).willReturn(List.of(contract));
+
+        assertThatThrownBy(() -> artistShipmentService.createShipment(USER_ID, SHOP_ID, request))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessage("중복된 상품 ID가 포함되어 있습니다.");
+    }
+
     private Artist artist() {
         return Artist.builder()
                 .id(ARTIST_ID)
@@ -223,9 +423,57 @@ class ArtistShipmentServiceTest {
         return ShopArtistContract.builder()
                 .shopArtistContractsId(contractId)
                 .contractStatus(contractStatus)
+                .commissionType(CommissionType.RATE)
+                .commissionValue(COMMISSION_VALUE)
                 .contractStartDate(CONTRACT_START_DATE)
                 .contractEndDate(CONTRACT_END_DATE)
                 .build();
+    }
+
+    private Product product(Long productId, String productName, int stockQuantity, Long version) {
+        return Product.builder()
+                .productsId(productId)
+                .artist(artist())
+                .productName(productName)
+                .price(SELLING_PRICE)
+                .status(ProductStatus.ACTIVE)
+                .productUrl("https://image.test/products/" + productId + ".png")
+                .stockQuantity(stockQuantity)
+                .version(version)
+                .build();
+    }
+
+    private ContractProduct contractProduct(
+            Long contractProductId,
+            ShopArtistContract contract,
+            Product product,
+            int stockQuantity
+    ) {
+        return ContractProduct.builder()
+                .contractProductsId(contractProductId)
+                .shopArtistContract(contract)
+                .product(product)
+                .sellingPrice(product.getPrice())
+                .stockQuantity(stockQuantity)
+                .soldQuantity(0)
+                .listingStatus(ContractProductListingStatus.ACTIVE)
+                .unitSettlementAmount(UNIT_SETTLEMENT_AMOUNT)
+                .marginAmount(product.getPrice().subtract(UNIT_SETTLEMENT_AMOUNT))
+                .build();
+    }
+
+    private CreateArtistShipmentRequest shipmentRequest(CreateArtistShipmentRequest.Item... items) {
+        CreateArtistShipmentRequest request = new CreateArtistShipmentRequest();
+        ReflectionTestUtils.setField(request, "items", List.of(items));
+        return request;
+    }
+
+    private CreateArtistShipmentRequest.Item shipmentItem(Long productId, int quantity, Long version) {
+        CreateArtistShipmentRequest.Item item = new CreateArtistShipmentRequest.Item();
+        ReflectionTestUtils.setField(item, "productId", productId);
+        ReflectionTestUtils.setField(item, "quantity", quantity);
+        ReflectionTestUtils.setField(item, "version", version);
+        return item;
     }
 
     private ArtistShipmentProductRow shipmentProductRow(

--- a/src/test/java/app/dearobjet/backend/domain/artist/ProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/artist/ProductRepositoryTest.java
@@ -104,6 +104,28 @@ class ProductRepositoryTest {
     }
 
     @Test
+    @DisplayName("출고 가능 상품은 작가 보유 재고가 있고 상품명 검색어에 맞는 활성 상품만 조회한다")
+    void givenKeyword_whenFindShipmentAvailableProducts_thenReturnMatchedStockProducts() {
+        Artist artist = createArtist("artist-c@test.com", "Postman 출고 작가");
+        Artist otherArtist = createArtist("artist-d@test.com", "Postman 다른 출고 작가");
+        Product cup = createProduct(artist, "세라믹 컵", ProductStatus.ACTIVE, 5);
+        createProduct(artist, "세라믹 접시", ProductStatus.ACTIVE, 0);
+        createProduct(artist, "비활성 컵", ProductStatus.INACTIVE, 5);
+        createProduct(otherArtist, "다른 작가 컵", ProductStatus.ACTIVE, 5);
+
+        Page<Product> products = productRepository.findShipmentAvailableProducts(
+                artist.getId(),
+                ProductStatus.ACTIVE,
+                "컵",
+                PageRequest.of(FIRST_PAGE_INDEX, PAGE_SIZE)
+        );
+
+        assertThat(products.getContent())
+                .extracting(Product::getProductsId)
+                .containsExactly(cup.getProductsId());
+    }
+
+    @Test
     @DisplayName("상품 메모를 저장하고 조회한다")
     void givenProductMemo_whenSaveAndFind_thenReturnMemo() {
         Artist artist = createArtist("artist-a@test.com", "Postman 도자기 작가");
@@ -141,12 +163,17 @@ class ProductRepositoryTest {
     }
 
     private Product createProduct(Artist artist, String productName, ProductStatus status) {
+        return createProduct(artist, productName, status, 0);
+    }
+
+    private Product createProduct(Artist artist, String productName, ProductStatus status, int stockQuantity) {
         return productRepository.save(Product.builder()
                 .artist(artist)
                 .productName(productName)
                 .price(DEFAULT_PRICE)
                 .status(status)
                 .productUrl("https://image.test/products/" + productName + ".png")
+                .stockQuantity(stockQuantity)
                 .build());
     }
 }


### PR DESCRIPTION
## 작업 내용
  - 작가 출고관리에서 소품샵 선택 시 출고 가능 품목 목록 조회 API 추가
  - 상품명 기준 검색 지원
  - 선택 품목 출고 API 추가
  - 출고 시 작가 보유 재고 차감, 소품샵 계약 품목 재고 증가
  - 신규 품목은 contract_products 생성 후 INBOUND 이력 저장
  - 기존 입고 품목은 기존 contract_products에 INBOUND 이력 추가
  - 출고 후 최근 입고확인 상태를 미확인으로 변경

  ## 테스트
  - ArtistShipmentService 단위 테스트 추가
  - ProductRepository 출고 가능 품목 검색 테스트 추가
  - 관련 Repository/Service 테스트 통과
