### PR TITLE
feat: 소품샵-작가 계약서 작성 플로우 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -5,16 +5,20 @@ import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse
 import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractDocumentResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
+import app.dearobjet.backend.domain.contract.dto.SendContractRequest;
+import app.dearobjet.backend.domain.contract.dto.SubmitArtistContractRequest;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.global.api.ApiResponse;
 import app.dearobjet.backend.global.auth.security.CustomUserDetails;
@@ -36,6 +40,60 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContractController {
 
     private final ContractService contractService;
+
+    @GetMapping("/template")
+    public ApiResponse<ContractTemplateResponse> getContractTemplate(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(contractService.getContractTemplate(resolveUserId(userDetails, userId)));
+    }
+
+    @PostMapping("/artists/{artistId}/send")
+    public ApiResponse<ContractDocumentResponse> sendContractToArtist(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long artistId,
+            @Valid @RequestBody SendContractRequest request
+    ) {
+        return ApiResponse.of(
+                contractService.sendContractToArtist(
+                        resolveUserId(userDetails, userId),
+                        artistId,
+                        request
+                )
+        );
+    }
+
+    @PatchMapping("/shops/{contractId}/artist-submission")
+    public ApiResponse<ContractDocumentResponse> submitArtistContract(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId,
+            @Valid @RequestBody SubmitArtistContractRequest request
+    ) {
+        return ApiResponse.of(
+                contractService.submitArtistContract(
+                        resolveUserId(userDetails, userId),
+                        contractId,
+                        request
+                )
+        );
+    }
+
+    @PatchMapping("/artists/{contractId}/approval")
+    public ApiResponse<ContractDocumentResponse> approveContract(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @PathVariable Long contractId
+    ) {
+        return ApiResponse.of(
+                contractService.approveContract(
+                        resolveUserId(userDetails, userId),
+                        contractId
+                )
+        );
+    }
 
     @GetMapping("/pending-count")
     public ApiResponse<ContractApplicationCountResponse> getPendingApplicationCount(

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -18,11 +18,36 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public interface ContractRepository extends JpaRepository<ShopArtistContract, Long> {
 
     long countByShopUserIdAndContractStatus(Long userId, ContractStatus contractStatus);
+
+    @Query("""
+            select count(c) > 0
+            from ShopArtistContract c
+            where c.shop.shopId = :shopId
+              and c.artist.id = :artistId
+              and (
+                  c.contractStatus = :pendingStatus
+                  or (
+                      c.contractStatus = :approvedStatus
+                      and (
+                          c.contractEndDate is null
+                          or c.contractEndDate >= :today
+                      )
+                  )
+              )
+            """)
+    boolean existsPendingOrCurrentApprovedContract(
+            @Param("shopId") Long shopId,
+            @Param("artistId") Long artistId,
+            @Param("pendingStatus") ContractStatus pendingStatus,
+            @Param("approvedStatus") ContractStatus approvedStatus,
+            @Param("today") LocalDate today
+    );
 
     @Query("""
             select coalesce(nullif(trim(bp.businessName), ''), nullif(trim(u.name), ''), 'UNKNOWN')
@@ -194,7 +219,8 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
                    c.contractStartDate as contractStartDate,
                    c.contractEndDate as contractEndDate,
                    c.contractStatus as contractStatus,
-                   c.contractRequestType as contractRequestType
+                   c.contractRequestType as contractRequestType,
+                   c.contractDocumentStatus as contractDocumentStatus
             from ShopArtistContract c
             join c.artist a
             join a.businessProfile bp

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -5,22 +5,27 @@ import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse
 import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractDocumentResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
+import app.dearobjet.backend.domain.contract.dto.SendContractRequest;
+import app.dearobjet.backend.domain.contract.dto.SubmitArtistContractRequest;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.repository.ContractProductRepository;
@@ -32,6 +37,7 @@ import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.enums.UserStatus;
 import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
+import app.dearobjet.backend.global.exception.DuplicateEntityException;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
 import app.dearobjet.backend.global.exception.ErrorCode;
 import app.dearobjet.backend.global.exception.InvalidInputException;
@@ -72,6 +78,110 @@ public class ContractService {
     private final ContractProductStockMovementRepository contractProductStockMovementRepository;
     private final ShopRepository shopRepository;
     private final ArtistRepository artistRepository;
+
+    @Transactional(readOnly = true)
+    public ContractTemplateResponse getContractTemplate(Long userId) {
+        return ContractTemplateResponse.from(getShopByUserId(userId));
+    }
+
+    @Transactional
+    public ContractDocumentResponse sendContractToArtist(Long userId, Long artistId, SendContractRequest request) {
+        Shop shop = getShopByUserId(userId);
+        Artist artist = artistRepository.findById(artistId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "계약서를 발송할 작가를 찾을 수 없습니다."
+                ));
+        validateContractTargetArtist(artist);
+
+        if (contractRepository.existsPendingOrCurrentApprovedContract(
+                shop.getShopId(),
+                artist.getId(),
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                LocalDate.now()
+        )) {
+            throw new DuplicateEntityException(
+                    ErrorCode.DUPLICATE_ENTITY,
+                    "이미 진행 중이거나 유효한 계약이 있는 작가입니다."
+            );
+        }
+
+        validateContractDates(request.getContractStartDate(), request.getContractEndDate());
+
+        ShopArtistContract contract = ShopArtistContract.createPendingDocument(shop, artist);
+        contract.fillShopContract(
+                request.getShopBusinessName(),
+                request.getShopOwnerName(),
+                request.getShopBusinessNumber(),
+                request.getShopAddress(),
+                request.getShopContact(),
+                request.getContractStartDate(),
+                request.getContractEndDate(),
+                request.getCommissionRate(),
+                request.getSettlementDay(),
+                request.getPaymentDay(),
+                request.getContractDate(),
+                request.getShopSignatureBusinessName(),
+                request.getShopSignatureOwnerName()
+        );
+
+        return ContractDocumentResponse.from(contractRepository.save(contract));
+    }
+
+    @Transactional
+    public ContractDocumentResponse submitArtistContract(
+            Long userId,
+            Long contractId,
+            SubmitArtistContractRequest request
+    ) {
+        ShopArtistContract contract = getArtistOwnedContract(userId, contractId);
+        if (contract.getContractStatus() != ContractStatus.PENDING
+                || contract.getContractDocumentStatus() != ContractDocumentStatus.SHOP_SENT) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "작가 작성이 가능한 계약서가 아닙니다."
+            );
+        }
+
+        contract.fillArtistContract(
+                request.getArtistName(),
+                normalizeOptional(request.getArtistBusinessNumber()),
+                request.getArtistAddress(),
+                request.getArtistContact(),
+                request.getArtistBankName(),
+                request.getArtistAccountHolder(),
+                request.getArtistAccountNumber(),
+                request.getArtistSignatureName()
+        );
+
+        return ContractDocumentResponse.from(contract);
+    }
+
+    @Transactional
+    public ContractDocumentResponse approveContract(Long userId, Long contractId) {
+        Shop shop = getShopByUserId(userId);
+        ShopArtistContract contract = contractRepository.findManagedArtistContractByIdAndShopId(
+                        contractId,
+                        shop.getShopId(),
+                        MANAGED_ARTIST_CONTRACT_STATUSES
+                )
+                .orElseThrow(() -> new EntityNotFoundException(
+                        ErrorCode.ENTITY_NOT_FOUND,
+                        "승인할 계약서 정보를 찾을 수 없습니다."
+                ));
+
+        if (contract.getContractStatus() != ContractStatus.PENDING
+                || contract.getContractDocumentStatus() != ContractDocumentStatus.ARTIST_SUBMITTED) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "작가 작성 완료 후에만 계약 승인할 수 있습니다."
+            );
+        }
+
+        contract.approveDocument();
+        return ContractDocumentResponse.from(contract);
+    }
 
     @Transactional(readOnly = true)
     public ContractApplicationCountResponse getPendingApplicationCount(Long userId) {
@@ -414,6 +524,33 @@ public class ContractService {
             return "";
         }
         return keyword.trim().toLowerCase();
+    }
+
+    private String normalizeOptional(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private void validateContractDates(LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "계약 종료일은 계약 시작일보다 빠를 수 없습니다."
+            );
+        }
+    }
+
+    private void validateContractTargetArtist(Artist artist) {
+        if (artist.getUser() == null
+                || artist.getUser().getRole() != Role.ARTIST
+                || artist.getUser().getUserStatus() != UserStatus.ACTIVE) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "계약서를 발송할 수 있는 활성 작가가 아닙니다."
+            );
+        }
     }
 
     private ContractProductStockMovement applyMovement(

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractDocumentResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractDocumentResponse.java
@@ -1,0 +1,74 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractDocumentResponse {
+
+    private final Long contractId;
+    private final ContractStatus contractStatus;
+    private final ContractDocumentStatus contractDocumentStatus;
+    private final String shopBusinessName;
+    private final String shopOwnerName;
+    private final String shopBusinessNumber;
+    private final String shopAddress;
+    private final String shopContact;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final BigDecimal commissionRate;
+    private final Integer settlementDay;
+    private final Integer paymentDay;
+    private final LocalDate contractDate;
+    private final String shopSignatureBusinessName;
+    private final String shopSignatureOwnerName;
+    private final String artistName;
+    private final String artistBusinessNumber;
+    private final String artistAddress;
+    private final String artistContact;
+    private final String artistBankName;
+    private final String artistAccountHolder;
+    private final String artistAccountNumber;
+    private final String artistSignatureName;
+
+    public static ContractDocumentResponse from(ShopArtistContract contract) {
+        return new ContractDocumentResponse(
+                contract.getShopArtistContractsId(),
+                contract.getContractStatus(),
+                contract.getContractDocumentStatus(),
+                valueOrEmpty(contract.getShopContractBusinessName()),
+                valueOrEmpty(contract.getShopContractOwnerName()),
+                valueOrEmpty(contract.getShopContractBusinessNumber()),
+                valueOrEmpty(contract.getShopContractAddress()),
+                valueOrEmpty(contract.getShopContractContact()),
+                contract.getContractStartDate(),
+                contract.getContractEndDate(),
+                contract.getCommissionValue(),
+                contract.getSettlementDay(),
+                contract.getPaymentDay(),
+                contract.getContractDate(),
+                valueOrEmpty(contract.getShopSignatureBusinessName()),
+                valueOrEmpty(contract.getShopSignatureOwnerName()),
+                valueOrEmpty(contract.getArtistContractName()),
+                valueOrEmpty(contract.getArtistContractBusinessNumber()),
+                valueOrEmpty(contract.getArtistContractAddress()),
+                valueOrEmpty(contract.getArtistContractContact()),
+                valueOrEmpty(contract.getArtistBankName()),
+                valueOrEmpty(contract.getArtistAccountHolder()),
+                valueOrEmpty(contract.getArtistAccountNumber()),
+                valueOrEmpty(contract.getArtistSignatureName())
+        );
+    }
+
+    private static String valueOrEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractStatusActionResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractStatusActionResponse.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.domain.contract.dto;
 
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import lombok.AccessLevel;
@@ -16,10 +17,16 @@ public class ContractStatusActionResponse {
     public static ContractStatusActionResponse from(
             ContractStatus status,
             ContractRequestType requestType,
+            ContractDocumentStatus documentStatus,
             boolean terminable
     ) {
         if (status == ContractStatus.PENDING && requestType == ContractRequestType.RELEASE) {
             return new ContractStatusActionResponse("RELEASE_APPROVE", "해제 승인");
+        }
+        if (status == ContractStatus.PENDING
+                && requestType == ContractRequestType.NONE
+                && documentStatus == ContractDocumentStatus.SHOP_SENT) {
+            return new ContractStatusActionResponse("WAITING_ARTIST_SUBMISSION", "작가 작성 대기");
         }
         if (status == ContractStatus.APPROVED && terminable) {
             return new ContractStatusActionResponse("TERMINATE_CONTRACT", "계약해지");

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractTemplateResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ContractTemplateResponse.java
@@ -1,0 +1,66 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.shop.entity.Shop;
+import app.dearobjet.backend.domain.user.entity.BusinessProfile;
+import app.dearobjet.backend.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContractTemplateResponse {
+
+    private final String shopBusinessName;
+    private final String shopOwnerName;
+    private final String shopBusinessNumber;
+    private final String shopAddress;
+    private final String shopContact;
+    private final String shopSignatureBusinessName;
+    private final String shopSignatureOwnerName;
+
+    private final String artistName;
+    private final String artistBusinessNumber;
+    private final String artistAddress;
+    private final String artistContact;
+    private final String artistBankName;
+    private final String artistAccountHolder;
+    private final String artistAccountNumber;
+    private final String artistSignatureName;
+
+    public static ContractTemplateResponse from(Shop shop) {
+        BusinessProfile profile = shop.getBusinessProfile();
+        User user = shop.getUser();
+        String businessName = valueOrEmpty(profile.getBusinessName());
+        String ownerName = valueOrEmpty(profile.getOwnerName());
+
+        return new ContractTemplateResponse(
+                businessName,
+                ownerName,
+                valueOrEmpty(profile.getBusinessNumber()),
+                valueOrEmpty(profile.getBusinessAddress()),
+                firstNonBlank(profile.getBusinessPhoneNumber(), user.getPhoneNumber()),
+                businessName,
+                ownerName,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                ""
+        );
+    }
+
+    private static String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        return valueOrEmpty(second);
+    }
+
+    private static String valueOrEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractDetailResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractDetailResponse.java
@@ -27,6 +27,7 @@ public class ManagedArtistContractDetailResponse {
     private final CommissionType commissionType;
     private final BigDecimal commissionValue;
     private final String memo;
+    private final ContractDocumentResponse contractDocument;
 
     public static ManagedArtistContractDetailResponse from(ShopArtistContract contract) {
         return new ManagedArtistContractDetailResponse(
@@ -41,7 +42,8 @@ public class ManagedArtistContractDetailResponse {
                 contract.getContractRequestType(),
                 contract.getCommissionType(),
                 contract.getCommissionValue(),
-                contract.getMemo() == null ? "" : contract.getMemo()
+                contract.getMemo() == null ? "" : contract.getMemo(),
+                ContractDocumentResponse.from(contract)
         );
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedArtistContractItemResponse.java
@@ -38,6 +38,7 @@ public class ManagedArtistContractItemResponse {
                 ContractStatusActionResponse.from(
                         row.getContractStatus(),
                         row.getContractRequestType(),
+                        row.getContractDocumentStatus(),
                         terminable
                 ),
                 true

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractDetailResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ManagedShopContractDetailResponse.java
@@ -27,6 +27,7 @@ public class ManagedShopContractDetailResponse {
     private final CommissionType commissionType;
     private final BigDecimal commissionValue;
     private final String memo;
+    private final ContractDocumentResponse contractDocument;
 
     public static ManagedShopContractDetailResponse from(ShopArtistContract contract) {
         return new ManagedShopContractDetailResponse(
@@ -41,7 +42,8 @@ public class ManagedShopContractDetailResponse {
                 contract.getContractRequestType(),
                 contract.getCommissionType(),
                 contract.getCommissionValue(),
-                contract.getMemo() == null ? "" : contract.getMemo()
+                contract.getMemo() == null ? "" : contract.getMemo(),
+                ContractDocumentResponse.from(contract)
         );
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/SendContractRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/SendContractRequest.java
@@ -1,0 +1,61 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class SendContractRequest {
+
+    @NotBlank(message = "소품샵 상호명은 필수입니다.")
+    private String shopBusinessName;
+
+    @NotBlank(message = "소품샵 대표자는 필수입니다.")
+    private String shopOwnerName;
+
+    @NotBlank(message = "소품샵 사업자등록번호는 필수입니다.")
+    private String shopBusinessNumber;
+
+    @NotBlank(message = "소품샵 주소는 필수입니다.")
+    private String shopAddress;
+
+    @NotBlank(message = "소품샵 연락처는 필수입니다.")
+    private String shopContact;
+
+    @NotNull(message = "계약 시작일은 필수입니다.")
+    private LocalDate contractStartDate;
+
+    @NotNull(message = "계약 종료일은 필수입니다.")
+    private LocalDate contractEndDate;
+
+    @NotNull(message = "수수료율은 필수입니다.")
+    @DecimalMin(value = "0.0", inclusive = false, message = "수수료율은 0보다 커야 합니다.")
+    private BigDecimal commissionRate;
+
+    @NotNull(message = "정산 기준일은 필수입니다.")
+    @Min(value = 1, message = "정산 기준일은 1일 이상이어야 합니다.")
+    @Max(value = 31, message = "정산 기준일은 31일 이하여야 합니다.")
+    private Integer settlementDay;
+
+    @NotNull(message = "지급일은 필수입니다.")
+    @Min(value = 1, message = "지급일은 1일 이상이어야 합니다.")
+    @Max(value = 31, message = "지급일은 31일 이하여야 합니다.")
+    private Integer paymentDay;
+
+    @NotNull(message = "계약일은 필수입니다.")
+    private LocalDate contractDate;
+
+    @NotBlank(message = "서명 상호명은 필수입니다.")
+    private String shopSignatureBusinessName;
+
+    @NotBlank(message = "서명 대표자는 필수입니다.")
+    private String shopSignatureOwnerName;
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/SubmitArtistContractRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/SubmitArtistContractRequest.java
@@ -1,0 +1,33 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SubmitArtistContractRequest {
+
+    @NotBlank(message = "작가명은 필수입니다.")
+    private String artistName;
+
+    private String artistBusinessNumber;
+
+    @NotBlank(message = "작가 주소는 필수입니다.")
+    private String artistAddress;
+
+    @NotBlank(message = "작가 연락처는 필수입니다.")
+    private String artistContact;
+
+    @NotBlank(message = "은행명은 필수입니다.")
+    private String artistBankName;
+
+    @NotBlank(message = "예금주는 필수입니다.")
+    private String artistAccountHolder;
+
+    @NotBlank(message = "계좌번호는 필수입니다.")
+    private String artistAccountNumber;
+
+    @NotBlank(message = "작가 서명은 필수입니다.")
+    private String artistSignatureName;
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
@@ -1,5 +1,6 @@
 package app.dearobjet.backend.domain.contract.dto.projection;
 
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 
@@ -13,4 +14,8 @@ public interface ManagedArtistContractRow {
     LocalDate getContractEndDate();
     ContractStatus getContractStatus();
     ContractRequestType getContractRequestType();
+
+    default ContractDocumentStatus getContractDocumentStatus() {
+        return ContractDocumentStatus.NONE;
+    }
 }

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.contract.entity;
 
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.shop.entity.Shop;
@@ -59,6 +60,65 @@ public class ShopArtistContract extends BaseTimeEntity {
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
+    @Column(name = "contract_document_status", nullable = false, length = 20)
+    private ContractDocumentStatus contractDocumentStatus = ContractDocumentStatus.NONE;
+
+    @Column(name = "shop_contract_business_name", length = 100)
+    private String shopContractBusinessName;
+
+    @Column(name = "shop_contract_owner_name", length = 50)
+    private String shopContractOwnerName;
+
+    @Column(name = "shop_contract_business_number", length = 30)
+    private String shopContractBusinessNumber;
+
+    @Column(name = "shop_contract_address", length = 500)
+    private String shopContractAddress;
+
+    @Column(name = "shop_contract_contact", length = 30)
+    private String shopContractContact;
+
+    @Column(name = "settlement_day")
+    private Integer settlementDay;
+
+    @Column(name = "payment_day")
+    private Integer paymentDay;
+
+    @Column(name = "contract_date")
+    private LocalDate contractDate;
+
+    @Column(name = "shop_signature_business_name", length = 100)
+    private String shopSignatureBusinessName;
+
+    @Column(name = "shop_signature_owner_name", length = 50)
+    private String shopSignatureOwnerName;
+
+    @Column(name = "artist_contract_name", length = 100)
+    private String artistContractName;
+
+    @Column(name = "artist_contract_business_number", length = 30)
+    private String artistContractBusinessNumber;
+
+    @Column(name = "artist_contract_address", length = 500)
+    private String artistContractAddress;
+
+    @Column(name = "artist_contract_contact", length = 30)
+    private String artistContractContact;
+
+    @Column(name = "artist_bank_name", length = 50)
+    private String artistBankName;
+
+    @Column(name = "artist_account_holder", length = 50)
+    private String artistAccountHolder;
+
+    @Column(name = "artist_account_number", length = 50)
+    private String artistAccountNumber;
+
+    @Column(name = "artist_signature_name", length = 100)
+    private String artistSignatureName;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
     @Column(name = "contract_request_type", nullable = false, length = 20)
     private ContractRequestType contractRequestType = ContractRequestType.NONE;
 
@@ -78,6 +138,76 @@ public class ShopArtistContract extends BaseTimeEntity {
 
     @Column(name = "terminated_at")
     private LocalDateTime terminatedAt;
+
+    public static ShopArtistContract createPendingDocument(Shop shop, Artist artist) {
+        return ShopArtistContract.builder()
+                .shop(shop)
+                .artist(artist)
+                .contractStatus(ContractStatus.PENDING)
+                .contractRequestType(ContractRequestType.NONE)
+                .contractDocumentStatus(ContractDocumentStatus.SHOP_SENT)
+                .commissionType(CommissionType.RATE)
+                .build();
+    }
+
+    public void fillShopContract(
+            String businessName,
+            String ownerName,
+            String businessNumber,
+            String address,
+            String contact,
+            LocalDate contractStartDate,
+            LocalDate contractEndDate,
+            BigDecimal commissionRate,
+            Integer settlementDay,
+            Integer paymentDay,
+            LocalDate contractDate,
+            String signatureBusinessName,
+            String signatureOwnerName
+    ) {
+        this.shopContractBusinessName = businessName;
+        this.shopContractOwnerName = ownerName;
+        this.shopContractBusinessNumber = businessNumber;
+        this.shopContractAddress = address;
+        this.shopContractContact = contact;
+        this.contractStartDate = contractStartDate;
+        this.contractEndDate = contractEndDate;
+        this.commissionType = CommissionType.RATE;
+        this.commissionValue = commissionRate;
+        this.settlementDay = settlementDay;
+        this.paymentDay = paymentDay;
+        this.contractDate = contractDate;
+        this.shopSignatureBusinessName = signatureBusinessName;
+        this.shopSignatureOwnerName = signatureOwnerName;
+        this.contractDocumentStatus = ContractDocumentStatus.SHOP_SENT;
+    }
+
+    public void fillArtistContract(
+            String artistName,
+            String businessNumber,
+            String address,
+            String contact,
+            String bankName,
+            String accountHolder,
+            String accountNumber,
+            String signatureName
+    ) {
+        this.artistContractName = artistName;
+        this.artistContractBusinessNumber = businessNumber;
+        this.artistContractAddress = address;
+        this.artistContractContact = contact;
+        this.artistBankName = bankName;
+        this.artistAccountHolder = accountHolder;
+        this.artistAccountNumber = accountNumber;
+        this.artistSignatureName = signatureName;
+        this.contractDocumentStatus = ContractDocumentStatus.ARTIST_SUBMITTED;
+    }
+
+    public void approveDocument() {
+        this.contractStatus = ContractStatus.APPROVED;
+        this.contractRequestType = ContractRequestType.NONE;
+        this.contractDocumentStatus = ContractDocumentStatus.APPROVED;
+    }
 
     public void updateMemo(String memo) {
         this.memo = memo == null ? "" : memo;

--- a/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractDocumentStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/enums/ContractDocumentStatus.java
@@ -1,0 +1,8 @@
+package app.dearobjet.backend.domain.contract.enums;
+
+public enum ContractDocumentStatus {
+    NONE,
+    SHOP_SENT,
+    ARTIST_SUBMITTED,
+    APPROVED
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -7,12 +7,16 @@ import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractDocumentResponse;
+import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
+import app.dearobjet.backend.domain.contract.dto.SendContractRequest;
+import app.dearobjet.backend.domain.contract.dto.SubmitArtistContractRequest;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
@@ -23,6 +27,7 @@ import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.CommissionType;
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractRequestType;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductStockMovementType;
@@ -39,6 +44,7 @@ import app.dearobjet.backend.domain.user.enums.UserStatus;
 import app.dearobjet.backend.domain.user.repository.ArtistRepository;
 import app.dearobjet.backend.domain.user.repository.ShopRepository;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.DuplicateEntityException;
 import app.dearobjet.backend.global.exception.InvalidInputException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,6 +79,7 @@ class ContractServiceTest {
     private static final Long ARTIST_ID = 20L;
     private static final LocalDate CONTRACT_START_DATE = LocalDate.of(2026, 5, 1);
     private static final LocalDate CONTRACT_END_DATE = LocalDate.of(2026, 12, 31);
+    private static final LocalDate CONTRACT_DATE = LocalDate.of(2026, 4, 30);
     private static final LocalDateTime OCCURRED_AT = LocalDateTime.of(2026, 4, 28, 16, 0);
     private static final String UPDATED_MEMO = "Postman에서 수정한 계약 작가 메모";
 
@@ -93,6 +100,130 @@ class ContractServiceTest {
 
     @Mock
     private ArtistRepository artistRepository;
+
+    @Test
+    @DisplayName("계약서 템플릿은 소품샵 사업자 정보로 기본값을 채운다")
+    void givenShopProfile_whenGetContractTemplate_thenReturnPrefilledShopFields() {
+        Shop shop = shopWithContractProfile(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+
+        ContractTemplateResponse response = contractService.getContractTemplate(USER_ID);
+
+        assertThat(response.getShopBusinessName()).isEqualTo("템플릿 소품샵");
+        assertThat(response.getShopOwnerName()).isEqualTo("대표자 A");
+        assertThat(response.getShopBusinessNumber()).isEqualTo("123-45-67890");
+        assertThat(response.getShopAddress()).isEqualTo("서울시 마포구");
+        assertThat(response.getShopContact()).isEqualTo("01011112222");
+        assertThat(response.getShopSignatureBusinessName()).isEqualTo("템플릿 소품샵");
+        assertThat(response.getShopSignatureOwnerName()).isEqualTo("대표자 A");
+        assertThat(response.getArtistName()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("소품샵이 계약서를 작성해 작가에게 발송한다")
+    void givenShopContractRequest_whenSendContractToArtist_thenCreatePendingContractDocument() {
+        Shop shop = shopWithId(SHOP_ID);
+        Artist artist = artistWithId(ARTIST_ID);
+        SendContractRequest request = sendContractRequest();
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(artistRepository.findById(ARTIST_ID)).willReturn(Optional.of(artist));
+        given(contractRepository.existsPendingOrCurrentApprovedContract(
+                SHOP_ID,
+                ARTIST_ID,
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                LocalDate.now()
+        )).willReturn(false);
+        given(contractRepository.save(any(ShopArtistContract.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        ContractDocumentResponse response = contractService.sendContractToArtist(USER_ID, ARTIST_ID, request);
+
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.PENDING);
+        assertThat(response.getContractDocumentStatus()).isEqualTo(ContractDocumentStatus.SHOP_SENT);
+        assertThat(response.getShopBusinessName()).isEqualTo("Postman 테스트 소품샵");
+        assertThat(response.getCommissionRate()).isEqualTo(new BigDecimal("20.0000"));
+        assertThat(response.getSettlementDay()).isEqualTo(15);
+        assertThat(response.getPaymentDay()).isEqualTo(10);
+        assertThat(response.getArtistName()).isEmpty();
+        verify(contractRepository).save(any(ShopArtistContract.class));
+    }
+
+    @Test
+    @DisplayName("이미 진행 중인 계약이 있으면 계약서를 발송할 수 없다")
+    void givenExistingActiveContract_whenSendContractToArtist_thenThrowException() {
+        Shop shop = shopWithId(SHOP_ID);
+        Artist artist = artistWithId(ARTIST_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(artistRepository.findById(ARTIST_ID)).willReturn(Optional.of(artist));
+        given(contractRepository.existsPendingOrCurrentApprovedContract(
+                SHOP_ID,
+                ARTIST_ID,
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                LocalDate.now()
+        )).willReturn(true);
+
+        assertThatThrownBy(() -> contractService.sendContractToArtist(USER_ID, ARTIST_ID, sendContractRequest()))
+                .isInstanceOf(DuplicateEntityException.class)
+                .hasMessageContaining("이미 진행 중이거나 유효한 계약이 있는 작가입니다.");
+    }
+
+    @Test
+    @DisplayName("작가가 계약서 나머지 내용을 작성해 제출한다")
+    void givenShopSentContract_whenSubmitArtistContract_thenChangeToArtistSubmitted() {
+        ShopArtistContract contract = shopSentContract();
+        givenArtistOwnedContract(contract);
+
+        ContractDocumentResponse response =
+                contractService.submitArtistContract(USER_ID, CONTRACT_ID, submitArtistContractRequest());
+
+        assertThat(response.getContractDocumentStatus()).isEqualTo(ContractDocumentStatus.ARTIST_SUBMITTED);
+        assertThat(response.getArtistName()).isEqualTo("Postman 도자기 작가");
+        assertThat(response.getArtistBusinessNumber()).isEmpty();
+        assertThat(response.getArtistBankName()).isEqualTo("국민은행");
+        assertThat(response.getArtistAccountNumber()).isEqualTo("1234567890");
+    }
+
+    @Test
+    @DisplayName("작가 작성 완료 계약서만 소품샵이 승인할 수 있다")
+    void givenArtistSubmittedContract_whenApproveContract_thenChangeToApproved() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = artistSubmittedContract();
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistContractByIdAndShopId(
+                CONTRACT_ID,
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(Optional.of(contract));
+
+        ContractDocumentResponse response = contractService.approveContract(USER_ID, CONTRACT_ID);
+
+        assertThat(response.getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+        assertThat(response.getContractDocumentStatus()).isEqualTo(ContractDocumentStatus.APPROVED);
+        assertThat(contract.getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("작가 작성 전 계약서는 승인할 수 없다")
+    void givenShopSentContract_whenApproveContract_thenThrowException() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = shopSentContract();
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findManagedArtistContractByIdAndShopId(
+                CONTRACT_ID,
+                SHOP_ID,
+                List.of(ContractStatus.PENDING, ContractStatus.APPROVED, ContractStatus.ENDED)
+        )).willReturn(Optional.of(contract));
+
+        assertThatThrownBy(() -> contractService.approveContract(USER_ID, CONTRACT_ID))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessageContaining("작가 작성 완료 후에만 계약 승인할 수 있습니다.");
+    }
 
     @Test
     @DisplayName("재고관리 목록에서 계약 작가를 조회한다")
@@ -813,6 +944,8 @@ class ContractServiceTest {
     private Artist artistWithId(Long artistId) {
         User artistUser = User.builder()
                 .id(USER_ID)
+                .role(Role.ARTIST)
+                .userStatus(UserStatus.ACTIVE)
                 .build();
         BusinessProfile businessProfile = BusinessProfile.builder()
                 .businessName("Postman 도자기 작가")
@@ -836,6 +969,25 @@ class ContractServiceTest {
                 .build();
         BusinessProfile businessProfile = BusinessProfile.builder()
                 .businessName("Postman 테스트 소품샵")
+                .build();
+        return Shop.builder()
+                .shopId(shopId)
+                .user(user)
+                .businessProfile(businessProfile)
+                .build();
+    }
+
+    private Shop shopWithContractProfile(Long shopId) {
+        User user = User.builder()
+                .id(USER_ID)
+                .phoneNumber("01099998888")
+                .build();
+        BusinessProfile businessProfile = BusinessProfile.builder()
+                .businessName("템플릿 소품샵")
+                .ownerName("대표자 A")
+                .businessNumber("123-45-67890")
+                .businessAddress("서울시 마포구")
+                .businessPhoneNumber("01011112222")
                 .build();
         return Shop.builder()
                 .shopId(shopId)
@@ -910,12 +1062,84 @@ class ContractServiceTest {
                 .build();
     }
 
+    private ShopArtistContract shopSentContract() {
+        ShopArtistContract contract = contractWithArtistAndShop(
+                CONTRACT_ID,
+                ContractStatus.PENDING,
+                ContractRequestType.NONE,
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE
+        );
+        contract.fillShopContract(
+                "Postman 테스트 소품샵",
+                "Postman 대표",
+                "111-22-33333",
+                "서울시 성동구",
+                "01012345678",
+                CONTRACT_START_DATE,
+                CONTRACT_END_DATE,
+                new BigDecimal("20.0000"),
+                15,
+                10,
+                CONTRACT_DATE,
+                "Postman 테스트 소품샵",
+                "Postman 대표"
+        );
+        return contract;
+    }
+
+    private ShopArtistContract artistSubmittedContract() {
+        ShopArtistContract contract = shopSentContract();
+        contract.fillArtistContract(
+                "Postman 도자기 작가",
+                null,
+                "부산시 해운대구",
+                "01022223333",
+                "국민은행",
+                "Postman 작가",
+                "1234567890",
+                "Postman 도자기 작가"
+        );
+        return contract;
+    }
+
     private AdjustContractInventoryRequest inventoryRequest() {
         AdjustContractInventoryRequest request = new AdjustContractInventoryRequest();
         setField(request, "movementType", ContractProductStockMovementType.INBOUND);
         setField(request, "quantity", 3);
         setField(request, "occurredAt", OCCURRED_AT);
         setField(request, "memo", "Postman 추가 입고");
+        return request;
+    }
+
+    private SendContractRequest sendContractRequest() {
+        SendContractRequest request = new SendContractRequest();
+        setField(request, "shopBusinessName", "Postman 테스트 소품샵");
+        setField(request, "shopOwnerName", "Postman 대표");
+        setField(request, "shopBusinessNumber", "111-22-33333");
+        setField(request, "shopAddress", "서울시 성동구");
+        setField(request, "shopContact", "01012345678");
+        setField(request, "contractStartDate", CONTRACT_START_DATE);
+        setField(request, "contractEndDate", CONTRACT_END_DATE);
+        setField(request, "commissionRate", new BigDecimal("20.0000"));
+        setField(request, "settlementDay", 15);
+        setField(request, "paymentDay", 10);
+        setField(request, "contractDate", CONTRACT_DATE);
+        setField(request, "shopSignatureBusinessName", "Postman 테스트 소품샵");
+        setField(request, "shopSignatureOwnerName", "Postman 대표");
+        return request;
+    }
+
+    private SubmitArtistContractRequest submitArtistContractRequest() {
+        SubmitArtistContractRequest request = new SubmitArtistContractRequest();
+        setField(request, "artistName", "Postman 도자기 작가");
+        setField(request, "artistBusinessNumber", " ");
+        setField(request, "artistAddress", "부산시 해운대구");
+        setField(request, "artistContact", "01022223333");
+        setField(request, "artistBankName", "국민은행");
+        setField(request, "artistAccountHolder", "Postman 작가");
+        setField(request, "artistAccountNumber", "1234567890");
+        setField(request, "artistSignatureName", "Postman 도자기 작가");
         return request;
     }
 


### PR DESCRIPTION
 ## 작업 내용
  - 소품샵 계약서 템플릿 조회(소품샵 정보) API 추가
  - 소품샵 계약서 작성/발송 API 추가
  - 작가 계약서 작성/제출 API 추가
  - 소품샵 계약 승인 API 추가
  - `ShopArtistContract`에 계약서 문서 상태 및 계약서 입력값 스냅샷 필드 추가
  - 작가 제출 전/후에 따라 입점관리 작가 리스트 액션 코드 구분
    - `WAITING_ARTIST_SUBMISSION`
    - `CONTRACT_APPROVE`

  ## 테스트
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest"`
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`
