### PR TITLE
feat: 채팅 상대 검색 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/controller/ChatRoomController.java
@@ -6,7 +6,6 @@ import app.dearobjet.backend.domain.chat.service.ChatRoomService;
 import app.dearobjet.backend.global.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/app/dearobjet/backend/domain/chat/controller/ChatUserController.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/controller/ChatUserController.java
@@ -1,0 +1,57 @@
+package app.dearobjet.backend.domain.chat.controller;
+
+import app.dearobjet.backend.domain.chat.dto.ChatUserSearchResponse;
+import app.dearobjet.backend.domain.chat.service.ChatUserSearchService;
+import app.dearobjet.backend.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat/users")
+@RequiredArgsConstructor
+public class ChatUserController {
+
+    private static final int DEFAULT_SEARCH_PAGE = 0;
+    private static final int DEFAULT_SEARCH_SIZE = 20;
+    private static final int MAX_SEARCH_SIZE = 100;
+
+    private final ChatUserSearchService chatUserSearchService;
+
+    /**
+     * 채팅 상대 검색
+     *
+     * GET /api/chat/users/search
+     */
+    @GetMapping("/search")
+    public ApiResponse<Page<ChatUserSearchResponse>> searchChatUsers(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Page<ChatUserSearchResponse> users = chatUserSearchService.search(
+                userId,
+                keyword,
+                PageRequest.of(normalizePage(page), normalizeSize(size))
+        );
+        return ApiResponse.of(users);
+    }
+
+    private int normalizePage(int page) {
+        return Math.max(page, DEFAULT_SEARCH_PAGE);
+    }
+
+    private int normalizeSize(int size) {
+        if (size < 1) {
+            return DEFAULT_SEARCH_SIZE;
+        }
+
+        return Math.min(size, MAX_SEARCH_SIZE);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/dto/ChatUserSearchResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/dto/ChatUserSearchResponse.java
@@ -1,0 +1,50 @@
+package app.dearobjet.backend.domain.chat.dto;
+
+import app.dearobjet.backend.domain.chat.dto.projection.ChatUserSearchRow;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatUserSearchResponse {
+
+    private static final String STATUS_PENDING = "계약 대기";
+    private static final String STATUS_COMPLETED = "계약 완료";
+    private static final String STATUS_NOT_CONTRACTED = "미계약";
+    private static final String STATUS_UNAVAILABLE = "-";
+
+    private final Long userId;
+    private final String accountName;
+    private final Role role;
+    private final String profileImageUrl;
+    private final Specialty specialty;
+    private final String statusLabel;
+
+    public static ChatUserSearchResponse from(ChatUserSearchRow row, boolean contractStatusAvailable) {
+        return new ChatUserSearchResponse(
+                row.getUserId(),
+                row.getAccountName(),
+                row.getRole(),
+                row.getProfileImageUrl(),
+                row.getSpecialty(),
+                resolveStatusLabel(row, contractStatusAvailable)
+        );
+    }
+
+    private static String resolveStatusLabel(ChatUserSearchRow row, boolean contractStatusAvailable) {
+        if (!contractStatusAvailable || row.getRole() != Role.SHOP) {
+            return STATUS_UNAVAILABLE;
+        }
+        if (Boolean.TRUE.equals(row.getPendingContractExists())) {
+            return STATUS_PENDING;
+        }
+        if (Boolean.TRUE.equals(row.getApprovedContractExists())) {
+            return STATUS_COMPLETED;
+        }
+
+        return STATUS_NOT_CONTRACTED;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/dto/projection/ChatUserSearchRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/dto/projection/ChatUserSearchRow.java
@@ -1,0 +1,21 @@
+package app.dearobjet.backend.domain.chat.dto.projection;
+
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+
+public interface ChatUserSearchRow {
+
+    Long getUserId();
+
+    String getAccountName();
+
+    Role getRole();
+
+    String getProfileImageUrl();
+
+    Specialty getSpecialty();
+
+    Boolean getPendingContractExists();
+
+    Boolean getApprovedContractExists();
+}

--- a/src/main/java/app/dearobjet/backend/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/service/ChatRoomService.java
@@ -47,6 +47,10 @@ public class ChatRoomService {
      */
     @Transactional
     public ChatRoomResponse createOrGetChatRoom(Long currentUserId, CreateChatRoomRequest request) {
+        if (request.getType() == ChatRoomType.ONE_TO_ONE && request.getParticipantIds().contains(currentUserId)) {
+            throw new InvalidInputException(ErrorCode.CANNOT_CHAT_WITH_SELF);
+        }
+
         // 참여자 목록에 현재 사용자 추가
         List<Long> allParticipantIds = new java.util.ArrayList<>(request.getParticipantIds());
         if (!allParticipantIds.contains(currentUserId)) {

--- a/src/main/java/app/dearobjet/backend/domain/chat/service/ChatUserSearchService.java
+++ b/src/main/java/app/dearobjet/backend/domain/chat/service/ChatUserSearchService.java
@@ -1,0 +1,56 @@
+package app.dearobjet.backend.domain.chat.service;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.chat.dto.ChatUserSearchResponse;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatUserSearchService {
+
+    private static final List<Role> SEARCHABLE_ROLES = List.of(Role.CUSTOMER, Role.ARTIST, Role.SHOP);
+
+    private final UserRepository userRepository;
+    private final ArtistRepository artistRepository;
+
+    public Page<ChatUserSearchResponse> search(Long currentUserId, String keyword, Pageable pageable) {
+        Long currentArtistId = artistRepository.findByUserId(currentUserId)
+                .map(Artist::getId)
+                .orElse(null);
+        boolean contractStatusAvailable = currentArtistId != null;
+
+        return userRepository.searchChatUsers(
+                        currentUserId,
+                        normalizeKeyword(keyword),
+                        SEARCHABLE_ROLES,
+                        Role.SHOP,
+                        UserStatus.ACTIVE,
+                        ContractStatus.PENDING,
+                        ContractStatus.APPROVED,
+                        LocalDate.now(),
+                        currentArtistId,
+                        pageable
+                )
+                .map(row -> ChatUserSearchResponse.from(row, contractStatusAvailable));
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+
+        return "%" + keyword.trim().toLowerCase() + "%";
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/user/repository/UserRepository.java
@@ -1,8 +1,18 @@
 package app.dearobjet.backend.domain.user.repository;
 
+import app.dearobjet.backend.domain.chat.dto.projection.ChatUserSearchRow;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
 import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -13,4 +23,72 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByPhoneNumber(String phoneNumber);
+
+    @Query(
+            value = """
+                    select u.id as userId,
+                           u.name as accountName,
+                           u.role as role,
+                           u.profileUrl as profileImageUrl,
+                           bp.specialty as specialty,
+                           case
+                               when u.role = :shopRole
+                                    and :currentArtistId is not null
+                                    and exists (
+                                        select 1
+                                        from ShopArtistContract c
+                                        where c.shop = s
+                                          and c.artist.id = :currentArtistId
+                                          and c.contractStatus = :pendingStatus
+                                    )
+                               then true
+                               else false
+                           end as pendingContractExists,
+                           case
+                               when u.role = :shopRole
+                                    and :currentArtistId is not null
+                                    and exists (
+                                        select 1
+                                        from ShopArtistContract c
+                                        where c.shop = s
+                                          and c.artist.id = :currentArtistId
+                                          and c.contractStatus = :approvedStatus
+                                          and (
+                                              c.contractEndDate is null
+                                              or c.contractEndDate >= :today
+                                          )
+                                    )
+                               then true
+                               else false
+                           end as approvedContractExists
+                    from User u
+                    left join BusinessProfile bp on bp.user = u
+                    left join Shop s on s.user = u
+                    where u.userStatus = :activeStatus
+                      and u.role in :searchableRoles
+                      and u.id <> :currentUserId
+                      and (:keyword is null or lower(u.name) like :keyword)
+                    order by u.name asc, u.id desc
+                    """,
+            countQuery = """
+                    select count(u)
+                    from User u
+                    where u.userStatus = :activeStatus
+                      and u.role in :searchableRoles
+                      and u.id <> :currentUserId
+                      and (:keyword is null or lower(u.name) like :keyword)
+                    """
+    )
+    Page<ChatUserSearchRow> searchChatUsers(
+            @Param("currentUserId") Long currentUserId,
+            @Param("keyword") String keyword,
+            @Param("searchableRoles") List<Role> searchableRoles,
+            @Param("shopRole") Role shopRole,
+            @Param("activeStatus") UserStatus activeStatus,
+            @Param("pendingStatus") ContractStatus pendingStatus,
+            @Param("approvedStatus") ContractStatus approvedStatus,
+            @Param("today") LocalDate today,
+            @Param("currentArtistId") Long currentArtistId,
+            Pageable pageable
+    );
 }

--- a/src/test/java/app/dearobjet/backend/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/chat/service/ChatMessageServiceTest.java
@@ -8,6 +8,7 @@ import app.dearobjet.backend.domain.chat.repository.ChatParticipantRepository;
 import app.dearobjet.backend.domain.chat.repository.ChatRoomRepository;
 import app.dearobjet.backend.domain.chat.service.redis.ChatMessagePublisher;
 import app.dearobjet.backend.domain.chat.service.redis.MessageCacheRedisService;
+import app.dearobjet.backend.domain.chat.service.redis.PresenceRedisService;
 import app.dearobjet.backend.domain.chat.service.redis.UnreadCountRedisService;
 import app.dearobjet.backend.domain.user.entity.User;
 import app.dearobjet.backend.domain.user.enums.Role;
@@ -59,6 +60,8 @@ class ChatMessageServiceTest {
     private UnreadCountRedisService unreadCountRedisService;
     @Mock
     private MessageCacheRedisService messageCacheRedisService;
+    @Mock
+    private PresenceRedisService presenceRedisService;
 
     private User sender;
     private User receiver;
@@ -136,6 +139,8 @@ class ChatMessageServiceTest {
                     .build();
             given(chatMessageRepository.save(any(ChatMessage.class)))
                     .willReturn(savedMessage);
+            given(presenceRedisService.getOnlineUsersInRoom(ROOM_ID))
+                    .willReturn(Collections.emptySet());
 
             // when
             ChatMessageResponse result = chatMessageService.sendMessage(SENDER_ID, ROOM_ID, request);
@@ -144,7 +149,7 @@ class ChatMessageServiceTest {
             assertThat(result.getContent()).isEqualTo("안녕하세요");
             assertThat(result.getSenderId()).isEqualTo(SENDER_ID);
             verify(messagePublisher).publishToRoom(any());
-            verify(unreadCountRedisService).incrementForParticipants(eq(ROOM_ID), anySet(), eq(SENDER_ID));
+            verify(unreadCountRedisService).incrementUnreadCount(RECEIVER_ID, ROOM_ID);
             verify(messageCacheRedisService).addRecentMessage(any(), eq(SENDER_ID));
         }
 

--- a/src/test/java/app/dearobjet/backend/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/chat/service/ChatRoomServiceTest.java
@@ -12,7 +12,8 @@ import app.dearobjet.backend.domain.user.entity.User;
 import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.enums.UserStatus;
 import app.dearobjet.backend.domain.user.repository.UserRepository;
-import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import app.dearobjet.backend.global.exception.InvalidInputException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -150,16 +151,13 @@ class ChatRoomServiceTest {
         @DisplayName("자기 자신과 채팅방 생성 시 예외")
         void givenSameUser_whenCreate_thenThrowException() {
             // given
-            // participantIds=[CURRENT_USER_ID], currentUserId=CURRENT_USER_ID
-            // → allParticipantIds=[CURRENT_USER_ID] (1명) → 파트너 조회 실패
             CreateChatRoomRequest request = CreateChatRoomRequest.oneToOne(CURRENT_USER_ID);
-
-            given(userRepository.findAllById(anyList()))
-                    .willReturn(List.of(currentUser));
 
             // when & then
             assertThatThrownBy(() -> chatRoomService.createOrGetChatRoom(CURRENT_USER_ID, request))
-                    .isInstanceOf(EntityNotFoundException.class);
+                    .isInstanceOf(InvalidInputException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.CANNOT_CHAT_WITH_SELF);
         }
     }
 }

--- a/src/test/java/app/dearobjet/backend/domain/chat/service/ChatUserSearchServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/chat/service/ChatUserSearchServiceTest.java
@@ -1,0 +1,167 @@
+package app.dearobjet.backend.domain.chat.service;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.chat.dto.ChatUserSearchResponse;
+import app.dearobjet.backend.domain.chat.dto.projection.ChatUserSearchRow;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.domain.user.repository.ArtistRepository;
+import app.dearobjet.backend.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("ChatUserSearchService 테스트")
+@ExtendWith(MockitoExtension.class)
+class ChatUserSearchServiceTest {
+
+    private static final Long CURRENT_USER_ID = 1L;
+    private static final Long CURRENT_ARTIST_ID = 10L;
+    private static final Long SHOP_USER_ID = 2L;
+    private static final Long CUSTOMER_USER_ID = 3L;
+
+    @InjectMocks
+    private ChatUserSearchService chatUserSearchService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @Test
+    @DisplayName("검색어는 공백 제거 후 소문자 like 패턴으로 조회한다")
+    void givenKeyword_whenSearch_thenNormalizeKeyword() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 20);
+        given(artistRepository.findByUserId(CURRENT_USER_ID)).willReturn(Optional.empty());
+        given(userRepository.searchChatUsers(
+                eq(CURRENT_USER_ID),
+                any(),
+                eq(List.of(Role.CUSTOMER, Role.ARTIST, Role.SHOP)),
+                eq(Role.SHOP),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class),
+                eq(null),
+                eq(pageable)
+        )).willReturn(Page.empty(pageable));
+
+        // when
+        chatUserSearchService.search(CURRENT_USER_ID, "  PostMan  ", pageable);
+
+        // then
+        ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(userRepository).searchChatUsers(
+                eq(CURRENT_USER_ID),
+                keywordCaptor.capture(),
+                eq(List.of(Role.CUSTOMER, Role.ARTIST, Role.SHOP)),
+                eq(Role.SHOP),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class),
+                eq(null),
+                eq(pageable)
+        );
+        assertThat(keywordCaptor.getValue()).isEqualTo("%postman%");
+    }
+
+    @Test
+    @DisplayName("현재 사용자가 작가이고 검색 결과가 소품샵이면 계약 상태를 라벨로 변환한다")
+    void givenArtistAndShopRows_whenSearch_thenReturnContractStatusLabels() {
+        // given
+        PageRequest pageable = PageRequest.of(0, 20);
+        Artist artist = Artist.builder().id(CURRENT_ARTIST_ID).build();
+        given(artistRepository.findByUserId(CURRENT_USER_ID)).willReturn(Optional.of(artist));
+        given(userRepository.searchChatUsers(
+                eq(CURRENT_USER_ID),
+                eq(null),
+                eq(List.of(Role.CUSTOMER, Role.ARTIST, Role.SHOP)),
+                eq(Role.SHOP),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class),
+                eq(CURRENT_ARTIST_ID),
+                eq(pageable)
+        )).willReturn(new PageImpl<>(List.of(
+                row(SHOP_USER_ID, "계약 대기 샵", Role.SHOP, Specialty.CERAMIC, true, false),
+                row(SHOP_USER_ID + 1, "계약 완료 샵", Role.SHOP, Specialty.LIVING_GOODS, false, true),
+                row(SHOP_USER_ID + 2, "미계약 샵", Role.SHOP, Specialty.DESK_OFFICE, false, false),
+                row(CUSTOMER_USER_ID, "일반 사용자", Role.CUSTOMER, null, false, false)
+        ), pageable, 4));
+
+        // when
+        Page<ChatUserSearchResponse> response = chatUserSearchService.search(CURRENT_USER_ID, " ", pageable);
+
+        // then
+        assertThat(response.getContent()).extracting(ChatUserSearchResponse::getStatusLabel)
+                .containsExactly("계약 대기", "계약 완료", "미계약", "-");
+    }
+
+    private ChatUserSearchRow row(
+            Long userId,
+            String accountName,
+            Role role,
+            Specialty specialty,
+            boolean pendingContractExists,
+            boolean approvedContractExists
+    ) {
+        return new ChatUserSearchRow() {
+            @Override
+            public Long getUserId() {
+                return userId;
+            }
+
+            @Override
+            public String getAccountName() {
+                return accountName;
+            }
+
+            @Override
+            public Role getRole() {
+                return role;
+            }
+
+            @Override
+            public String getProfileImageUrl() {
+                return null;
+            }
+
+            @Override
+            public Specialty getSpecialty() {
+                return specialty;
+            }
+
+            @Override
+            public Boolean getPendingContractExists() {
+                return pendingContractExists;
+            }
+
+            @Override
+            public Boolean getApprovedContractExists() {
+                return approvedContractExists;
+            }
+        };
+    }
+}

--- a/src/test/java/app/dearobjet/backend/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,141 @@
+package app.dearobjet.backend.domain.user.repository;
+
+import app.dearobjet.backend.domain.artist.entity.Artist;
+import app.dearobjet.backend.domain.chat.dto.projection.ChatUserSearchRow;
+import app.dearobjet.backend.domain.contract.ContractRepository;
+import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
+import app.dearobjet.backend.domain.contract.enums.ContractStatus;
+import app.dearobjet.backend.domain.shop.entity.Shop;
+import app.dearobjet.backend.domain.user.entity.BusinessProfile;
+import app.dearobjet.backend.domain.user.entity.User;
+import app.dearobjet.backend.domain.user.enums.BusinessCategory;
+import app.dearobjet.backend.domain.user.enums.BusinessType;
+import app.dearobjet.backend.domain.user.enums.Role;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import app.dearobjet.backend.domain.user.enums.UserStatus;
+import app.dearobjet.backend.global.common.config.JpaConfig;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+class UserRepositoryTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 5, 12);
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ArtistRepository artistRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Autowired
+    private BusinessProfileRepository businessProfileRepository;
+
+    @Autowired
+    private ContractRepository contractRepository;
+
+    @Test
+    @DisplayName("채팅 상대 검색은 활성 가입 완료 사용자만 계정명으로 조회한다")
+    void givenUsers_whenSearchChatUsers_thenReturnActiveRegisteredUsersByAccountName() {
+        // given
+        User currentUser = userRepository.save(user("current@test.com", "현재 작가", Role.ARTIST, UserStatus.ACTIVE));
+        BusinessProfile artistProfile = businessProfileRepository.save(businessProfile(currentUser, "현재 작가 스튜디오", Specialty.CERAMIC));
+        Artist currentArtist = artistRepository.save(Artist.builder()
+                .user(currentUser)
+                .businessProfile(artistProfile)
+                .build());
+
+        User matchedCustomer = userRepository.save(user("customer@test.com", "검색 일반", Role.CUSTOMER, UserStatus.ACTIVE));
+        User pendingShopUser = userRepository.save(user("pending-shop@test.com", "검색 대기샵", Role.SHOP, UserStatus.ACTIVE));
+        Shop pendingShop = createShop(pendingShopUser, "검색 대기 소품샵", Specialty.LIVING_GOODS);
+        User completedShopUser = userRepository.save(user("completed-shop@test.com", "검색 완료샵", Role.SHOP, UserStatus.ACTIVE));
+        Shop completedShop = createShop(completedShopUser, "검색 완료 소품샵", Specialty.DESK_OFFICE);
+        userRepository.save(user("temp@test.com", "검색 임시", Role.TEMP, UserStatus.ACTIVE));
+        userRepository.save(user("inactive@test.com", "검색 비활성", Role.CUSTOMER, UserStatus.INACTIVE));
+
+        contractRepository.save(ShopArtistContract.builder()
+                .artist(currentArtist)
+                .shop(pendingShop)
+                .contractStatus(ContractStatus.PENDING)
+                .build());
+        contractRepository.save(ShopArtistContract.builder()
+                .artist(currentArtist)
+                .shop(completedShop)
+                .contractStatus(ContractStatus.APPROVED)
+                .contractEndDate(TODAY.plusDays(1))
+                .build());
+
+        // when
+        Page<ChatUserSearchRow> rows = userRepository.searchChatUsers(
+                currentUser.getId(),
+                "%검색%",
+                List.of(Role.CUSTOMER, Role.ARTIST, Role.SHOP),
+                Role.SHOP,
+                UserStatus.ACTIVE,
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                TODAY,
+                currentArtist.getId(),
+                PageRequest.of(0, 20)
+        );
+
+        // then
+        assertThat(rows.getContent()).extracting(ChatUserSearchRow::getUserId)
+                .containsExactlyInAnyOrder(matchedCustomer.getId(), pendingShopUser.getId(), completedShopUser.getId());
+        assertThat(findByUserId(rows, pendingShopUser.getId()).getPendingContractExists()).isTrue();
+        assertThat(findByUserId(rows, completedShopUser.getId()).getApprovedContractExists()).isTrue();
+    }
+
+    private ChatUserSearchRow findByUserId(Page<ChatUserSearchRow> rows, Long userId) {
+        return rows.getContent().stream()
+                .filter(row -> row.getUserId().equals(userId))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private Shop createShop(User user, String businessName, Specialty specialty) {
+        BusinessProfile businessProfile = businessProfileRepository.save(businessProfile(user, businessName, specialty));
+        return shopRepository.save(Shop.builder()
+                .user(user)
+                .businessProfile(businessProfile)
+                .build());
+    }
+
+    private User user(String email, String name, Role role, UserStatus status) {
+        return User.builder()
+                .email(email)
+                .name(name)
+                .role(role)
+                .userStatus(status)
+                .build();
+    }
+
+    private BusinessProfile businessProfile(User user, String businessName, Specialty specialty) {
+        return BusinessProfile.builder()
+                .user(user)
+                .businessType(BusinessType.WHOLESALE_RETAIL)
+                .businessNumber("123-45-67890")
+                .businessName(businessName)
+                .ownerName("대표")
+                .businessAddress("서울")
+                .businessCategory(BusinessCategory.CRAFT_RETAIL)
+                .specialty(specialty)
+                .reviewDataAgreement(true)
+                .build();
+    }
+}


### PR DESCRIPTION
  ## 요약
  - 마이페이지 메시지 화면에서 채팅 상대를 검색할 수 있는 API를 추가
  - 검색 결과에서 선택한 사용자는 기존 1:1 채팅방 연결 API로 연결
  - 작가 기준으로 소품샵의 계약 상태를 함께 반환

  ## 주요 변경
  - `GET /api/chat/users/search` 추가
  - 활성 가입 완료 사용자(`CUSTOMER`, `ARTIST`, `SHOP`)만 검색
  - 자기 자신, `TEMP`, `INACTIVE`, `ADMIN` 제외
  - 검색 기준은 `User.name`
  - 응답에 계정명, 역할, 프로필 이미지, 주요 카테고리, 상태 라벨 포함
  - 기존 `POST /api/chat/rooms/direct/{partnerId}` 재사용
  - 자기 자신과 1:1 채팅 생성 시 `CANNOT_CHAT_WITH_SELF` 예외 처리 보강

  ## 테스트
  - `./gradlew test`