### PR TITLE
[FEAT] 포스트 기획 반영

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/post/controller/PostController.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/controller/PostController.java
@@ -39,6 +39,13 @@ public class PostController {
         return ApiResponse.of(postService.createPost(userDetails.getUserId(), request, images));
     }
 
+    @GetMapping("/all")
+    public ApiResponse<PostListResponse> getAllPosts(
+            @RequestParam(defaultValue = "1") int page
+    ) {
+        return ApiResponse.of(postService.getAllPosts(page));
+    }
+
     @GetMapping
     public ApiResponse<PostListResponse> getPosts(
             @RequestParam Long userId,

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/CreatePostRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/CreatePostRequest.java
@@ -4,12 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CreatePostRequest(
-        @NotBlank(message = "제목은 필수입니다.")
-        @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
-        String title,
-
         @NotBlank(message = "내용은 필수입니다.")
-        @Size(max = 5000, message = "내용은 5000자를 초과할 수 없습니다.")
+        @Size(max = 500, message = "내용은 500자를 초과할 수 없습니다.")
         String content,
 
         Boolean isPublic

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/PostListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/PostListResponse.java
@@ -11,7 +11,8 @@ public record PostListResponse(
     public record Item(
             Long postId,
             String thumbnailUrl,
-            String title,
+            String authorName,
+            String authorProfileUrl,
             LocalDateTime createdAt
     ) {
     }

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/PostResponse.java
@@ -7,11 +7,9 @@ public record PostResponse(
         Long postId,
         Long userId,
         String userName,
-        String title,
+        String profileUrl,
         String content,
         List<String> imageUrls,
-        Integer viewCount,
-        Integer likeCount,
         Boolean isPublic,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/UpdatePostRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/UpdatePostRequest.java
@@ -4,12 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdatePostRequest(
-        @NotBlank(message = "제목은 필수입니다.")
-        @Size(max = 100, message = "제목은 100자를 초과할 수 없습니다.")
-        String title,
-
         @NotBlank(message = "내용은 필수입니다.")
-        @Size(max = 5000, message = "내용은 5000자를 초과할 수 없습니다.")
+        @Size(max = 500, message = "내용은 500자를 초과할 수 없습니다.")
         String content,
 
         Boolean isPublic

--- a/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
@@ -22,28 +22,16 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private String title;
-
     @Column(columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "image_urls", columnDefinition = "JSON")
     private String imageUrls;
 
-    @Column(name = "view_count")
-    private Integer viewCount;
-
-    @Column(name = "like_count")
-    private Integer likeCount;
-
-    @Column(name = "comment_count")
-    private Integer commentCount;
-
     @Column(name = "is_public")
     private Boolean isPublic;
 
-    public void update(String title, String content, String imageUrls, Boolean isPublic) {
-        this.title = title;
+    public void update(String content, String imageUrls, Boolean isPublic) {
         this.content = content;
         if (imageUrls != null) {
             this.imageUrls = imageUrls;

--- a/src/main/java/app/dearobjet/backend/domain/post/service/PostService.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/service/PostService.java
@@ -7,7 +7,6 @@ import app.dearobjet.backend.domain.post.dto.UpdatePostRequest;
 import app.dearobjet.backend.domain.post.entity.Post;
 import app.dearobjet.backend.domain.post.repository.PostRepository;
 import app.dearobjet.backend.domain.user.entity.User;
-import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.repository.UserRepository;
 import app.dearobjet.backend.global.exception.BusinessException;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
@@ -44,20 +43,12 @@ public class PostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        if (user.getRole() != Role.ARTIST) {
-            throw new BusinessException(ErrorCode.FORBIDDEN);
-        }
-
         List<String> urls = uploadImages(images, userId);
 
         Post post = postRepository.save(Post.builder()
                 .user(user)
-                .title(request.title())
                 .content(request.content())
                 .imageUrls(toJson(urls))
-                .viewCount(0)
-                .likeCount(0)
-                .commentCount(0)
                 .isPublic(request.isPublic() != null ? request.isPublic() : true)
                 .build());
 
@@ -74,20 +65,20 @@ public class PostService {
         );
 
         Page<Post> postPage = postRepository.findByUser_Id(targetUserId, pageable);
+        return toListResponse(postPage, page);
+    }
 
-        List<PostListResponse.Item> items = new ArrayList<>();
-        for (Post post : postPage.getContent()) {
-            List<String> urls = fromJson(post.getImageUrls());
-            String thumbnail = urls.isEmpty() ? null : urls.get(0);
-            items.add(new PostListResponse.Item(
-                    post.getPostId(),
-                    thumbnail,
-                    post.getTitle(),
-                    post.getCreatedAt()
-            ));
-        }
+    @Transactional(readOnly = true)
+    public PostListResponse getAllPosts(int page) {
+        Pageable pageable = PageRequest.of(
+                Math.max(page - 1, 0),
+                POST_PAGE_SIZE,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "postId"))
+        );
 
-        return new PostListResponse(items, page, postPage.getTotalPages());
+        Page<Post> postPage = postRepository.findAll(pageable);
+        return toListResponse(postPage, page);
     }
 
     @Transactional(readOnly = true)
@@ -116,7 +107,7 @@ public class PostService {
             urls = fromJson(post.getImageUrls());
         }
 
-        post.update(request.title(), request.content(), imageUrlsJson, request.isPublic());
+        post.update(request.content(), imageUrlsJson, request.isPublic());
         return toResponse(post, urls);
     }
 
@@ -130,6 +121,22 @@ public class PostService {
         }
 
         postRepository.delete(post);
+    }
+
+    private PostListResponse toListResponse(Page<Post> postPage, int page) {
+        List<PostListResponse.Item> items = new ArrayList<>();
+        for (Post post : postPage.getContent()) {
+            List<String> urls = fromJson(post.getImageUrls());
+            String thumbnail = urls.isEmpty() ? null : urls.get(0);
+            items.add(new PostListResponse.Item(
+                    post.getPostId(),
+                    thumbnail,
+                    post.getUser().getName(),
+                    post.getUser().getProfileUrl(),
+                    post.getCreatedAt()
+            ));
+        }
+        return new PostListResponse(items, page, postPage.getTotalPages());
     }
 
     private List<String> uploadImages(List<MultipartFile> images, Long userId) {
@@ -169,11 +176,9 @@ public class PostService {
                 post.getPostId(),
                 post.getUser().getId(),
                 post.getUser().getName(),
-                post.getTitle(),
+                post.getUser().getProfileUrl(),
                 post.getContent(),
                 urls,
-                post.getViewCount(),
-                post.getLikeCount(),
                 post.getIsPublic(),
                 post.getCreatedAt()
         );


### PR DESCRIPTION
불필요 필드(title, viewCount, likeCount, commentCount) 제거, 모든 역할(customer/artist/shop) 포스트 작성 허용, 전체 목록 조회 API(GET /api/v1/posts/all) 추가, content 최대 500자 제한, 응답에 작성자 profileUrl 포함.