### PR TITLE
feat: 완료 계약서 목록 조회 및 삭제 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -4,6 +4,7 @@ import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
+import app.dearobjet.backend.domain.contract.dto.CompletedContractDocumentListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractDocumentResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
@@ -12,6 +13,8 @@ import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
+import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsRequest;
+import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
@@ -25,6 +28,7 @@ import app.dearobjet.backend.global.auth.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,6 +44,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContractController {
 
     private final ContractService contractService;
+
+    @GetMapping("/documents/completed")
+    public ApiResponse<CompletedContractDocumentListResponse> getCompletedContractDocuments(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(
+                contractService.getCompletedContractDocuments(resolveUserId(userDetails, userId))
+        );
+    }
+
+    @DeleteMapping("/documents/completed")
+    public ApiResponse<DeleteCompletedContractDocumentsResponse> deleteCompletedContractDocuments(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId,
+            @Valid @RequestBody DeleteCompletedContractDocumentsRequest request
+    ) {
+        return ApiResponse.of(
+                contractService.deleteCompletedContractDocuments(
+                        resolveUserId(userDetails, userId),
+                        request
+                )
+        );
+    }
 
     @GetMapping("/template")
     public ApiResponse<ContractTemplateResponse> getContractTemplate(

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -3,10 +3,12 @@ package app.dearobjet.backend.domain.contract;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
+import app.dearobjet.backend.domain.contract.dto.projection.CompletedContractDocumentRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.user.enums.Role;
@@ -24,6 +26,44 @@ import java.time.LocalDateTime;
 public interface ContractRepository extends JpaRepository<ShopArtistContract, Long> {
 
     long countByShopUserIdAndContractStatus(Long userId, ContractStatus contractStatus);
+
+    @Query("""
+            select c.shopArtistContractsId as contractId,
+                   a.id as artistId,
+                   coalesce(nullif(c.artistContractName, ''), bp.businessName) as artistName,
+                   c.artistContractBusinessNumber as artistBusinessNumber,
+                   c.artistContractContact as artistContact,
+                   c.contractDate as contractDate,
+                   c.contractStartDate as contractStartDate,
+                   c.contractEndDate as contractEndDate
+            from ShopArtistContract c
+            join c.artist a
+            join a.businessProfile bp
+            where c.shop.shopId = :shopId
+              and c.contractStatus = :contractStatus
+              and c.contractDocumentStatus = :documentStatus
+              and c.shopDocumentDeletedAt is null
+            order by case when c.contractDate is null then 1 else 0 end,
+                     c.contractDate desc,
+                     c.shopArtistContractsId desc
+            """)
+    List<CompletedContractDocumentRow> findCompletedDocumentRowsByShopId(
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("documentStatus") ContractDocumentStatus documentStatus
+    );
+
+    @Query("""
+            select c
+            from ShopArtistContract c
+            join fetch c.shop s
+            where c.shopArtistContractsId in :contractIds
+              and s.shopId = :shopId
+            """)
+    List<ShopArtistContract> findAllByIdsAndShopId(
+            @Param("contractIds") List<Long> contractIds,
+            @Param("shopId") Long shopId
+    );
 
     @Query("""
             select count(c) > 0

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -4,6 +4,7 @@ import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
+import app.dearobjet.backend.domain.contract.dto.CompletedContractDocumentListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractApplicationCountResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractDocumentResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
@@ -12,6 +13,8 @@ import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
+import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsRequest;
+import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
@@ -50,7 +53,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -78,6 +83,41 @@ public class ContractService {
     private final ContractProductStockMovementRepository contractProductStockMovementRepository;
     private final ShopRepository shopRepository;
     private final ArtistRepository artistRepository;
+
+    @Transactional(readOnly = true)
+    public CompletedContractDocumentListResponse getCompletedContractDocuments(Long userId) {
+        Shop shop = getShopByUserId(userId);
+
+        return CompletedContractDocumentListResponse.from(
+                contractRepository.findCompletedDocumentRowsByShopId(
+                        shop.getShopId(),
+                        ContractStatus.APPROVED,
+                        ContractDocumentStatus.APPROVED
+                )
+        );
+    }
+
+    @Transactional
+    public DeleteCompletedContractDocumentsResponse deleteCompletedContractDocuments(
+            Long userId,
+            DeleteCompletedContractDocumentsRequest request
+    ) {
+        Shop shop = getShopByUserId(userId);
+        List<Long> requestedIds = distinctIds(request.getContractIds());
+        List<ShopArtistContract> contracts = contractRepository.findAllByIdsAndShopId(
+                requestedIds,
+                shop.getShopId()
+        );
+        validateAllRequestedContractsFound(requestedIds, contracts);
+
+        LocalDateTime deletedAt = LocalDateTime.now();
+        contracts.forEach(contract -> {
+            validateCompletedDocument(contract);
+            contract.hideCompletedDocumentForShop(userId, deletedAt);
+        });
+
+        return DeleteCompletedContractDocumentsResponse.from(requestedIds);
+    }
 
     @Transactional(readOnly = true)
     public ContractTemplateResponse getContractTemplate(Long userId) {
@@ -549,6 +589,40 @@ public class ContractService {
             throw new InvalidInputException(
                     ErrorCode.INVALID_INPUT,
                     "계약서를 발송할 수 있는 활성 작가가 아닙니다."
+            );
+        }
+    }
+
+    private List<Long> distinctIds(List<Long> ids) {
+        return ids.stream()
+                .distinct()
+                .toList();
+    }
+
+    private void validateAllRequestedContractsFound(
+            List<Long> requestedIds,
+            List<ShopArtistContract> contracts
+    ) {
+        Set<Long> foundIds = new HashSet<>(
+                contracts.stream()
+                        .map(ShopArtistContract::getShopArtistContractsId)
+                        .toList()
+        );
+        boolean allFound = requestedIds.stream().allMatch(foundIds::contains);
+        if (!allFound) {
+            throw new EntityNotFoundException(
+                    ErrorCode.ENTITY_NOT_FOUND,
+                    "삭제할 계약서 중 소품샵 소유가 아니거나 존재하지 않는 계약서가 있습니다."
+            );
+        }
+    }
+
+    private void validateCompletedDocument(ShopArtistContract contract) {
+        if (contract.getContractStatus() != ContractStatus.APPROVED
+                || contract.getContractDocumentStatus() != ContractDocumentStatus.APPROVED) {
+            throw new InvalidInputException(
+                    ErrorCode.INVALID_INPUT,
+                    "완료된 계약서만 삭제할 수 있습니다."
             );
         }
     }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/CompletedContractDocumentItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/CompletedContractDocumentItemResponse.java
@@ -1,0 +1,43 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.CompletedContractDocumentRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CompletedContractDocumentItemResponse {
+
+    private static final String CONTRACT_TITLE = "입점 계약서";
+
+    private final Long contractId;
+    private final String title;
+    private final LocalDate contractDate;
+    private final Long artistId;
+    private final String artistName;
+    private final String artistBusinessNumber;
+    private final String artistContact;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+
+    public static CompletedContractDocumentItemResponse from(CompletedContractDocumentRow row) {
+        return new CompletedContractDocumentItemResponse(
+                row.getContractId(),
+                CONTRACT_TITLE,
+                row.getContractDate(),
+                row.getArtistId(),
+                valueOrEmpty(row.getArtistName()),
+                valueOrEmpty(row.getArtistBusinessNumber()),
+                valueOrEmpty(row.getArtistContact()),
+                row.getContractStartDate(),
+                row.getContractEndDate()
+        );
+    }
+
+    private static String valueOrEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/CompletedContractDocumentListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/CompletedContractDocumentListResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.CompletedContractDocumentRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CompletedContractDocumentListResponse {
+
+    private final List<CompletedContractDocumentItemResponse> items;
+
+    public static CompletedContractDocumentListResponse from(List<CompletedContractDocumentRow> rows) {
+        return new CompletedContractDocumentListResponse(
+                rows.stream()
+                        .map(CompletedContractDocumentItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/DeleteCompletedContractDocumentsRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/DeleteCompletedContractDocumentsRequest.java
@@ -1,0 +1,16 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class DeleteCompletedContractDocumentsRequest {
+
+    @NotEmpty(message = "삭제할 계약서는 1개 이상 선택해야 합니다.")
+    private List<@NotNull(message = "계약서 ID는 필수입니다.") Long> contractIds;
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/DeleteCompletedContractDocumentsResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/DeleteCompletedContractDocumentsResponse.java
@@ -1,0 +1,22 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteCompletedContractDocumentsResponse {
+
+    private final int deletedCount;
+    private final List<Long> deletedContractIds;
+
+    public static DeleteCompletedContractDocumentsResponse from(List<Long> deletedContractIds) {
+        return new DeleteCompletedContractDocumentsResponse(
+                deletedContractIds.size(),
+                deletedContractIds
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/CompletedContractDocumentRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/CompletedContractDocumentRow.java
@@ -1,0 +1,14 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import java.time.LocalDate;
+
+public interface CompletedContractDocumentRow {
+    Long getContractId();
+    Long getArtistId();
+    String getArtistName();
+    String getArtistBusinessNumber();
+    String getArtistContact();
+    LocalDate getContractDate();
+    LocalDate getContractStartDate();
+    LocalDate getContractEndDate();
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/entity/ShopArtistContract.java
@@ -139,6 +139,12 @@ public class ShopArtistContract extends BaseTimeEntity {
     @Column(name = "terminated_at")
     private LocalDateTime terminatedAt;
 
+    @Column(name = "shop_document_deleted_at")
+    private LocalDateTime shopDocumentDeletedAt;
+
+    @Column(name = "shop_document_deleted_by_user_id")
+    private Long shopDocumentDeletedByUserId;
+
     public static ShopArtistContract createPendingDocument(Shop shop, Artist artist) {
         return ShopArtistContract.builder()
                 .shop(shop)
@@ -207,6 +213,18 @@ public class ShopArtistContract extends BaseTimeEntity {
         this.contractStatus = ContractStatus.APPROVED;
         this.contractRequestType = ContractRequestType.NONE;
         this.contractDocumentStatus = ContractDocumentStatus.APPROVED;
+    }
+
+    public void hideCompletedDocumentForShop(Long deletedByUserId, LocalDateTime deletedAt) {
+        if (deletedByUserId == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "계약서 삭제 사용자 ID는 필수입니다.");
+        }
+        if (deletedAt == null) {
+            throw new InvalidInputException(ErrorCode.INVALID_INPUT, "계약서 삭제 시각은 필수입니다.");
+        }
+
+        this.shopDocumentDeletedAt = deletedAt;
+        this.shopDocumentDeletedByUserId = deletedByUserId;
     }
 
     public void updateMemo(String memo) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: backend
 
   profiles:
-    active: prod # 인증인가가 필요하다면 prod로 변경
+    active: dev # 인증인가가 필요하다면 prod로 변경
 
   config:
     import: optional:file:.env[.properties]

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -4,12 +4,15 @@ import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryRequest;
 import app.dearobjet.backend.domain.contract.dto.AdjustContractInventoryResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistAccountSearchResponse;
 import app.dearobjet.backend.domain.contract.dto.ArtistSuggestionListResponse;
+import app.dearobjet.backend.domain.contract.dto.CompletedContractDocumentListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInboundConfirmResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractInventoryListResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractMemoResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractDocumentResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
+import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsRequest;
+import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
@@ -21,6 +24,7 @@ import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.contract.dto.projection.CompletedContractDocumentRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
@@ -118,6 +122,82 @@ class ContractServiceTest {
         assertThat(response.getShopSignatureBusinessName()).isEqualTo("템플릿 소품샵");
         assertThat(response.getShopSignatureOwnerName()).isEqualTo("대표자 A");
         assertThat(response.getArtistName()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("소품샵 완료 계약서 목록을 조회한다")
+    void givenCompletedDocuments_whenGetCompletedContractDocuments_thenReturnDocumentRows() {
+        Shop shop = shopWithId(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findCompletedDocumentRowsByShopId(
+                SHOP_ID,
+                ContractStatus.APPROVED,
+                ContractDocumentStatus.APPROVED
+        )).willReturn(List.of(completedContractDocumentRow(CONTRACT_ID)));
+
+        CompletedContractDocumentListResponse response =
+                contractService.getCompletedContractDocuments(USER_ID);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getItems().get(0).getTitle()).isEqualTo("입점 계약서");
+        assertThat(response.getItems().get(0).getContractDate()).isEqualTo(CONTRACT_DATE);
+        assertThat(response.getItems().get(0).getArtistId()).isEqualTo(ARTIST_ID);
+        assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 도자기 작가");
+    }
+
+    @Test
+    @DisplayName("완료 계약서를 소품샵 계약서 관리 목록에서 숨김 처리한다")
+    void givenCompletedDocuments_whenDeleteCompletedContractDocuments_thenHideDocumentsForShop() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = approvedDocumentContract();
+        DeleteCompletedContractDocumentsRequest request = deleteCompletedDocumentsRequest(CONTRACT_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findAllByIdsAndShopId(List.of(CONTRACT_ID), SHOP_ID))
+                .willReturn(List.of(contract));
+
+        DeleteCompletedContractDocumentsResponse response =
+                contractService.deleteCompletedContractDocuments(USER_ID, request);
+
+        assertThat(response.getDeletedCount()).isEqualTo(1);
+        assertThat(response.getDeletedContractIds()).containsExactly(CONTRACT_ID);
+        assertThat(contract.getShopDocumentDeletedAt()).isNotNull();
+        assertThat(contract.getShopDocumentDeletedByUserId()).isEqualTo(USER_ID);
+        assertThat(contract.getContractStatus()).isEqualTo(ContractStatus.APPROVED);
+        assertThat(contract.getContractDocumentStatus()).isEqualTo(ContractDocumentStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("소품샵 소유가 아닌 계약서가 포함되면 삭제할 수 없다")
+    void givenNotOwnedDocument_whenDeleteCompletedContractDocuments_thenThrowException() {
+        Shop shop = shopWithId(SHOP_ID);
+        DeleteCompletedContractDocumentsRequest request = deleteCompletedDocumentsRequest(CONTRACT_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findAllByIdsAndShopId(List.of(CONTRACT_ID), SHOP_ID))
+                .willReturn(List.of());
+
+        assertThatThrownBy(() -> contractService.deleteCompletedContractDocuments(USER_ID, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("삭제할 계약서 중 소품샵 소유가 아니거나 존재하지 않는 계약서가 있습니다.");
+    }
+
+    @Test
+    @DisplayName("미완료 계약서는 삭제할 수 없다")
+    void givenIncompleteDocument_whenDeleteCompletedContractDocuments_thenThrowException() {
+        Shop shop = shopWithId(SHOP_ID);
+        ShopArtistContract contract = shopSentContract();
+        DeleteCompletedContractDocumentsRequest request = deleteCompletedDocumentsRequest(CONTRACT_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findAllByIdsAndShopId(List.of(CONTRACT_ID), SHOP_ID))
+                .willReturn(List.of(contract));
+
+        assertThatThrownBy(() -> contractService.deleteCompletedContractDocuments(USER_ID, request))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessageContaining("완료된 계약서만 삭제할 수 있습니다.");
     }
 
     @Test
@@ -783,6 +863,50 @@ class ContractServiceTest {
         };
     }
 
+    private CompletedContractDocumentRow completedContractDocumentRow(Long contractId) {
+        return new CompletedContractDocumentRow() {
+            @Override
+            public Long getContractId() {
+                return contractId;
+            }
+
+            @Override
+            public Long getArtistId() {
+                return ARTIST_ID;
+            }
+
+            @Override
+            public String getArtistName() {
+                return "Postman 도자기 작가";
+            }
+
+            @Override
+            public String getArtistBusinessNumber() {
+                return "222-33-44444";
+            }
+
+            @Override
+            public String getArtistContact() {
+                return "01022223333";
+            }
+
+            @Override
+            public LocalDate getContractDate() {
+                return CONTRACT_DATE;
+            }
+
+            @Override
+            public LocalDate getContractStartDate() {
+                return CONTRACT_START_DATE;
+            }
+
+            @Override
+            public LocalDate getContractEndDate() {
+                return CONTRACT_END_DATE;
+            }
+        };
+    }
+
     private ArtistAccountSearchRow artistAccountSearchRow(Long artistId, Long userId, String artistName) {
         return new ArtistAccountSearchRow() {
             @Override
@@ -1108,6 +1232,12 @@ class ContractServiceTest {
         return contract;
     }
 
+    private ShopArtistContract approvedDocumentContract() {
+        ShopArtistContract contract = artistSubmittedContract();
+        contract.approveDocument();
+        return contract;
+    }
+
     private AdjustContractInventoryRequest inventoryRequest() {
         AdjustContractInventoryRequest request = new AdjustContractInventoryRequest();
         setField(request, "movementType", ContractProductStockMovementType.INBOUND);
@@ -1145,6 +1275,12 @@ class ContractServiceTest {
         setField(request, "artistAccountHolder", "Postman 작가");
         setField(request, "artistAccountNumber", "1234567890");
         setField(request, "artistSignatureName", "Postman 도자기 작가");
+        return request;
+    }
+
+    private DeleteCompletedContractDocumentsRequest deleteCompletedDocumentsRequest(Long... contractIds) {
+        DeleteCompletedContractDocumentsRequest request = new DeleteCompletedContractDocumentsRequest();
+        setField(request, "contractIds", List.of(contractIds));
         return request;
     }
 


### PR DESCRIPTION
## 작업 내용
  - 소품샵 계약서 관리 페이지용 완료 계약서 목록 조회 API 추가
  - 체크박스 선택 삭제 API 추가
  - 삭제는 계약 자체 삭제가 아니라 소품샵 계약서 관리 목록에서만 숨김 처리
  - 완료 기준은 `contractStatus=APPROVED` + `contractDocumentStatus=APPROVED`
  - (임시) 계약서 제목은 `"입점 계약서"`로 고정

  ## API
  - `GET /api/v1/contracts/documents/completed`
  - `DELETE /api/v1/contracts/documents/completed`

  ## 테스트
  - 완료 계약서 목록 조회
  - 숨김 처리 후 목록 제외 확인
  - 미완료 계약서 삭제 시 예외 확인
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest" --tests
  "app.dearobjet.backend.domain.contract.ContractProductRepositoryTest"`