### PR TITLE
[FIX] 포스트 이미지 컬럼 타입 변경 및 PostServiceTest 컴파일 오류 수정

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
@@ -25,7 +25,7 @@ public class Post extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "image_urls", columnDefinition = "JSON")
+    @Column(name = "image_urls", columnDefinition = "TEXT")
     private String imageUrls;
 
     @Column(name = "is_public")

--- a/src/test/java/app/dearobjet/backend/domain/post/PostServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/post/PostServiceTest.java
@@ -13,7 +13,6 @@ import app.dearobjet.backend.domain.post.entity.Post;
 import app.dearobjet.backend.domain.post.repository.PostRepository;
 import app.dearobjet.backend.domain.post.service.PostService;
 import app.dearobjet.backend.domain.user.entity.User;
-import app.dearobjet.backend.domain.user.enums.Role;
 import app.dearobjet.backend.domain.user.repository.UserRepository;
 import app.dearobjet.backend.global.exception.BusinessException;
 import app.dearobjet.backend.global.exception.EntityNotFoundException;
@@ -50,9 +49,9 @@ class PostServiceTest {
 
     @Test
     void createPost_savesPost() {
-        User user = User.builder().id(1L).name("작가").role(Role.ARTIST).build();
+        User user = User.builder().id(1L).name("작가").build();
         MockMultipartFile image = new MockMultipartFile("images", "img.jpg", "image/jpeg", "img".getBytes());
-        CreatePostRequest request = new CreatePostRequest("제목", "내용", true);
+        CreatePostRequest request = new CreatePostRequest("내용", true);
 
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(s3FileUploadService.uploadPostImage(image, 1L)).willReturn("https://cdn/post.jpg");
@@ -61,12 +60,8 @@ class PostServiceTest {
             return Post.builder()
                     .postId(100L)
                     .user(post.getUser())
-                    .title(post.getTitle())
                     .content(post.getContent())
                     .imageUrls(post.getImageUrls())
-                    .viewCount(0)
-                    .likeCount(0)
-                    .commentCount(0)
                     .isPublic(post.getIsPublic())
                     .build();
         });
@@ -74,26 +69,16 @@ class PostServiceTest {
         PostResponse response = postService.createPost(1L, request, List.of(image));
 
         assertThat(response.postId()).isEqualTo(100L);
-        assertThat(response.title()).isEqualTo("제목");
         assertThat(response.content()).isEqualTo("내용");
         assertThat(response.imageUrls()).containsExactly("https://cdn/post.jpg");
         assertThat(response.isPublic()).isTrue();
     }
 
     @Test
-    void createPost_throwsWhenNotArtist() {
-        User user = User.builder().id(1L).role(Role.CUSTOMER).build();
-        given(userRepository.findById(1L)).willReturn(Optional.of(user));
-
-        assertThatThrownBy(() -> postService.createPost(1L, new CreatePostRequest("제목", "내용", true), null))
-                .isInstanceOf(BusinessException.class);
-    }
-
-    @Test
     void createPost_throwsWhenUserNotFound() {
         given(userRepository.findById(1L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> postService.createPost(1L, new CreatePostRequest("제목", "내용", true), null))
+        assertThatThrownBy(() -> postService.createPost(1L, new CreatePostRequest("내용", true), null))
                 .isInstanceOf(EntityNotFoundException.class);
     }
 
@@ -103,13 +88,11 @@ class PostServiceTest {
         Post post1 = Post.builder()
                 .postId(2L)
                 .user(user)
-                .title("제목2")
                 .imageUrls("[\"https://cdn/2.jpg\"]")
                 .build();
         Post post2 = Post.builder()
                 .postId(1L)
                 .user(user)
-                .title("제목1")
                 .imageUrls("[]")
                 .build();
 
@@ -131,11 +114,8 @@ class PostServiceTest {
         Post post = Post.builder()
                 .postId(1L)
                 .user(user)
-                .title("제목")
                 .content("내용")
                 .imageUrls("[\"https://cdn/1.jpg\",\"https://cdn/2.jpg\"]")
-                .viewCount(0)
-                .likeCount(0)
                 .isPublic(true)
                 .build();
 
@@ -144,7 +124,7 @@ class PostServiceTest {
         PostResponse response = postService.getPost(1L);
 
         assertThat(response.postId()).isEqualTo(1L);
-        assertThat(response.title()).isEqualTo("제목");
+        assertThat(response.content()).isEqualTo("내용");
         assertThat(response.imageUrls()).containsExactly("https://cdn/1.jpg", "https://cdn/2.jpg");
     }
 
@@ -162,22 +142,18 @@ class PostServiceTest {
         Post post = Post.builder()
                 .postId(1L)
                 .user(user)
-                .title("이전")
                 .content("이전내용")
                 .imageUrls("[\"https://cdn/old.jpg\"]")
-                .viewCount(0)
-                .likeCount(0)
                 .isPublic(true)
                 .build();
         MockMultipartFile image = new MockMultipartFile("images", "new.jpg", "image/jpeg", "img".getBytes());
-        UpdatePostRequest request = new UpdatePostRequest("새제목", "새내용", true);
+        UpdatePostRequest request = new UpdatePostRequest("새내용", true);
 
         given(postRepository.findById(1L)).willReturn(Optional.of(post));
         given(s3FileUploadService.uploadPostImage(image, 1L)).willReturn("https://cdn/new.jpg");
 
         PostResponse response = postService.updatePost(1L, 1L, request, List.of(image));
 
-        assertThat(response.title()).isEqualTo("새제목");
         assertThat(response.content()).isEqualTo("새내용");
         assertThat(response.imageUrls()).containsExactly("https://cdn/new.jpg");
     }
@@ -188,20 +164,17 @@ class PostServiceTest {
         Post post = Post.builder()
                 .postId(1L)
                 .user(user)
-                .title("이전")
                 .content("이전내용")
                 .imageUrls("[\"https://cdn/old.jpg\"]")
-                .viewCount(0)
-                .likeCount(0)
                 .isPublic(true)
                 .build();
-        UpdatePostRequest request = new UpdatePostRequest("새제목", "새내용", true);
+        UpdatePostRequest request = new UpdatePostRequest("새내용", true);
 
         given(postRepository.findById(1L)).willReturn(Optional.of(post));
 
         PostResponse response = postService.updatePost(1L, 1L, request, null);
 
-        assertThat(response.title()).isEqualTo("새제목");
+        assertThat(response.content()).isEqualTo("새내용");
         assertThat(response.imageUrls()).containsExactly("https://cdn/old.jpg");
     }
 
@@ -212,7 +185,7 @@ class PostServiceTest {
 
         given(postRepository.findById(1L)).willReturn(Optional.of(post));
 
-        assertThatThrownBy(() -> postService.updatePost(1L, 1L, new UpdatePostRequest("새제목", "새내용", true), null))
+        assertThatThrownBy(() -> postService.updatePost(1L, 1L, new UpdatePostRequest("새내용", true), null))
                 .isInstanceOf(BusinessException.class);
     }
 


### PR DESCRIPTION
image_urls 컬럼이 columnDefinition = "JSON"으로 돼 있어 PostgreSQL에서 varchar 바인딩이 거부돼 포스트 등록 INSERT가 실패하던 문제를 TEXT로 변경해 해결했습니다. 또한 이전 커밋에서 Post 엔티티 필드를 제거하면서 PostServiceTest가 함께 정리되지 않아 컴파일이 깨져 있던 부분을 현재 엔티티/DTO에 맞게 다시 작성했습니다.

이미 image_urls가 json 타입으로 만들어진 로컬 DB에서는 ddl-auto: update가 컬럼 타입을 바꿔주지 않으므로 ALTER TABLE posts ALTER COLUMN image_urls TYPE TEXT; 한 번 실행해주세요.