### PR TITLE
[FEAT] 이미지 포함 포스트 CRUD API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/post/controller/PostController.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/controller/PostController.java
@@ -1,0 +1,75 @@
+package app.dearobjet.backend.domain.post.controller;
+
+import app.dearobjet.backend.domain.post.dto.CreatePostRequest;
+import app.dearobjet.backend.domain.post.dto.PostListResponse;
+import app.dearobjet.backend.domain.post.dto.PostResponse;
+import app.dearobjet.backend.domain.post.dto.UpdatePostRequest;
+import app.dearobjet.backend.domain.post.service.PostService;
+import app.dearobjet.backend.global.api.ApiResponse;
+import app.dearobjet.backend.global.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<PostResponse> createPost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestPart("request") CreatePostRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    ) {
+        return ApiResponse.of(postService.createPost(userDetails.getUserId(), request, images));
+    }
+
+    @GetMapping
+    public ApiResponse<PostListResponse> getPosts(
+            @RequestParam Long userId,
+            @RequestParam(defaultValue = "1") int page
+    ) {
+        return ApiResponse.of(postService.getPosts(userId, page));
+    }
+
+    @GetMapping("/{postId}")
+    public ApiResponse<PostResponse> getPost(
+            @PathVariable Long postId
+    ) {
+        return ApiResponse.of(postService.getPost(postId));
+    }
+
+    @PutMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<PostResponse> updatePost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long postId,
+            @Valid @RequestPart("request") UpdatePostRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    ) {
+        return ApiResponse.of(postService.updatePost(userDetails.getUserId(), postId, request, images));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiResponse<Void> deletePost(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long postId
+    ) {
+        postService.deletePost(userDetails.getUserId(), postId);
+        return ApiResponse.of(null);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/CreatePostRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/CreatePostRequest.java
@@ -1,0 +1,17 @@
+package app.dearobjet.backend.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreatePostRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
+        @Size(max = 5000, message = "내용은 5000자를 초과할 수 없습니다.")
+        String content,
+
+        Boolean isPublic
+) {
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/PostListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/PostListResponse.java
@@ -1,0 +1,18 @@
+package app.dearobjet.backend.domain.post.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostListResponse(
+        List<Item> items,
+        int page,
+        int totalPages
+) {
+    public record Item(
+            Long postId,
+            String thumbnailUrl,
+            String title,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/PostResponse.java
@@ -1,0 +1,18 @@
+package app.dearobjet.backend.domain.post.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostResponse(
+        Long postId,
+        Long userId,
+        String userName,
+        String title,
+        String content,
+        List<String> imageUrls,
+        Integer viewCount,
+        Integer likeCount,
+        Boolean isPublic,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/UpdatePostRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/UpdatePostRequest.java
@@ -1,0 +1,17 @@
+package app.dearobjet.backend.domain.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePostRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
+        @Size(max = 5000, message = "내용은 5000자를 초과할 수 없습니다.")
+        String content,
+
+        Boolean isPublic
+) {
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
@@ -41,4 +41,15 @@ public class Post extends BaseTimeEntity {
 
     @Column(name = "is_public")
     private Boolean isPublic;
+
+    public void update(String title, String content, String imageUrls, Boolean isPublic) {
+        this.title = title;
+        this.content = content;
+        if (imageUrls != null) {
+            this.imageUrls = imageUrls;
+        }
+        if (isPublic != null) {
+            this.isPublic = isPublic;
+        }
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/repository/PostRepository.java
@@ -1,0 +1,11 @@
+package app.dearobjet.backend.domain.post.repository;
+
+import app.dearobjet.backend.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByUser_Id(Long userId, Pageable pageable);
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/service/PostService.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/service/PostService.java
@@ -1,0 +1,181 @@
+package app.dearobjet.backend.domain.post.service;
+
+import app.dearobjet.backend.domain.post.dto.CreatePostRequest;
+import app.dearobjet.backend.domain.post.dto.PostListResponse;
+import app.dearobjet.backend.domain.post.dto.PostResponse;
+import app.dearobjet.backend.domain.post.dto.UpdatePostRequest;
+import app.dearobjet.backend.domain.post.entity.Post;
+import app.dearobjet.backend.domain.post.repository.PostRepository;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.s3.service.S3FileUploadService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private static final int POST_PAGE_SIZE = 12;
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final S3FileUploadService s3FileUploadService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public PostResponse createPost(Long userId, CreatePostRequest request, List<MultipartFile> images) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getRole() != Role.ARTIST) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        List<String> urls = uploadImages(images, userId);
+
+        Post post = postRepository.save(Post.builder()
+                .user(user)
+                .title(request.title())
+                .content(request.content())
+                .imageUrls(toJson(urls))
+                .viewCount(0)
+                .likeCount(0)
+                .commentCount(0)
+                .isPublic(request.isPublic() != null ? request.isPublic() : true)
+                .build());
+
+        return toResponse(post, urls);
+    }
+
+    @Transactional(readOnly = true)
+    public PostListResponse getPosts(Long targetUserId, int page) {
+        Pageable pageable = PageRequest.of(
+                Math.max(page - 1, 0),
+                POST_PAGE_SIZE,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "postId"))
+        );
+
+        Page<Post> postPage = postRepository.findByUser_Id(targetUserId, pageable);
+
+        List<PostListResponse.Item> items = new ArrayList<>();
+        for (Post post : postPage.getContent()) {
+            List<String> urls = fromJson(post.getImageUrls());
+            String thumbnail = urls.isEmpty() ? null : urls.get(0);
+            items.add(new PostListResponse.Item(
+                    post.getPostId(),
+                    thumbnail,
+                    post.getTitle(),
+                    post.getCreatedAt()
+            ));
+        }
+
+        return new PostListResponse(items, page, postPage.getTotalPages());
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND, "포스트를 찾을 수 없습니다."));
+
+        return toResponse(post, fromJson(post.getImageUrls()));
+    }
+
+    @Transactional
+    public PostResponse updatePost(Long userId, Long postId, UpdatePostRequest request, List<MultipartFile> images) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND, "포스트를 찾을 수 없습니다."));
+
+        if (!post.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        String imageUrlsJson = null;
+        List<String> urls;
+        if (images != null && !images.isEmpty()) {
+            urls = uploadImages(images, userId);
+            imageUrlsJson = toJson(urls);
+        } else {
+            urls = fromJson(post.getImageUrls());
+        }
+
+        post.update(request.title(), request.content(), imageUrlsJson, request.isPublic());
+        return toResponse(post, urls);
+    }
+
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND, "포스트를 찾을 수 없습니다."));
+
+        if (!post.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        postRepository.delete(post);
+    }
+
+    private List<String> uploadImages(List<MultipartFile> images, Long userId) {
+        if (images == null || images.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> urls = new ArrayList<>();
+        for (MultipartFile image : images) {
+            if (image != null && !image.isEmpty()) {
+                urls.add(s3FileUploadService.uploadPostImage(image, userId));
+            }
+        }
+        return urls;
+    }
+
+    private String toJson(List<String> urls) {
+        try {
+            return objectMapper.writeValueAsString(urls);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "이미지 URL 직렬화에 실패했습니다.");
+        }
+    }
+
+    private List<String> fromJson(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private PostResponse toResponse(Post post, List<String> urls) {
+        return new PostResponse(
+                post.getPostId(),
+                post.getUser().getId(),
+                post.getUser().getName(),
+                post.getTitle(),
+                post.getContent(),
+                urls,
+                post.getViewCount(),
+                post.getLikeCount(),
+                post.getIsPublic(),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                                 "/ws/**"
                         ).permitAll()
 
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/notices/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/shops/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/shops/*/classes").permitAll()

--- a/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다"),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A003", "리프레시 토큰을 찾을 수 없습니다"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A004", "인증이 필요합니다"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "A005", "접근 권한이 없습니다"),
 
     // Notice (N0XX)
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "공지사항을 찾을 수 없습니다"),

--- a/src/main/java/app/dearobjet/backend/global/s3/service/S3FileUploadService.java
+++ b/src/main/java/app/dearobjet/backend/global/s3/service/S3FileUploadService.java
@@ -181,6 +181,34 @@ public class S3FileUploadService {
         }
     }
 
+    public String uploadPostImage(MultipartFile file, Long userId) {
+        validateImageFile(file, "포스트 이미지 파일", MAX_IMAGE_FILE_SIZE_BYTES);
+
+        String key = buildPostImageKey(userId, file.getOriginalFilename());
+        String contentType = file.getContentType();
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+            return buildPublicUrl(key);
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "파일 읽기에 실패했습니다.");
+        } catch (S3Exception e) {
+            String detailMessage = e.awsErrorDetails() == null
+                    ? e.getMessage()
+                    : e.awsErrorDetails().errorCode() + ": " + e.awsErrorDetails().errorMessage();
+            throw new BusinessException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "S3 업로드에 실패했습니다. " + detailMessage
+            );
+        }
+    }
+
     public String uploadStoryThumbnail(MultipartFile file, Long userId) {
         validateImageFile(file, "스토리 썸네일 파일", MAX_IMAGE_FILE_SIZE_BYTES);
 
@@ -274,6 +302,11 @@ public class S3FileUploadService {
     private String buildBankbookImageKey(Long userId, String originalFilename) {
         String extension = extractExtension(originalFilename);
         return "bankbook-image/" + userId + "/" + UUID.randomUUID() + extension;
+    }
+
+    private String buildPostImageKey(Long userId, String originalFilename) {
+        String extension = extractExtension(originalFilename);
+        return "post-image/" + userId + "/" + UUID.randomUUID() + extension;
     }
 
     private String buildStoryThumbnailKey(Long userId, String originalFilename) {

--- a/src/test/java/app/dearobjet/backend/domain/post/PostServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/post/PostServiceTest.java
@@ -1,0 +1,239 @@
+package app.dearobjet.backend.domain.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import app.dearobjet.backend.domain.post.dto.CreatePostRequest;
+import app.dearobjet.backend.domain.post.dto.PostListResponse;
+import app.dearobjet.backend.domain.post.dto.PostResponse;
+import app.dearobjet.backend.domain.post.dto.UpdatePostRequest;
+import app.dearobjet.backend.domain.post.entity.Post;
+import app.dearobjet.backend.domain.post.repository.PostRepository;
+import app.dearobjet.backend.domain.post.service.PostService;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.s3.service.S3FileUploadService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private S3FileUploadService s3FileUploadService;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private PostService postService;
+
+    @Test
+    void createPost_savesPost() {
+        User user = User.builder().id(1L).name("작가").role(Role.ARTIST).build();
+        MockMultipartFile image = new MockMultipartFile("images", "img.jpg", "image/jpeg", "img".getBytes());
+        CreatePostRequest request = new CreatePostRequest("제목", "내용", true);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(s3FileUploadService.uploadPostImage(image, 1L)).willReturn("https://cdn/post.jpg");
+        given(postRepository.save(any(Post.class))).willAnswer(invocation -> {
+            Post post = invocation.getArgument(0);
+            return Post.builder()
+                    .postId(100L)
+                    .user(post.getUser())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .imageUrls(post.getImageUrls())
+                    .viewCount(0)
+                    .likeCount(0)
+                    .commentCount(0)
+                    .isPublic(post.getIsPublic())
+                    .build();
+        });
+
+        PostResponse response = postService.createPost(1L, request, List.of(image));
+
+        assertThat(response.postId()).isEqualTo(100L);
+        assertThat(response.title()).isEqualTo("제목");
+        assertThat(response.content()).isEqualTo("내용");
+        assertThat(response.imageUrls()).containsExactly("https://cdn/post.jpg");
+        assertThat(response.isPublic()).isTrue();
+    }
+
+    @Test
+    void createPost_throwsWhenNotArtist() {
+        User user = User.builder().id(1L).role(Role.CUSTOMER).build();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> postService.createPost(1L, new CreatePostRequest("제목", "내용", true), null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void createPost_throwsWhenUserNotFound() {
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postService.createPost(1L, new CreatePostRequest("제목", "내용", true), null))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void getPosts_returnsPaginatedItems() {
+        User user = User.builder().id(1L).name("작가").build();
+        Post post1 = Post.builder()
+                .postId(2L)
+                .user(user)
+                .title("제목2")
+                .imageUrls("[\"https://cdn/2.jpg\"]")
+                .build();
+        Post post2 = Post.builder()
+                .postId(1L)
+                .user(user)
+                .title("제목1")
+                .imageUrls("[]")
+                .build();
+
+        given(postRepository.findByUser_Id(any(), any()))
+                .willReturn(new PageImpl<>(List.of(post1, post2)));
+
+        PostListResponse response = postService.getPosts(1L, 1);
+
+        assertThat(response.items()).hasSize(2);
+        assertThat(response.items().get(0).postId()).isEqualTo(2L);
+        assertThat(response.items().get(0).thumbnailUrl()).isEqualTo("https://cdn/2.jpg");
+        assertThat(response.items().get(1).thumbnailUrl()).isNull();
+        assertThat(response.page()).isEqualTo(1);
+    }
+
+    @Test
+    void getPost_returnsPost() {
+        User user = User.builder().id(1L).name("작가").build();
+        Post post = Post.builder()
+                .postId(1L)
+                .user(user)
+                .title("제목")
+                .content("내용")
+                .imageUrls("[\"https://cdn/1.jpg\",\"https://cdn/2.jpg\"]")
+                .viewCount(0)
+                .likeCount(0)
+                .isPublic(true)
+                .build();
+
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+        PostResponse response = postService.getPost(1L);
+
+        assertThat(response.postId()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("제목");
+        assertThat(response.imageUrls()).containsExactly("https://cdn/1.jpg", "https://cdn/2.jpg");
+    }
+
+    @Test
+    void getPost_throwsWhenNotFound() {
+        given(postRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postService.getPost(1L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void updatePost_updatesFieldsAndImages() {
+        User user = User.builder().id(1L).name("작가").build();
+        Post post = Post.builder()
+                .postId(1L)
+                .user(user)
+                .title("이전")
+                .content("이전내용")
+                .imageUrls("[\"https://cdn/old.jpg\"]")
+                .viewCount(0)
+                .likeCount(0)
+                .isPublic(true)
+                .build();
+        MockMultipartFile image = new MockMultipartFile("images", "new.jpg", "image/jpeg", "img".getBytes());
+        UpdatePostRequest request = new UpdatePostRequest("새제목", "새내용", true);
+
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+        given(s3FileUploadService.uploadPostImage(image, 1L)).willReturn("https://cdn/new.jpg");
+
+        PostResponse response = postService.updatePost(1L, 1L, request, List.of(image));
+
+        assertThat(response.title()).isEqualTo("새제목");
+        assertThat(response.content()).isEqualTo("새내용");
+        assertThat(response.imageUrls()).containsExactly("https://cdn/new.jpg");
+    }
+
+    @Test
+    void updatePost_keepsOldImagesWhenNoneProvided() {
+        User user = User.builder().id(1L).name("작가").build();
+        Post post = Post.builder()
+                .postId(1L)
+                .user(user)
+                .title("이전")
+                .content("이전내용")
+                .imageUrls("[\"https://cdn/old.jpg\"]")
+                .viewCount(0)
+                .likeCount(0)
+                .isPublic(true)
+                .build();
+        UpdatePostRequest request = new UpdatePostRequest("새제목", "새내용", true);
+
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+        PostResponse response = postService.updatePost(1L, 1L, request, null);
+
+        assertThat(response.title()).isEqualTo("새제목");
+        assertThat(response.imageUrls()).containsExactly("https://cdn/old.jpg");
+    }
+
+    @Test
+    void updatePost_throwsWhenNotOwner() {
+        User owner = User.builder().id(2L).build();
+        Post post = Post.builder().postId(1L).user(owner).build();
+
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> postService.updatePost(1L, 1L, new UpdatePostRequest("새제목", "새내용", true), null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void deletePost_deletesOwnedPost() {
+        User user = User.builder().id(1L).build();
+        Post post = Post.builder().postId(1L).user(user).build();
+
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+        postService.deletePost(1L, 1L);
+    }
+
+    @Test
+    void deletePost_throwsWhenNotOwner() {
+        User owner = User.builder().id(2L).build();
+        Post post = Post.builder().postId(1L).user(owner).build();
+
+        given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> postService.deletePost(1L, 1L))
+                .isInstanceOf(BusinessException.class);
+    }
+}


### PR DESCRIPTION
작가 회원만 포스트를 작성할 수 있고, 조회는 누구나 가능하도록 포스트 CRUD API를 구현했습니다. userId로 특정 작가 또는 소품샵의 포스트 목록을 페이징 조회할 수 있으며, 다중 이미지는 S3에 업로드 후 JSON 배열로 저장됩니다.