### PR TITLE
[FEAT] 관리자 포스트/공지사항 관리 API

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeController.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeController.java
@@ -21,10 +21,11 @@ public class AdminNoticeController {
     public ApiResponse<NoticeListResponse> getNotices(
             @RequestParam(required = false) NoticeTarget target,
             @RequestParam(required = false) NoticeCategory category,
+            @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ApiResponse.of(adminNoticeService.getNotices(target, category, page, size));
+        return ApiResponse.of(adminNoticeService.getNotices(target, category, keyword, page, size));
     }
 
     @GetMapping("/notices/{noticeId}")

--- a/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeService.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -25,6 +26,8 @@ public class AdminNoticeService {
                 .badge(request.getBadge())
                 .title(request.getTitle())
                 .body(request.getBody())
+                .status(request.getStatus() != null ? request.getStatus() : NoticeStatus.PUBLISHED)
+                .pinned(request.getPinned() != null ? request.getPinned() : false)
                 .publishedAt(
                         request.getPublishedAt() != null
                                 ? request.getPublishedAt()
@@ -36,17 +39,11 @@ public class AdminNoticeService {
     }
 
     @Transactional(readOnly = true)
-    public NoticeListResponse getNotices(NoticeTarget target, NoticeCategory category, int page, int size) {
-        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "publishedAt"));
+    public NoticeListResponse getNotices(NoticeTarget target, NoticeCategory category, String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
 
-        Page<Notice> noticePage;
-        if (target == null) {
-            noticePage = noticeRepository.findAll(pageable);
-        } else if (category == null) {
-            noticePage = noticeRepository.findByTarget(target, pageable);
-        } else {
-            noticePage = noticeRepository.findByTargetAndCategory(target, category, pageable);
-        }
+        String normalizedKeyword = StringUtils.hasText(keyword) ? keyword.strip() : null;
+        Page<Notice> noticePage = noticeRepository.searchForAdmin(target, category, normalizedKeyword, pageable);
 
         List<NoticeResponse> items = noticePage.getContent().stream()
                 .map(this::toResponse)
@@ -85,6 +82,8 @@ public class AdminNoticeService {
                 notice.getBadge(),
                 notice.getTitle(),
                 notice.getBody(),
+                notice.getStatus(),
+                Boolean.TRUE.equals(notice.getPinned()),
                 notice.getPublishedAt(),
                 isNew
         );

--- a/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
@@ -34,6 +34,15 @@ public class Notice {
     @Column(columnDefinition = "TEXT")
     private String body;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "varchar(20) default 'PUBLISHED'")
+    private NoticeStatus status = NoticeStatus.PUBLISHED;   // DRAFT | PUBLISHED | HIDDEN
+
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private Boolean pinned = false;
+
     @Column(nullable = false)
     private OffsetDateTime publishedAt;
 
@@ -43,6 +52,8 @@ public class Notice {
         if (request.getBadge() != null) this.badge = request.getBadge();
         if (request.getTitle() != null) this.title = request.getTitle();
         if (request.getBody() != null) this.body = request.getBody();
+        if (request.getStatus() != null) this.status = request.getStatus();
+        if (request.getPinned() != null) this.pinned = request.getPinned();
         if (request.getPublishedAt() != null) this.publishedAt = request.getPublishedAt();
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeCreateRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeCreateRequest.java
@@ -11,5 +11,7 @@ public class NoticeCreateRequest {
     private String badge;
     private String title;
     private String body;
+    private NoticeStatus status;
+    private Boolean pinned;
     private OffsetDateTime publishedAt;
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
@@ -4,9 +4,25 @@ package app.dearobjet.backend.domain.notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NoticeRepository extends JpaRepository<Notice,Long> {
-    Page<Notice> findByTarget(NoticeTarget target, Pageable pageable);
 
-    Page<Notice> findByTargetAndCategory(NoticeTarget target, NoticeCategory category, Pageable pageable);
+    @Query("select n from Notice n where "
+            + "(:target is null or n.target = :target) and "
+            + "(:category is null or n.category = :category) and "
+            + "(:keyword is null or lower(n.title) like lower(concat('%', :keyword, '%'))) "
+            + "order by case when n.pinned = true then 0 else 1 end, n.publishedAt desc")
+    Page<Notice> searchForAdmin(@Param("target") NoticeTarget target,
+                                @Param("category") NoticeCategory category,
+                                @Param("keyword") String keyword,
+                                Pageable pageable);
+
+    @Query("select n from Notice n where n.target = :target "
+            + "and (:category is null or n.category = :category) "
+            + "and (n.status is null or n.status = app.dearobjet.backend.domain.notification.NoticeStatus.PUBLISHED)")
+    Page<Notice> findPublicByTarget(@Param("target") NoticeTarget target,
+                                    @Param("category") NoticeCategory category,
+                                    Pageable pageable);
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeResponse.java
@@ -14,6 +14,8 @@ public class NoticeResponse {
     private final String badge;
     private final String title;
     private final String body;
+    private final NoticeStatus status;
+    private final boolean pinned;
     private final OffsetDateTime createdAt;
     private final boolean isNew;
 }

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeService.java
@@ -23,9 +23,7 @@ public class NoticeService {
                 Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "publishedAt")
         );
 
-        Page<Notice> noticePage = (category == null)
-                ? noticeRepository.findByTarget(target, pageable)
-                : noticeRepository.findByTargetAndCategory(target, category, pageable);
+        Page<Notice> noticePage = noticeRepository.findPublicByTarget(target, category, pageable);
 
         List<NoticeResponse> noticeResponses = new ArrayList<>();
         for (Notice notice : noticePage.getContent()) {
@@ -52,6 +50,8 @@ public class NoticeService {
                 notice.getBadge(),
                 notice.getTitle(),
                 notice.getBody(),
+                notice.getStatus(),
+                Boolean.TRUE.equals(notice.getPinned()),
                 notice.getPublishedAt(),
                 isNew
         );

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeStatus.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeStatus.java
@@ -1,0 +1,7 @@
+package app.dearobjet.backend.domain.notification;
+
+public enum NoticeStatus {
+    DRAFT,       // 임시저장
+    PUBLISHED,   // 게시중
+    HIDDEN       // 숨김
+}

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeUpdateRequest.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeUpdateRequest.java
@@ -11,5 +11,7 @@ public class NoticeUpdateRequest {
     private String badge;
     private String title;
     private String body;
+    private NoticeStatus status;
+    private Boolean pinned;
     private OffsetDateTime publishedAt;
 }

--- a/src/main/java/app/dearobjet/backend/domain/post/controller/AdminPostController.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/controller/AdminPostController.java
@@ -1,0 +1,49 @@
+package app.dearobjet.backend.domain.post.controller;
+
+import app.dearobjet.backend.domain.post.dto.AdminPostListResponse;
+import app.dearobjet.backend.domain.post.dto.PostResponse;
+import app.dearobjet.backend.domain.post.service.AdminPostService;
+import app.dearobjet.backend.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/posts")
+public class AdminPostController {
+
+    private final AdminPostService adminPostService;
+
+    @GetMapping
+    public ApiResponse<AdminPostListResponse> getPosts(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) String keyword
+    ) {
+        return ApiResponse.of(adminPostService.getPosts(page, keyword));
+    }
+
+    @GetMapping("/{postId}")
+    public ApiResponse<PostResponse> getPost(@PathVariable Long postId) {
+        return ApiResponse.of(adminPostService.getPost(postId));
+    }
+
+    @PatchMapping("/{postId}/blind")
+    public ApiResponse<PostResponse> updateBlinded(
+            @PathVariable Long postId,
+            @RequestParam boolean blinded
+    ) {
+        return ApiResponse.of(adminPostService.updateBlinded(postId, blinded));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiResponse<Void> deletePost(@PathVariable Long postId) {
+        adminPostService.deletePost(postId);
+        return ApiResponse.of(null);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/AdminPostListResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/AdminPostListResponse.java
@@ -1,0 +1,20 @@
+package app.dearobjet.backend.domain.post.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminPostListResponse(
+        List<Item> items,
+        int page,
+        int totalPages,
+        long totalCount
+) {
+    public record Item(
+            Long postId,
+            String preview,
+            String authorName,
+            LocalDateTime createdAt,
+            boolean blinded
+    ) {
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/dto/PostResponse.java
@@ -11,6 +11,7 @@ public record PostResponse(
         String content,
         List<String> imageUrls,
         Boolean isPublic,
+        Boolean blinded,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/entity/Post.java
@@ -31,6 +31,10 @@ public class Post extends BaseTimeEntity {
     @Column(name = "is_public")
     private Boolean isPublic;
 
+    @Builder.Default
+    @Column(name = "blinded", nullable = false, columnDefinition = "boolean default false")
+    private Boolean blinded = false;
+
     public void update(String content, String imageUrls, Boolean isPublic) {
         this.content = content;
         if (imageUrls != null) {
@@ -39,5 +43,9 @@ public class Post extends BaseTimeEntity {
         if (isPublic != null) {
             this.isPublic = isPublic;
         }
+    }
+
+    public void changeBlinded(boolean blinded) {
+        this.blinded = blinded;
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/repository/PostRepository.java
@@ -4,8 +4,19 @@ import app.dearobjet.backend.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    Page<Post> findByUser_Id(Long userId, Pageable pageable);
+    @Query("select p from Post p where p.user.id = :userId and (p.blinded = false or p.blinded is null)")
+    Page<Post> findVisibleByUser(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("select p from Post p where p.blinded = false or p.blinded is null")
+    Page<Post> findAllVisible(Pageable pageable);
+
+    @Query("select p from Post p where :keyword is null "
+            + "or lower(p.content) like lower(concat('%', :keyword, '%')) "
+            + "or lower(p.user.name) like lower(concat('%', :keyword, '%'))")
+    Page<Post> searchForAdmin(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/app/dearobjet/backend/domain/post/service/AdminPostService.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/service/AdminPostService.java
@@ -1,0 +1,84 @@
+package app.dearobjet.backend.domain.post.service;
+
+import app.dearobjet.backend.domain.post.dto.AdminPostListResponse;
+import app.dearobjet.backend.domain.post.dto.PostResponse;
+import app.dearobjet.backend.domain.post.entity.Post;
+import app.dearobjet.backend.domain.post.repository.PostRepository;
+import app.dearobjet.backend.global.exception.EntityNotFoundException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPostService {
+
+    private static final int PAGE_SIZE = 20;
+    private static final int PREVIEW_LENGTH = 30;
+
+    private final PostService postService;
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public AdminPostListResponse getPosts(int page, String keyword) {
+        Pageable pageable = PageRequest.of(
+                Math.max(page - 1, 0),
+                PAGE_SIZE,
+                Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.DESC, "postId"))
+        );
+
+        String normalizedKeyword = StringUtils.hasText(keyword) ? keyword.strip() : null;
+        Page<Post> postPage = postRepository.searchForAdmin(normalizedKeyword, pageable);
+
+        List<AdminPostListResponse.Item> items = postPage.getContent().stream()
+                .map(post -> new AdminPostListResponse.Item(
+                        post.getPostId(),
+                        preview(post.getContent()),
+                        post.getUser().getName(),
+                        post.getCreatedAt(),
+                        Boolean.TRUE.equals(post.getBlinded())
+                ))
+                .toList();
+
+        return new AdminPostListResponse(items, page, postPage.getTotalPages(), postPage.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getPost(Long postId) {
+        return postService.getPost(postId);
+    }
+
+    @Transactional
+    public PostResponse updateBlinded(Long postId, boolean blinded) {
+        Post post = findPost(postId);
+        post.changeBlinded(blinded);
+        return postService.getPost(postId);
+    }
+
+    @Transactional
+    public void deletePost(Long postId) {
+        postRepository.delete(findPost(postId));
+    }
+
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND, "포스트를 찾을 수 없습니다."));
+    }
+
+    private String preview(String content) {
+        if (content == null) {
+            return "";
+        }
+        String trimmed = content.strip();
+        return trimmed.length() > PREVIEW_LENGTH
+                ? trimmed.substring(0, PREVIEW_LENGTH) + "..."
+                : trimmed;
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/post/service/PostService.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/service/PostService.java
@@ -64,7 +64,7 @@ public class PostService {
                         .and(Sort.by(Sort.Direction.DESC, "postId"))
         );
 
-        Page<Post> postPage = postRepository.findByUser_Id(targetUserId, pageable);
+        Page<Post> postPage = postRepository.findVisibleByUser(targetUserId, pageable);
         return toListResponse(postPage, page);
     }
 
@@ -77,7 +77,7 @@ public class PostService {
                         .and(Sort.by(Sort.Direction.DESC, "postId"))
         );
 
-        Page<Post> postPage = postRepository.findAll(pageable);
+        Page<Post> postPage = postRepository.findAllVisible(pageable);
         return toListResponse(postPage, page);
     }
 
@@ -180,6 +180,7 @@ public class PostService {
                 post.getContent(),
                 urls,
                 post.getIsPublic(),
+                post.getBlinded(),
                 post.getCreatedAt()
         );
     }

--- a/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
+++ b/src/main/java/app/dearobjet/backend/global/auth/security/SecurityConfig.java
@@ -64,6 +64,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/classes/*/available-slots").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/shops/map/geocode").hasRole("ADMIN")
 
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+
                         .anyRequest().authenticated()
                 )
 

--- a/src/test/java/app/dearobjet/backend/domain/post/PostServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/post/PostServiceTest.java
@@ -96,7 +96,7 @@ class PostServiceTest {
                 .imageUrls("[]")
                 .build();
 
-        given(postRepository.findByUser_Id(any(), any()))
+        given(postRepository.findVisibleByUser(any(), any()))
                 .willReturn(new PageImpl<>(List.of(post1, post2)));
 
         PostListResponse response = postService.getPosts(1L, 1);


### PR DESCRIPTION
어드민 페이지의 포스트 관리와 공지사항 관리 기능을 추가했습니다.

- 포스트: 관리자 목록 조회(검색 포함), 블라인드 처리, 강제 삭제
- 공지사항: 상태(임시저장/게시중/숨김), 상단 고정, 제목 검색 추가
- /api/v1/admin/** 에 ADMIN 권한 적용
