### PR TITLE
[FEAT] 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/controller/UserController.java
@@ -85,6 +85,17 @@ public class UserController {
         ));
     }
 
+    @PostMapping("/me/withdrawal")
+    @Operation(summary = "회원탈퇴 요청")
+    public ResponseEntity<ApiResponse<Void>> requestWithdrawal(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        userService.requestWithdrawal(userDetails.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.of(null));
+    }
+
     // CUSTOMER 가입 완료
     @PostMapping("/complete")
     @Operation(summary = "일반 사용자 가입")

--- a/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/entity/User.java
@@ -6,6 +6,7 @@ import app.dearobjet.backend.global.common.entity.BaseTimeEntity;
 import app.dearobjet.backend.global.exception.BusinessException;
 import app.dearobjet.backend.global.exception.ErrorCode;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Entity
@@ -50,8 +51,29 @@ public class User extends BaseTimeEntity {
     @Column(name = "social_id")
     private String socialId;
 
+    @Column(name = "withdrawal_requested_at")
+    private LocalDateTime withdrawalRequestedAt;
+
     public void deactivate() {
         this.userStatus = UserStatus.INACTIVE;
+    }
+
+    public void requestWithdrawal() {
+        this.userStatus = UserStatus.INACTIVE;
+        this.withdrawalRequestedAt = LocalDateTime.now();
+    }
+
+    public void recoverWithdrawal() {
+        if (!isWithdrawalRequested()) {
+            return;
+        }
+
+        this.userStatus = UserStatus.ACTIVE;
+        this.withdrawalRequestedAt = null;
+    }
+
+    public boolean isWithdrawalRequested() {
+        return this.userStatus == UserStatus.INACTIVE && this.withdrawalRequestedAt != null;
     }
 
     public void completeRegistration(

--- a/src/main/java/app/dearobjet/backend/domain/user/service/UserService.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/service/UserService.java
@@ -52,6 +52,8 @@ public interface UserService {
     // 회원 비활성화
     void deactivateUser(Long userId);
 
+    void requestWithdrawal(Long userId);
+
     void changePhone(Long userId, String newPhone);
 }
 

--- a/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/service/UserServiceImpl.java
@@ -48,6 +48,10 @@ public class UserServiceImpl implements UserService {
     @Override
     public User getOrCreateKakaoUser(String socialId, String email) {
         return userRepository.findBySocialId(socialId)
+                .map(user -> {
+                    user.recoverWithdrawal();
+                    return user;
+                })
                 .orElseGet(() -> createTempUser(socialId, email));
     }
 
@@ -256,6 +260,13 @@ public class UserServiceImpl implements UserService {
         User user = getUser(userId);
 
         user.deactivate();
+    }
+
+    @Override
+    public void requestWithdrawal(Long userId) {
+        User user = getUser(userId);
+
+        user.requestWithdrawal();
     }
 
     @Override

--- a/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/jwt/JwtAuthenticationFilter.java
@@ -59,6 +59,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UserDetails userDetails =
                 userDetailsService.loadUserByUsername(String.valueOf(userId));
 
+        if (!userDetails.isEnabled()) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(
                         userDetails,

--- a/src/main/java/app/dearobjet/backend/global/auth/service/TokenService.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/service/TokenService.java
@@ -1,6 +1,7 @@
 package app.dearobjet.backend.global.auth.service;
 
 import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
 import app.dearobjet.backend.domain.user.repository.UserRepository;
 import app.dearobjet.backend.global.auth.dto.RefreshResult;
 import app.dearobjet.backend.global.auth.jwt.JwtProvider;
@@ -31,6 +32,10 @@ public class TokenService {
         // 4. 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow();
+
+        if (user.getUserStatus() != UserStatus.ACTIVE) {
+            throw new IllegalStateException("INACTIVE_USER");
+        }
 
         // 5. 새 토큰 발급
         String newAccessToken =


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR번호} [{이슈번호}]

## **⚡ Content**

- 회원 탈퇴 추가

## **📆 TBD**

- USERSTATUS가 INACTIVE이며 탈퇴 timestamp가 30일 이상 지났을 시 탈퇴 배치 처리 필요
- 카카오 어드민 키를 활용한 카카오 Oauth 내 Dearobjet 서비스 탈퇴 추가

## **🌟 Point**

- user 컬럼 탈퇴 timestamp 추가
- 재 로그인 시 INACTIVE -> ACTIVE 로 변경

## ❓ Question

- 없음