### PR TITLE
[FIX] 공지사항/포스트/결제 API 에러 처리 및 검색 쿼리 버그 수정

### DIFF
--- a/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeService.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/AdminNoticeService.java
@@ -42,7 +42,7 @@ public class AdminNoticeService {
     public NoticeListResponse getNotices(NoticeTarget target, NoticeCategory category, String keyword, int page, int size) {
         Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
 
-        String normalizedKeyword = StringUtils.hasText(keyword) ? keyword.strip() : null;
+        String normalizedKeyword = StringUtils.hasText(keyword) ? keyword.strip() : "";
         Page<Notice> noticePage = noticeRepository.searchForAdmin(target, category, normalizedKeyword, pageable);
 
         List<NoticeResponse> items = noticePage.getContent().stream()

--- a/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/Notice.java
@@ -2,6 +2,7 @@ package app.dearobjet.backend.domain.notification;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.OffsetDateTime;
 
@@ -36,7 +37,8 @@ public class Notice {
 
     @Enumerated(EnumType.STRING)
     @Builder.Default
-    @Column(nullable = false, columnDefinition = "varchar(20) default 'PUBLISHED'")
+    @Column(nullable = false, length = 20)
+    @ColumnDefault("'PUBLISHED'")
     private NoticeStatus status = NoticeStatus.PUBLISHED;   // DRAFT | PUBLISHED | HIDDEN
 
     @Builder.Default

--- a/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/notification/NoticeRepository.java
@@ -12,7 +12,7 @@ public interface NoticeRepository extends JpaRepository<Notice,Long> {
     @Query("select n from Notice n where "
             + "(:target is null or n.target = :target) and "
             + "(:category is null or n.category = :category) and "
-            + "(:keyword is null or lower(n.title) like lower(concat('%', :keyword, '%'))) "
+            + "lower(n.title) like lower(concat('%', :keyword, '%')) "
             + "order by case when n.pinned = true then 0 else 1 end, n.publishedAt desc")
     Page<Notice> searchForAdmin(@Param("target") NoticeTarget target,
                                 @Param("category") NoticeCategory category,

--- a/src/main/java/app/dearobjet/backend/domain/order/OrderAccessDeniedException.java
+++ b/src/main/java/app/dearobjet/backend/domain/order/OrderAccessDeniedException.java
@@ -1,7 +1,10 @@
 package app.dearobjet.backend.domain.order;
 
-public class OrderAccessDeniedException extends RuntimeException {
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+
+public class OrderAccessDeniedException extends BusinessException {
   public OrderAccessDeniedException(Long orderId) {
-    super("본인 주문만 접근할 수 있습니다. orderId=" + orderId);
+    super(ErrorCode.ORDER_ACCESS_DENIED, "본인 주문만 접근할 수 있습니다. orderId=" + orderId);
   }
 }

--- a/src/main/java/app/dearobjet/backend/domain/order/OrderNotFoundException.java
+++ b/src/main/java/app/dearobjet/backend/domain/order/OrderNotFoundException.java
@@ -1,7 +1,10 @@
 package app.dearobjet.backend.domain.order;
 
-public class OrderNotFoundException extends RuntimeException {
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+
+public class OrderNotFoundException extends BusinessException {
     public OrderNotFoundException(Long orderId) {
-        super("해당 주문을 찾을 수 없습니다. orderId=" + orderId);
+        super(ErrorCode.ORDER_NOT_FOUND, "해당 주문을 찾을 수 없습니다. orderId=" + orderId);
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentCancelException.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentCancelException.java
@@ -1,0 +1,10 @@
+package app.dearobjet.backend.domain.payment;
+
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+
+public class PaymentCancelException extends BusinessException {
+    public PaymentCancelException(Throwable cause) {
+        super(ErrorCode.PAYMENT_CANCEL_FAILED, cause);
+    }
+}

--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentNotFoundException.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentNotFoundException.java
@@ -1,7 +1,10 @@
 package app.dearobjet.backend.domain.payment;
 
-public class PaymentNotFoundException extends RuntimeException {
+import app.dearobjet.backend.global.exception.BusinessException;
+import app.dearobjet.backend.global.exception.ErrorCode;
+
+public class PaymentNotFoundException extends BusinessException {
     public PaymentNotFoundException(Long id) {
-        super("결제 정보를 찾을 수 없습니다. paymentId=" + id);
+        super(ErrorCode.PAYMENT_NOT_FOUND, "결제 정보를 찾을 수 없습니다. paymentId=" + id);
     }
 }

--- a/src/main/java/app/dearobjet/backend/domain/payment/PaymentService.java
+++ b/src/main/java/app/dearobjet/backend/domain/payment/PaymentService.java
@@ -10,6 +10,7 @@ import app.dearobjet.backend.domain.payment.entity.*;
 import app.dearobjet.backend.domain.payment.toss.TossPaymentsClient;
 import app.dearobjet.backend.domain.payment.toss.TossPaymentsProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
@@ -117,7 +119,11 @@ public class PaymentService {
 
         Long cancelAmount = (req.getAmount() == null) ? payment.getAmount() : req.getAmount();
 
-        tossClient.cancel(payment.getPaymentKey(), cancelAmount, req.getReason());
+        try {
+            tossClient.cancel(payment.getPaymentKey(), cancelAmount, req.getReason());
+        } catch (Exception e) {
+            throw new PaymentCancelException(e);
+        }
         payment.markCanceled();
         order.cancel(req.getReason() == null ? "USER_CANCEL" : req.getReason());
     }
@@ -131,7 +137,13 @@ public class PaymentService {
 
         if (payment.isTerminal()) return;
 
-        TossPaymentResponse tossPayment = tossClient.getPayment(paymentKey);
+        TossPaymentResponse tossPayment;
+        try {
+            tossPayment = tossClient.getPayment(paymentKey);
+        } catch (Exception e) {
+            log.warn("토스 웹훅 처리 중 결제 조회 실패. paymentKey={}", paymentKey, e);
+            return;
+        }
         String status = tossPayment == null ? null : tossPayment.getStatus();
         String orderId = tossPayment == null ? null : tossPayment.getOrderId();
         Long totalAmount = tossPayment == null ? null : tossPayment.getTotalAmount();

--- a/src/main/java/app/dearobjet/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/repository/PostRepository.java
@@ -15,8 +15,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("select p from Post p where p.blinded = false or p.blinded is null")
     Page<Post> findAllVisible(Pageable pageable);
 
-    @Query("select p from Post p where :keyword is null "
-            + "or lower(p.content) like lower(concat('%', :keyword, '%')) "
+    @Query("select p from Post p where "
+            + "lower(p.content) like lower(concat('%', :keyword, '%')) "
             + "or lower(p.user.name) like lower(concat('%', :keyword, '%'))")
     Page<Post> searchForAdmin(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/app/dearobjet/backend/domain/post/service/AdminPostService.java
+++ b/src/main/java/app/dearobjet/backend/domain/post/service/AdminPostService.java
@@ -34,7 +34,7 @@ public class AdminPostService {
                 Sort.by(Sort.Direction.DESC, "createdAt").and(Sort.by(Sort.Direction.DESC, "postId"))
         );
 
-        String normalizedKeyword = StringUtils.hasText(keyword) ? keyword.strip() : null;
+        String normalizedKeyword = StringUtils.hasText(keyword) ? keyword.strip() : "";
         Page<Post> postPage = postRepository.searchForAdmin(normalizedKeyword, pageable);
 
         List<AdminPostListResponse.Item> items = postPage.getContent().stream()

--- a/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/ErrorCode.java
@@ -51,7 +51,13 @@ public enum ErrorCode {
     PRODUCT_STOCK_CONFLICT(HttpStatus.CONFLICT, "P001", "상품 재고가 이미 변경되었습니다"),
 
     // Payment (PAY0XX)
-    PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_GATEWAY, "PAY001", "결제 승인에 실패했습니다");
+    PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_GATEWAY, "PAY001", "결제 승인에 실패했습니다"),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY002", "결제 정보를 찾을 수 없습니다"),
+    PAYMENT_CANCEL_FAILED(HttpStatus.BAD_GATEWAY, "PAY003", "결제 취소에 실패했습니다"),
+
+    // Order (O0XX)
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "주문을 찾을 수 없습니다"),
+    ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "O002", "본인 주문만 접근할 수 있습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/app/dearobjet/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/dearobjet/backend/global/exception/GlobalExceptionHandler.java
@@ -6,9 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -46,6 +50,61 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getBindingResult());
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * 필수 요청 파라미터 누락 처리 (400)
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+        log.warn("MissingServletRequestParameterException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * 요청 파라미터/경로변수 타입 불일치 처리 (400)
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.warn("MethodArgumentTypeMismatchException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(
+                ErrorCode.INVALID_INPUT,
+                "'" + e.getName() + "' 파라미터의 형식이 올바르지 않습니다."
+        );
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * 잘못된 형식의 요청 본문 처리 (400)
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadableException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, "요청 본문 형식이 올바르지 않습니다.");
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(response));
+    }
+
+    /**
+     * 지원하지 않는 요청 미디어 타입 처리 (415)
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleHttpMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException e) {
+        log.warn("HttpMediaTypeNotSupportedException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, "지원하지 않는 요청 형식입니다.");
+        return ResponseEntity
+                .status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
                 .body(ApiResponse.of(response));
     }
 

--- a/src/test/java/app/dearobjet/backend/domain/story/StoryServiceTest.java
+++ b/src/test/java/app/dearobjet/backend/domain/story/StoryServiceTest.java
@@ -119,7 +119,7 @@ class StoryServiceTest {
                 .build();
 
         given(shopRepository.findById(10L)).willReturn(Optional.of(shop));
-        given(storyRepository.findByUser_Id(any(), any()))
+        given(storyRepository.findByUser_IdAndBlindedFalse(any(), any()))
                 .willReturn(new PageImpl<>(List.of(story)));
 
         StoryListResponse response = storyService.getStoriesByShop(10L, 1);


### PR DESCRIPTION
공지사항/포스트/결제 API에서 500 오류로 처리되던 여러 예외 상황을 정리했습니다.

- 공지사항, 포스트 어드민 검색을 검색어 없이 호출하면 500 나던 것 수정
- 공지사항 상태 컬럼의 DDL 문법 오류로 서버 기동마다 나던 에러 수정
- 존재하지 않는 결제/주문 조회, 남의 주문 접근 시 500 나던 것 404/403으로 수정
- 결제 취소, 토스 웹훅 처리 중 토스 API 호출 실패 시 500 나던 것 수정
- 필수 파라미터 누락, 잘못된 JSON, 잘못된 요청 형식일 때 500 나던 것 400/415로 정리