### PR TITLE
feat: 작성중 계약서 리스트 조회 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -15,6 +15,7 @@ import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsRequest;
 import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsResponse;
+import app.dearobjet.backend.domain.contract.dto.InProgressContractDocumentListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
@@ -52,6 +53,16 @@ public class ContractController {
     ) {
         return ApiResponse.of(
                 contractService.getCompletedContractDocuments(resolveUserId(userDetails, userId))
+        );
+    }
+
+    @GetMapping("/documents/in-progress")
+    public ApiResponse<InProgressContractDocumentListResponse> getInProgressContractDocuments(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(
+                contractService.getInProgressContractDocuments(resolveUserId(userDetails, userId))
         );
     }
 

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -5,6 +5,7 @@ import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRow;
 import app.dearobjet.backend.domain.contract.dto.projection.CompletedContractDocumentRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
+import app.dearobjet.backend.domain.contract.dto.projection.InProgressContractDocumentRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
@@ -51,6 +52,50 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
             @Param("shopId") Long shopId,
             @Param("contractStatus") ContractStatus contractStatus,
             @Param("documentStatus") ContractDocumentStatus documentStatus
+    );
+
+    @Query("""
+            select c.shopArtistContractsId as contractId,
+                   a.id as counterpartyId,
+                   coalesce(nullif(c.artistContractName, ''), bp.businessName) as counterpartyName,
+                   c.contractDate as contractDate,
+                   c.contractStartDate as contractStartDate,
+                   c.contractEndDate as contractEndDate,
+                   c.contractDocumentStatus as contractDocumentStatus
+            from ShopArtistContract c
+            join c.artist a
+            join a.businessProfile bp
+            where c.shop.shopId = :shopId
+              and c.contractStatus = :contractStatus
+              and c.contractDocumentStatus in :documentStatuses
+            order by c.shopArtistContractsId desc
+            """)
+    List<InProgressContractDocumentRow> findInProgressDocumentRowsByShopId(
+            @Param("shopId") Long shopId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("documentStatuses") List<ContractDocumentStatus> documentStatuses
+    );
+
+    @Query("""
+            select c.shopArtistContractsId as contractId,
+                   s.shopId as counterpartyId,
+                   bp.businessName as counterpartyName,
+                   c.contractDate as contractDate,
+                   c.contractStartDate as contractStartDate,
+                   c.contractEndDate as contractEndDate,
+                   c.contractDocumentStatus as contractDocumentStatus
+            from ShopArtistContract c
+            join c.shop s
+            join s.businessProfile bp
+            where c.artist.id = :artistId
+              and c.contractStatus = :contractStatus
+              and c.contractDocumentStatus in :documentStatuses
+            order by c.shopArtistContractsId desc
+            """)
+    List<InProgressContractDocumentRow> findInProgressDocumentRowsByArtistId(
+            @Param("artistId") Long artistId,
+            @Param("contractStatus") ContractStatus contractStatus,
+            @Param("documentStatuses") List<ContractDocumentStatus> documentStatuses
     );
 
     @Query("""

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -15,6 +15,7 @@ import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsRequest;
 import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsResponse;
+import app.dearobjet.backend.domain.contract.dto.InProgressContractDocumentListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
@@ -78,6 +79,11 @@ public class ContractService {
             ContractStatus.ENDED
     );
 
+    private static final List<ContractDocumentStatus> IN_PROGRESS_DOCUMENT_STATUSES = List.of(
+            ContractDocumentStatus.SHOP_SENT,
+            ContractDocumentStatus.ARTIST_SUBMITTED
+    );
+
     private final ContractRepository contractRepository;
     private final ContractProductRepository contractProductRepository;
     private final ContractProductStockMovementRepository contractProductStockMovementRepository;
@@ -95,6 +101,28 @@ public class ContractService {
                         ContractDocumentStatus.APPROVED
                 )
         );
+    }
+
+    @Transactional(readOnly = true)
+    public InProgressContractDocumentListResponse getInProgressContractDocuments(Long userId) {
+        return shopRepository.findByUser_Id(userId)
+                .map(shop -> InProgressContractDocumentListResponse.forShop(
+                        contractRepository.findInProgressDocumentRowsByShopId(
+                                shop.getShopId(),
+                                ContractStatus.PENDING,
+                                IN_PROGRESS_DOCUMENT_STATUSES
+                        )
+                ))
+                .orElseGet(() -> {
+                    Artist artist = getArtistByUserId(userId);
+                    return InProgressContractDocumentListResponse.forArtist(
+                            contractRepository.findInProgressDocumentRowsByArtistId(
+                                    artist.getId(),
+                                    ContractStatus.PENDING,
+                                    IN_PROGRESS_DOCUMENT_STATUSES
+                            )
+                    );
+                });
     }
 
     @Transactional

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/InProgressContractDocumentItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/InProgressContractDocumentItemResponse.java
@@ -1,0 +1,62 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.InProgressContractDocumentRow;
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InProgressContractDocumentItemResponse {
+
+    private static final String CONTRACT_TITLE = "입점 계약서";
+    private static final String SHOP_VIEWER_TYPE = "SHOP";
+    private static final String ARTIST_VIEWER_TYPE = "ARTIST";
+    private static final String SHOP_DETAIL_PATH_FORMAT = "/api/v1/contracts/artists/%d";
+    private static final String ARTIST_DETAIL_PATH_FORMAT = "/api/v1/contracts/shops/%d";
+
+    private final Long contractId;
+    private final String title;
+    private final String viewerType;
+    private final Long counterpartyId;
+    private final String counterpartyName;
+    private final LocalDate contractDate;
+    private final LocalDate contractStartDate;
+    private final LocalDate contractEndDate;
+    private final ContractDocumentStatus contractDocumentStatus;
+    private final String detailApiPath;
+
+    public static InProgressContractDocumentItemResponse forShop(InProgressContractDocumentRow row) {
+        return from(row, SHOP_VIEWER_TYPE, SHOP_DETAIL_PATH_FORMAT.formatted(row.getContractId()));
+    }
+
+    public static InProgressContractDocumentItemResponse forArtist(InProgressContractDocumentRow row) {
+        return from(row, ARTIST_VIEWER_TYPE, ARTIST_DETAIL_PATH_FORMAT.formatted(row.getContractId()));
+    }
+
+    private static InProgressContractDocumentItemResponse from(
+            InProgressContractDocumentRow row,
+            String viewerType,
+            String detailApiPath
+    ) {
+        return new InProgressContractDocumentItemResponse(
+                row.getContractId(),
+                CONTRACT_TITLE,
+                viewerType,
+                row.getCounterpartyId(),
+                valueOrEmpty(row.getCounterpartyName()),
+                row.getContractDate(),
+                row.getContractStartDate(),
+                row.getContractEndDate(),
+                row.getContractDocumentStatus(),
+                detailApiPath
+        );
+    }
+
+    private static String valueOrEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/InProgressContractDocumentListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/InProgressContractDocumentListResponse.java
@@ -1,0 +1,35 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.InProgressContractDocumentRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InProgressContractDocumentListResponse {
+
+    private final List<InProgressContractDocumentItemResponse> items;
+
+    public static InProgressContractDocumentListResponse forShop(List<InProgressContractDocumentRow> rows) {
+        return from(rows, InProgressContractDocumentItemResponse::forShop);
+    }
+
+    public static InProgressContractDocumentListResponse forArtist(List<InProgressContractDocumentRow> rows) {
+        return from(rows, InProgressContractDocumentItemResponse::forArtist);
+    }
+
+    private static InProgressContractDocumentListResponse from(
+            List<InProgressContractDocumentRow> rows,
+            Function<InProgressContractDocumentRow, InProgressContractDocumentItemResponse> mapper
+    ) {
+        return new InProgressContractDocumentListResponse(
+                rows.stream()
+                        .map(mapper)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/InProgressContractDocumentRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/InProgressContractDocumentRow.java
@@ -1,0 +1,15 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
+
+import java.time.LocalDate;
+
+public interface InProgressContractDocumentRow {
+    Long getContractId();
+    Long getCounterpartyId();
+    String getCounterpartyName();
+    LocalDate getContractDate();
+    LocalDate getContractStartDate();
+    LocalDate getContractEndDate();
+    ContractDocumentStatus getContractDocumentStatus();
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -13,6 +13,7 @@ import app.dearobjet.backend.domain.contract.dto.ContractTemplateResponse;
 import app.dearobjet.backend.domain.contract.dto.ContractTerminationResponse;
 import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsRequest;
 import app.dearobjet.backend.domain.contract.dto.DeleteCompletedContractDocumentsResponse;
+import app.dearobjet.backend.domain.contract.dto.InProgressContractDocumentListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedArtistContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResultResponse;
@@ -25,6 +26,7 @@ import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistAccountSearchRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
 import app.dearobjet.backend.domain.contract.dto.projection.CompletedContractDocumentRow;
+import app.dearobjet.backend.domain.contract.dto.projection.InProgressContractDocumentRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
@@ -145,6 +147,68 @@ class ContractServiceTest {
         assertThat(response.getItems().get(0).getContractDate()).isEqualTo(CONTRACT_DATE);
         assertThat(response.getItems().get(0).getArtistId()).isEqualTo(ARTIST_ID);
         assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 도자기 작가");
+    }
+
+    @Test
+    @DisplayName("소품샵은 작성중 계약서 목록에서 요청한 작가 계약서를 조회한다")
+    void givenShopUser_whenGetInProgressContractDocuments_thenReturnArtistCounterpartyRows() {
+        Shop shop = shopWithId(SHOP_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(shop));
+        given(contractRepository.findInProgressDocumentRowsByShopId(
+                SHOP_ID,
+                ContractStatus.PENDING,
+                List.of(ContractDocumentStatus.SHOP_SENT, ContractDocumentStatus.ARTIST_SUBMITTED)
+        )).willReturn(List.of(inProgressContractDocumentRow(
+                CONTRACT_ID,
+                ARTIST_ID,
+                "Postman 도자기 작가",
+                ContractDocumentStatus.SHOP_SENT
+        )));
+
+        InProgressContractDocumentListResponse response =
+                contractService.getInProgressContractDocuments(USER_ID);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getItems().get(0).getViewerType()).isEqualTo("SHOP");
+        assertThat(response.getItems().get(0).getCounterpartyId()).isEqualTo(ARTIST_ID);
+        assertThat(response.getItems().get(0).getCounterpartyName()).isEqualTo("Postman 도자기 작가");
+        assertThat(response.getItems().get(0).getContractDocumentStatus()).isEqualTo(ContractDocumentStatus.SHOP_SENT);
+        assertThat(response.getItems().get(0).getDetailApiPath())
+                .isEqualTo("/api/v1/contracts/artists/" + CONTRACT_ID);
+    }
+
+    @Test
+    @DisplayName("작가는 작성중 계약서 목록에서 요청한 소품샵 계약서를 조회한다")
+    void givenArtistUser_whenGetInProgressContractDocuments_thenReturnShopCounterpartyRows() {
+        Artist artist = artistWithId(ARTIST_ID);
+
+        given(shopRepository.findByUser_Id(USER_ID)).willReturn(Optional.empty());
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(contractRepository.findInProgressDocumentRowsByArtistId(
+                ARTIST_ID,
+                ContractStatus.PENDING,
+                List.of(ContractDocumentStatus.SHOP_SENT, ContractDocumentStatus.ARTIST_SUBMITTED)
+        )).willReturn(List.of(inProgressContractDocumentRow(
+                CONTRACT_ID,
+                SHOP_ID,
+                "Postman 테스트 소품샵",
+                ContractDocumentStatus.ARTIST_SUBMITTED
+        )));
+
+        InProgressContractDocumentListResponse response =
+                contractService.getInProgressContractDocuments(USER_ID);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getContractId()).isEqualTo(CONTRACT_ID);
+        assertThat(response.getItems().get(0).getViewerType()).isEqualTo("ARTIST");
+        assertThat(response.getItems().get(0).getCounterpartyId()).isEqualTo(SHOP_ID);
+        assertThat(response.getItems().get(0).getCounterpartyName()).isEqualTo("Postman 테스트 소품샵");
+        assertThat(response.getItems().get(0).getContractDocumentStatus())
+                .isEqualTo(ContractDocumentStatus.ARTIST_SUBMITTED);
+        assertThat(response.getItems().get(0).getDetailApiPath())
+                .isEqualTo("/api/v1/contracts/shops/" + CONTRACT_ID);
     }
 
     @Test
@@ -903,6 +967,50 @@ class ContractServiceTest {
             @Override
             public LocalDate getContractEndDate() {
                 return CONTRACT_END_DATE;
+            }
+        };
+    }
+
+    private InProgressContractDocumentRow inProgressContractDocumentRow(
+            Long contractId,
+            Long counterpartyId,
+            String counterpartyName,
+            ContractDocumentStatus documentStatus
+    ) {
+        return new InProgressContractDocumentRow() {
+            @Override
+            public Long getContractId() {
+                return contractId;
+            }
+
+            @Override
+            public Long getCounterpartyId() {
+                return counterpartyId;
+            }
+
+            @Override
+            public String getCounterpartyName() {
+                return counterpartyName;
+            }
+
+            @Override
+            public LocalDate getContractDate() {
+                return CONTRACT_DATE;
+            }
+
+            @Override
+            public LocalDate getContractStartDate() {
+                return CONTRACT_START_DATE;
+            }
+
+            @Override
+            public LocalDate getContractEndDate() {
+                return CONTRACT_END_DATE;
+            }
+
+            @Override
+            public ContractDocumentStatus getContractDocumentStatus() {
+                return documentStatus;
             }
         };
     }


### PR DESCRIPTION
## Summary
  - 계약서 페이지에서 소품샵/작가가 작성중인 계약서 리스트를 조회하는 API를 추가
  - 소품샵/작가 사용자에 따라 같은 API에서 상대 계약자 정보를 반환
  - 상세 조회는 기존 계약 상세 API를 재사용하도록 `detailApiPath`를 응답에 포함

  ## API
  - `GET /api/v1/contracts/documents/in-progress`

  ## 포함 상태
  - `contractStatus = PENDING`
  - `contractDocumentStatus IN (SHOP_SENT, ARTIST_SUBMITTED)`

  ## Test
  - `./gradlew test --tests "app.dearobjet.backend.domain.contract.ContractServiceTest"`