### PR TITLE
 feat: 계약서 작성 단계별 승인 액션 처리 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ManagedArtistContractRow.java
@@ -14,8 +14,5 @@ public interface ManagedArtistContractRow {
     LocalDate getContractEndDate();
     ContractStatus getContractStatus();
     ContractRequestType getContractRequestType();
-
-    default ContractDocumentStatus getContractDocumentStatus() {
-        return ContractDocumentStatus.NONE;
-    }
+    ContractDocumentStatus getContractDocumentStatus();
 }

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -878,6 +878,11 @@ class ContractServiceTest {
             public ContractRequestType getContractRequestType() {
                 return requestType;
             }
+
+            @Override
+            public ContractDocumentStatus getContractDocumentStatus() {
+                return ContractDocumentStatus.ARTIST_SUBMITTED;
+            }
         };
     }
 


### PR DESCRIPTION
related to #77 

## 작업 내용
  - 소품샵 계약서 템플릿 조회 API 추가
  - 소품샵 계약서 작성/발송 API 추가
  - 작가 계약서 작성/제출 API 추가
  - 소품샵 계약 승인 API 추가
  - `ShopArtistContract`에 계약서 문서 상태 및 계약서 입력값 스냅샷 필드 추가
  - 계약서 문서 상태에 따라 입점관리 작가 리스트의 다음 액션 분기
    - `SHOP_SENT`: `WAITING_ARTIST_SUBMISSION`
    - `ARTIST_SUBMITTED`: `CONTRACT_APPROVE`
    - `APPROVED`: `NONE`
  - Spring projection에서 `contractDocumentStatus`가 실제 DB 값으로 매핑되도록 수정

  ## 테스트
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`
  - 직접 API 호출로 계약서 발송 직후 작가 리스트 응답 확인
    - 기대값: `nextAction.code = WAITING_ARTIST_SUBMISSION`
