### PR TITLE
feat: 작가 입점관리 소품샵 제안 API 추가

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractController.java
@@ -22,6 +22,7 @@ import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResult
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.SendContractRequest;
+import app.dearobjet.backend.domain.contract.dto.ShopSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.SubmitArtistContractRequest;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.global.api.ApiResponse;
@@ -164,6 +165,14 @@ public class ContractController {
             @RequestParam(required = false) Long userId
     ) {
         return ApiResponse.of(contractService.getArtistSuggestions(resolveUserId(userDetails, userId)));
+    }
+
+    @GetMapping("/shops/suggestions")
+    public ApiResponse<ShopSuggestionListResponse> getShopSuggestions(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long userId
+    ) {
+        return ApiResponse.of(contractService.getShopSuggestions(resolveUserId(userDetails, userId)));
     }
 
     @GetMapping("/artists/search")

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractRepository.java
@@ -8,6 +8,7 @@ import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow
 import app.dearobjet.backend.domain.contract.dto.projection.InProgressContractDocumentRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ShopSuggestionRow;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
 import app.dearobjet.backend.domain.contract.enums.ContractDocumentStatus;
 import app.dearobjet.backend.domain.contract.enums.ContractProductListingStatus;
@@ -456,6 +457,44 @@ public interface ContractRepository extends JpaRepository<ShopArtistContract, Lo
     List<ArtistSuggestionRow> findArtistSuggestionRows(
             @Param("shopId") Long shopId,
             @Param("artistRole") Role artistRole,
+            @Param("activeStatus") UserStatus activeStatus,
+            @Param("pendingStatus") ContractStatus pendingStatus,
+            @Param("approvedStatus") ContractStatus approvedStatus,
+            @Param("today") java.time.LocalDate today
+    );
+
+    @Query("""
+            select s.shopId as shopId,
+                   u.id as userId,
+                   bp.businessName as shopName,
+                   u.profileUrl as shopImageUrl,
+                   bp.specialty as specialty,
+                   s.instagramId as instagramId
+            from Shop s
+            join s.user u
+            join s.businessProfile bp
+            where u.role = :shopRole
+              and u.userStatus = :activeStatus
+              and not exists (
+                  select 1
+                  from ShopArtistContract c
+                  where c.artist.id = :artistId
+                    and c.shop = s
+                    and (
+                        c.contractStatus = :pendingStatus
+                        or (
+                            c.contractStatus = :approvedStatus
+                            and (
+                                c.contractEndDate is null
+                                or c.contractEndDate >= :today
+                            )
+                        )
+                    )
+              )
+            """)
+    List<ShopSuggestionRow> findShopSuggestionRows(
+            @Param("artistId") Long artistId,
+            @Param("shopRole") Role shopRole,
             @Param("activeStatus") UserStatus activeStatus,
             @Param("pendingStatus") ContractStatus pendingStatus,
             @Param("approvedStatus") ContractStatus approvedStatus,

--- a/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/ContractService.java
@@ -22,6 +22,7 @@ import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResult
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.SendContractRequest;
+import app.dearobjet.backend.domain.contract.dto.ShopSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.SubmitArtistContractRequest;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
@@ -37,6 +38,7 @@ import app.dearobjet.backend.domain.contract.repository.ContractProductStockMove
 import app.dearobjet.backend.domain.shop.entity.Shop;
 import app.dearobjet.backend.domain.artist.entity.Artist;
 import app.dearobjet.backend.domain.contract.dto.projection.ArtistSuggestionRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ShopSuggestionRow;
 import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.enums.UserStatus;
 import app.dearobjet.backend.domain.user.repository.ArtistRepository;
@@ -64,6 +66,7 @@ public class ContractService {
 
     private static final int TERMINATION_GRACE_PERIOD_DAYS = 14;
     private static final int ARTIST_SUGGESTION_LIMIT = 10;
+    private static final int SHOP_SUGGESTION_LIMIT = 10;
     private static final int ARTIST_ACCOUNT_SEARCH_LIMIT = 10;
     private static final int MIN_ARTIST_ACCOUNT_SEARCH_KEYWORD_LENGTH = 2;
 
@@ -295,6 +298,26 @@ public class ContractService {
         return ArtistSuggestionListResponse.from(
                 rows.stream()
                         .limit(ARTIST_SUGGESTION_LIMIT)
+                        .toList()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ShopSuggestionListResponse getShopSuggestions(Long userId) {
+        Artist artist = getArtistByUserId(userId);
+        List<ShopSuggestionRow> rows = new ArrayList<>(contractRepository.findShopSuggestionRows(
+                artist.getId(),
+                Role.SHOP,
+                UserStatus.ACTIVE,
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                LocalDate.now()
+        ));
+
+        Collections.shuffle(rows);
+        return ShopSuggestionListResponse.from(
+                rows.stream()
+                        .limit(SHOP_SUGGESTION_LIMIT)
                         .toList()
         );
     }

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ShopSuggestionItemResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ShopSuggestionItemResponse.java
@@ -1,0 +1,30 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ShopSuggestionRow;
+import app.dearobjet.backend.domain.user.enums.Specialty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ShopSuggestionItemResponse {
+
+    private final Long shopId;
+    private final Long userId;
+    private final String shopName;
+    private final String shopImageUrl;
+    private final Specialty specialty;
+    private final String instagramId;
+
+    public static ShopSuggestionItemResponse from(ShopSuggestionRow row) {
+        return new ShopSuggestionItemResponse(
+                row.getShopId(),
+                row.getUserId(),
+                row.getShopName(),
+                row.getShopImageUrl(),
+                row.getSpecialty(),
+                row.getInstagramId()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/ShopSuggestionListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/ShopSuggestionListResponse.java
@@ -1,0 +1,23 @@
+package app.dearobjet.backend.domain.contract.dto;
+
+import app.dearobjet.backend.domain.contract.dto.projection.ShopSuggestionRow;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ShopSuggestionListResponse {
+
+    private final List<ShopSuggestionItemResponse> items;
+
+    public static ShopSuggestionListResponse from(List<ShopSuggestionRow> rows) {
+        return new ShopSuggestionListResponse(
+                rows.stream()
+                        .map(ShopSuggestionItemResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ShopSuggestionRow.java
+++ b/src/main/java/app/dearobjet/backend/domain/contract/dto/projection/ShopSuggestionRow.java
@@ -1,0 +1,12 @@
+package app.dearobjet.backend.domain.contract.dto.projection;
+
+import app.dearobjet.backend.domain.user.enums.Specialty;
+
+public interface ShopSuggestionRow {
+    Long getShopId();
+    Long getUserId();
+    String getShopName();
+    String getShopImageUrl();
+    Specialty getSpecialty();
+    String getInstagramId();
+}

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractProductRepositoryTest.java
@@ -8,6 +8,7 @@ import app.dearobjet.backend.domain.contract.dto.projection.ArtistShipmentShopRo
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryProductRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ShopSuggestionRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
@@ -817,6 +818,111 @@ class ContractProductRepositoryTest {
     }
 
     @Test
+    @DisplayName("입점 소품샵 제안 목록은 현재 작가와 진행중 계약이 없는 활성 소품샵만 반환한다")
+    void givenShopsAndContracts_whenQueryShopSuggestions_thenExcludeCurrentArtistActiveContractsOnly() {
+        User artistUser = createUser(
+                "shop-suggestion-artist@test.com",
+                "추천 조회 작가",
+                Role.ARTIST,
+                "01093500001",
+                null
+        );
+        User otherArtistUser = createUser(
+                "shop-suggestion-other-artist@test.com",
+                "다른 추천 조회 작가",
+                Role.ARTIST,
+                "01093500002",
+                null
+        );
+        Artist artist = createArtist(artistUser, "추천 조회 작가", Specialty.CERAMIC);
+        Artist otherArtist = createArtist(otherArtistUser, "다른 추천 조회 작가", Specialty.CERAMIC);
+
+        Shop eligibleShop = createShop(
+                createUser("shop-suggestion-eligible@test.com", "추천 가능 소품샵", Role.SHOP, "01093500003", null),
+                "추천 가능 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop rejectedShop = createShop(
+                createUser("shop-suggestion-rejected@test.com", "거절 이력 소품샵", Role.SHOP, "01093500004", null),
+                "거절 이력 소품샵",
+                Specialty.HANDMADE_CRAFT
+        );
+        Shop terminatedShop = createShop(
+                createUser("shop-suggestion-terminated@test.com", "해지 이력 소품샵", Role.SHOP, "01093500005", null),
+                "해지 이력 소품샵",
+                Specialty.FABRIC_TEXTILE
+        );
+        Shop otherArtistContractShop = createShop(
+                createUser("shop-suggestion-other-contract@test.com", "다른작가 계약 소품샵", Role.SHOP, "01093500006", null),
+                "다른작가 계약 소품샵",
+                Specialty.INTERIOR_DECOR
+        );
+        Shop pendingShop = createShop(
+                createUser("shop-suggestion-pending@test.com", "대기 제외 소품샵", Role.SHOP, "01093500007", null),
+                "대기 제외 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop approvedShop = createShop(
+                createUser("shop-suggestion-approved@test.com", "계약 제외 소품샵", Role.SHOP, "01093500008", null),
+                "계약 제외 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop endedShop = createShop(
+                createUser("shop-suggestion-ended@test.com", "만료 가능 소품샵", Role.SHOP, "01093500009", null),
+                "만료 가능 소품샵",
+                Specialty.LIVING_GOODS
+        );
+        Shop expiredApprovedShop = createShop(
+                createUser("shop-suggestion-expired-approved@test.com", "종료일 경과 소품샵", Role.SHOP, "01093500010", null),
+                "종료일 경과 소품샵",
+                Specialty.LIVING_GOODS
+        );
+
+        createContract(artist, rejectedShop, ContractStatus.REJECTED, ContractRequestType.NONE, null, null);
+        createContract(artist, terminatedShop, ContractStatus.TERMINATED, ContractRequestType.NONE, null, null);
+        createContract(otherArtist, otherArtistContractShop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+        createContract(artist, pendingShop, ContractStatus.PENDING, ContractRequestType.EXTENSION, null, null);
+        createContract(artist, approvedShop, ContractStatus.APPROVED, ContractRequestType.NONE, null, null);
+        createContract(artist, endedShop, ContractStatus.ENDED, ContractRequestType.NONE, null, null);
+        createContract(
+                artist,
+                expiredApprovedShop,
+                ContractStatus.APPROVED,
+                ContractRequestType.NONE,
+                QUERY_TODAY.minusMonths(2),
+                QUERY_TODAY.minusDays(1)
+        );
+        flushAndClear();
+
+        var rows = contractRepository.findShopSuggestionRows(
+                artist.getId(),
+                Role.SHOP,
+                UserStatus.ACTIVE,
+                ContractStatus.PENDING,
+                ContractStatus.APPROVED,
+                QUERY_TODAY
+        );
+
+        assertThat(rows).extracting("shopName")
+                .contains(
+                        "추천 가능 소품샵",
+                        "거절 이력 소품샵",
+                        "해지 이력 소품샵",
+                        "다른작가 계약 소품샵",
+                        "만료 가능 소품샵",
+                        "종료일 경과 소품샵"
+                )
+                .doesNotContain(
+                        "대기 제외 소품샵",
+                        "계약 제외 소품샵"
+                );
+        assertThat(findShopSuggestionRow(rows, "추천 가능 소품샵").getShopId())
+                .isEqualTo(eligibleShop.getShopId());
+        assertThat(findShopSuggestionRow(rows, "추천 가능 소품샵").getUserId())
+                .isEqualTo(eligibleShop.getUser().getId());
+    }
+
+    @Test
     @DisplayName("계약서 발송용 작가 계정 검색은 상호명, 사용자 이름, 이메일로 검색한다")
     void givenKeyword_whenSearchArtistAccounts_thenReturnMatchedActiveArtists() {
         User shopUser = createUser(
@@ -1371,6 +1477,13 @@ class ContractProductRepositoryTest {
     private ArtistSuggestionRow findSuggestionRow(List<ArtistSuggestionRow> rows, String artistName) {
         return rows.stream()
                 .filter(row -> artistName.equals(row.getArtistName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private ShopSuggestionRow findShopSuggestionRow(List<ShopSuggestionRow> rows, String shopName) {
+        return rows.stream()
+                .filter(row -> shopName.equals(row.getShopName()))
                 .findFirst()
                 .orElseThrow();
     }

--- a/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/contract/ContractServiceTest.java
@@ -20,6 +20,7 @@ import app.dearobjet.backend.domain.contract.dto.ManagedShopContractActionResult
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractDetailResponse;
 import app.dearobjet.backend.domain.contract.dto.ManagedShopContractListResponse;
 import app.dearobjet.backend.domain.contract.dto.SendContractRequest;
+import app.dearobjet.backend.domain.contract.dto.ShopSuggestionListResponse;
 import app.dearobjet.backend.domain.contract.dto.SubmitArtistContractRequest;
 import app.dearobjet.backend.domain.contract.dto.UpdateContractMemoRequest;
 import app.dearobjet.backend.domain.contract.dto.projection.ContractInventoryRow;
@@ -29,6 +30,7 @@ import app.dearobjet.backend.domain.contract.dto.projection.CompletedContractDoc
 import app.dearobjet.backend.domain.contract.dto.projection.InProgressContractDocumentRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedArtistContractRow;
 import app.dearobjet.backend.domain.contract.dto.projection.ManagedShopContractRow;
+import app.dearobjet.backend.domain.contract.dto.projection.ShopSuggestionRow;
 import app.dearobjet.backend.domain.contract.entity.ContractProduct;
 import app.dearobjet.backend.domain.contract.entity.ContractProductStockMovement;
 import app.dearobjet.backend.domain.contract.entity.ShopArtistContract;
@@ -447,6 +449,65 @@ class ContractServiceTest {
         assertThat(response.getItems().get(0).getArtistName()).isEqualTo("Postman 추천 작가");
         assertThat(response.getItems().get(0).getArtistImageUrl()).isEqualTo("https://image.test/suggested.png");
         assertThat(response.getItems().get(0).getInstagramId()).isEqualTo("suggested_artist");
+    }
+
+    @Test
+    @DisplayName("입점 소품샵 제안 목록에서 랜덤 최대 10곳을 조회한다")
+    void givenEligibleShops_whenGetShopSuggestions_thenReturnUpToTenShops() {
+        Artist artist = artistWithId(ARTIST_ID);
+        List<ShopSuggestionRow> rows = java.util.stream.LongStream.rangeClosed(1, 12)
+                .mapToObj(index -> shopSuggestionRow(
+                        SHOP_ID + index,
+                        USER_ID + index,
+                        "추천 소품샵 " + index
+                ))
+                .toList();
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(contractRepository.findShopSuggestionRows(
+                eq(ARTIST_ID),
+                eq(Role.SHOP),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
+        )).willReturn(rows);
+
+        ShopSuggestionListResponse response = contractService.getShopSuggestions(USER_ID);
+
+        assertThat(response.getItems()).hasSize(10);
+        assertThat(response.getItems())
+                .allSatisfy(item -> {
+                    assertThat(item.getShopId()).isNotNull();
+                    assertThat(item.getUserId()).isNotNull();
+                    assertThat(item.getShopName()).startsWith("추천 소품샵 ");
+                    assertThat(item.getSpecialty()).isEqualTo(Specialty.LIVING_GOODS);
+                });
+    }
+
+    @Test
+    @DisplayName("입점 소품샵 제안 목록에 채팅방 생성용 사용자 ID를 포함한다")
+    void givenEligibleShop_whenGetShopSuggestions_thenReturnShopAndUserIdentifiers() {
+        Artist artist = artistWithId(ARTIST_ID);
+
+        given(artistRepository.findByUserId(USER_ID)).willReturn(Optional.of(artist));
+        given(contractRepository.findShopSuggestionRows(
+                eq(ARTIST_ID),
+                eq(Role.SHOP),
+                eq(UserStatus.ACTIVE),
+                eq(ContractStatus.PENDING),
+                eq(ContractStatus.APPROVED),
+                any(LocalDate.class)
+        )).willReturn(List.of(shopSuggestionRow(SHOP_ID, USER_ID + 100, "Postman 추천 소품샵")));
+
+        ShopSuggestionListResponse response = contractService.getShopSuggestions(USER_ID);
+
+        assertThat(response.getItems()).hasSize(1);
+        assertThat(response.getItems().get(0).getShopId()).isEqualTo(SHOP_ID);
+        assertThat(response.getItems().get(0).getUserId()).isEqualTo(USER_ID + 100);
+        assertThat(response.getItems().get(0).getShopName()).isEqualTo("Postman 추천 소품샵");
+        assertThat(response.getItems().get(0).getShopImageUrl()).isEqualTo("https://image.test/suggested-shop.png");
+        assertThat(response.getItems().get(0).getInstagramId()).isEqualTo("suggested_shop");
     }
 
     @Test
@@ -923,6 +984,40 @@ class ContractServiceTest {
             @Override
             public String getInstagramId() {
                 return "suggested_artist";
+            }
+        };
+    }
+
+    private ShopSuggestionRow shopSuggestionRow(Long shopId, Long userId, String shopName) {
+        return new ShopSuggestionRow() {
+            @Override
+            public Long getShopId() {
+                return shopId;
+            }
+
+            @Override
+            public Long getUserId() {
+                return userId;
+            }
+
+            @Override
+            public String getShopName() {
+                return shopName;
+            }
+
+            @Override
+            public String getShopImageUrl() {
+                return "https://image.test/suggested-shop.png";
+            }
+
+            @Override
+            public Specialty getSpecialty() {
+                return Specialty.LIVING_GOODS;
+            }
+
+            @Override
+            public String getInstagramId() {
+                return "suggested_shop";
             }
         };
     }


### PR DESCRIPTION
## 요약
  - 작가 관리 영역에 GET /api/v1/contracts/shops/suggestions 추가
  - 기존 소품샵 관리 영역의 GET /api/v1/contracts/artists/suggestions와 대칭 구조로 구현
  - 활성 소품샵 중 현재 작가와 PENDING 또는 유효한 APPROVED 계약이 없는 소품샵만 추천
  - 응답 필드: shopId, userId, shopName, shopImageUrl, specialty, instagramId
  - 서비스/리포지토리 테스트 추가

##  기능 설명
 - 작가가 입점 제안할 수 있는 소품샵 목록을 조회하는 API입니다. 이미 해당 작가와 진행 중이거나 유효한 계약이 있는 소품샵은 제외
 - ENDED, TERMINATED, REJECTED, 종료일이 지난 APPROVED 계약 이력은 다시 추천 대상에 포함